### PR TITLE
Fix for new OpaqueNetwork devices

### DIFF
--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -1568,7 +1568,8 @@ class PyVmomiHelper(PyVmomi):
                 add_key = add_key + 1
                 nic = self.device_helper.create_nic(device_type,
                                                     'Network Adapter %s' % (add_key),
-                                                    network_devices[key])
+                                                    network_devices[key],
+                                                    add_key)
                 nic.operation = vim.vm.device.VirtualDeviceSpec.Operation.add
                 nic_change_detected = True
 

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -1644,8 +1644,9 @@ class PyVmomiHelper(PyVmomi):
             if nic_change_detected:
                 # Change to fix the issue found while configuring opaque network
                 # VMs cloned from a template with opaque network will get disconnected
+                # Only for existing network devices
                 # Replacing deprecated config parameter with relocation Spec
-                if isinstance(self.cache.get_network(network_name), vim.OpaqueNetwork):
+                if key < len(current_net_devices) and isinstance(self.cache.get_network(network_name), vim.OpaqueNetwork):
                     self.relospec.deviceChange.append(nic)
                 else:
                     self.configspec.deviceChange.append(nic)

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -811,8 +811,9 @@ class PyVmomiDeviceHelper(object):
             self.module.fail_json(msg='Invalid device_type "%s"'
                                       ' for network "%s"' % (device_type, name))
 
-    def create_nic(self, device_type, device_label, device_infos):
+    def create_nic(self, device_type, device_label, device_infos, key):
         nic = vim.vm.device.VirtualDeviceSpec()
+        nic.device.key = key
         nic.device = self.get_device(device_type, device_infos['name'])
         nic.device.wakeOnLanEnabled = bool(device_infos.get('wake_on_lan', True))
         nic.device.deviceInfo = vim.Description()
@@ -1506,6 +1507,7 @@ class PyVmomiHelper(PyVmomi):
                                       "Removing interfaces is not allowed"
                                       % (len(network_devices), len(current_net_devices)))
 
+        add_key = len(network_devices)
         for key in range(0, len(network_devices)):
             nic_change_detected = False
             network_name = network_devices[key]['name']
@@ -1563,8 +1565,9 @@ class PyVmomiHelper(PyVmomi):
             else:
                 # Default device type is vmxnet3, VMware best practice
                 device_type = network_devices[key].get('device_type', 'vmxnet3')
+                add_key = add_key + 1
                 nic = self.device_helper.create_nic(device_type,
-                                                    'Network Adapter %s' % (key + 1),
+                                                    'Network Adapter %s' % (add_key),
                                                     network_devices[key])
                 nic.operation = vim.vm.device.VirtualDeviceSpec.Operation.add
                 nic_change_detected = True

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -813,8 +813,8 @@ class PyVmomiDeviceHelper(object):
 
     def create_nic(self, device_type, device_label, device_infos, key):
         nic = vim.vm.device.VirtualDeviceSpec()
-        nic.device.key = key
         nic.device = self.get_device(device_type, device_infos['name'])
+        nic.device.key = key
         nic.device.wakeOnLanEnabled = bool(device_infos.get('wake_on_lan', True))
         nic.device.deviceInfo = vim.Description()
         nic.device.deviceInfo.label = device_label


### PR DESCRIPTION
##### SUMMARY
Fix for new OpaqueNetwork devices when cloning a template

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_guest

##### ADDITIONAL INFORMATION
* Use a template with 1 network device
* Use vmware_guest to clone the template into a VM with 2 OpaqueNetwork devices

##### Error
```
Failed to create a virtual machine : The number of network adapter settings in the customization specification: 2 does not match the number of network adapters present in the virtual machine: 1
```

##### Output
```
{
    "msg": "Failed to create a virtual machine : The number of network adapter settings in the customization specification: 2 does not match the number of network adapters present in the virtual machine: 1.",
    "invocation": {
        "module_args": {
            "hostname": "host.XXX.local",
            "username": "XXX@XXX.local",
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "validate_certs": false,
            "datacenter": "XXX01",
            "cluster": "VIPERNEXT SDN DTA CCA TENANT",
            "convert": "thick",
            "datastore": "datastore1 (3)",
            "folder": "/XXX-XXX01/vm/Tenants/XXX",
            "name": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "annotation": "2020/05/06 11:10",
            "networks": [
                {
                    "gateway": "10.40.244.73",
                    "ip": "10.40.244.75",
                    "name": "T",
                    "netmask": "255.255.255.248",
                    "type": "static"
                },
                {
                    "gateway": "10.40.244.73",
                    "ip": "10.40.244.77",
                    "name": "T",
                    "netmask": "255.255.255.248",
                    "type": "static"
                }
            ],
            "hardware": {
                "hotadd_cpu": true,
                "hotremove_cpu": true,
                "hotadd_memory": true,
                "memory_mb": 1024,
                "num_cpus": 1,
                "num_cpu_cores_per_socket": 1
            },
            "customization": {
                "autologon": true,
                "hostname": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "joinworkgroup": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "orgname": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
                "timezone": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER"
            },
            "template": "TPL_W2016SE",
            "resource_pool": "TENANT POOL",
            "wait_for_ip_address": true,
            "wait_for_customization": true,
            "port": 443,
            "state": "present",
            "is_template": false,
            "customvalues": [],
            "name_match": "first",
            "use_instance_uuid": false,
            "disk": [],
            "cdrom": [],
            "force": false,
            "state_change_timeout": 0,
            "linked_clone": false,
            "vapp_properties": [],
            "proxy_host": null,
            "proxy_port": null,
            "uuid": null,
            "guest_id": null,
            "esxi_hostname": null,
            "snapshot_src": null,
            "customization_spec": null
        }
    },
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/libexec/platform-python"
    },
    "_ansible_no_log": false,
    "changed": false,
    "_ansible_delegated_vars": {
        "ansible_host": "localhost"
    }
}
```
