### PR TITLE
cdrom dict is now handled as a single-element list

### DIFF
--- a/changelogs/fragments/213_vmware_guest_cdrom.yml
+++ b/changelogs/fragments/213_vmware_guest_cdrom.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- vmware_guest - handle CDROM specification (https://github.com/ansible-collections/community.vmware/pull/213).

--- a/tests/integration/targets/prepare_vmware_tests/tasks/setup_virtualmachines.yml
+++ b/tests/integration/targets/prepare_vmware_tests/tasks/setup_virtualmachines.yml
@@ -15,8 +15,11 @@
       num_cpus: 1
       scsi: paravirtual
     cdrom:
-      type: iso
-      iso_path: "[{{ ro_datastore }}] fedora.iso"
+      - type: iso
+        iso_path: "[{{ ro_datastore }}] fedora.iso"
+        controller_type: ide
+        controller_number: 0
+        unit_number: 0
     networks:
     - name: VM Network
   with_items: '{{ virtual_machines }}'
@@ -39,8 +42,11 @@
       num_cpus: 1
       scsi: paravirtual
     cdrom:
-      type: iso
-      iso_path: "[{{ ro_datastore }}] fedora.iso"
+      - type: iso
+        iso_path: "[{{ ro_datastore }}] fedora.iso"
+        controller_type: ide
+        controller_number: 0
+        unit_number: 0
     networks:
     - name: VM Network
   with_items: '{{ virtual_machines_in_cluster }}'

--- a/tests/integration/targets/vmware_guest/tasks/cdrom_d1_c1_f0.yml
+++ b/tests/integration/targets/vmware_guest/tasks/cdrom_d1_c1_f0.yml
@@ -20,8 +20,11 @@
       type: thin
       datastore: "{{ rw_datastore }}"
     cdrom:
-      type: iso
-      iso_path: "[{{ ro_datastore }}] centos.iso"
+      - type: iso
+        iso_path: "[{{ ro_datastore }}] centos.iso"
+        controller_type: ide
+        controller_number: 0
+        unit_number: 0
   register: cdrom_vm
 
 - debug: var=cdrom_vm
@@ -42,8 +45,11 @@
     datastore: "{{ rw_datastore }}"
     datacenter: "{{ dc1 }}"
     cdrom:
-      type: iso
-      iso_path: "[{{ ro_datastore }}] fedora.iso"
+      - type: iso
+        iso_path: "[{{ ro_datastore }}] fedora.iso"
+        controller_type: ide
+        controller_number: 0
+        unit_number: 0
     state: present
   register: cdrom_vm
 
@@ -64,7 +70,10 @@
     name: test_vm1
     datacenter: "{{ dc1 }}"
     cdrom:
-      type: client
+      - type: client
+        controller_type: ide
+        controller_number: 0
+        unit_number: 0
     state: present
   register: cdrom_vm
 
@@ -98,7 +107,7 @@
     name: test_vm2
     datacenter: "{{ dc1 }}"
     cdrom:
-      type: none
+      - type: none
     state: present
   register: cdrom_vm
 
@@ -136,8 +145,11 @@
       type: thin
       datastore: "{{ rw_datastore }}"
     cdrom:
-      type: iso
-      iso_path: "[{{ ro_datastore }}] fedora.iso"
+      - type: iso
+        iso_path: "[{{ ro_datastore }}] fedora.iso"
+        controller_type: ide
+        controller_number: 0
+        unit_number: 0
   register: cdrom_vm
 
 - debug: var=cdrom_vm
@@ -178,8 +190,11 @@
           type: thin
           datastore: "{{ rw_datastore }}"
         cdrom:
-          type: iso
-          iso_path: "[{{ ro_datastore }}] base.iso"
+          - type: iso
+            iso_path: "[{{ ro_datastore }}] base.iso"
+            controller_type: ide
+            controller_number: 0
+            unit_number: 0
       register: cdrom_vm
     - debug: var=cdrom_vm
     - name: assert the VM was created

--- a/tests/integration/targets/vmware_guest/tasks/template_d1_c1_f0.yml
+++ b/tests/integration/targets/vmware_guest/tasks/template_d1_c1_f0.yml
@@ -18,8 +18,11 @@
       num_cpus: 1
       scsi: paravirtual
     cdrom:
-      type: iso
-      iso_path: "[{{ ro_datastore }}] fedora.iso"
+      - controller_type: ide
+        controller_number: 0
+        unit_number: 0
+        type: iso
+        iso_path: "[{{ ro_datastore }}] fedora.iso"
     networks:
     - name: VM Network
 

--- a/tests/integration/targets/vmware_guest/tasks/windows_vbs_d1_c1_f0.yml
+++ b/tests/integration/targets/vmware_guest/tasks/windows_vbs_d1_c1_f0.yml
@@ -21,8 +21,6 @@
     - size_mb: 128
       type: thin
       datastore: '{{ rw_datastore }}'
-    cdrom:
-      type: client
   register: vbs_vm
 
 - debug: var=vbs_vm
@@ -55,8 +53,6 @@
     - size_mb: 128
       type: thin
       datastore: '{{ rw_datastore }}'
-    cdrom:
-      type: client
   register: vbs_vm
 
 - debug: var=vbs_vm

--- a/tests/integration/targets/vmware_guest_network/tasks/main.yml
+++ b/tests/integration/targets/vmware_guest_network/tasks/main.yml
@@ -33,8 +33,11 @@
         num_cpus: 1
         scsi: paravirtual
       cdrom:
-        type: iso
-        iso_path: "[{{ ro_datastore }}] fedora.iso"
+        - type: iso
+          iso_path: "[{{ ro_datastore }}] fedora.iso"
+          controller_type: ide
+          controller_number: 0
+          unit_number: 0
       networks:
       - name: VM Network
 

--- a/tests/integration/targets/vmware_guest_powerstate/tasks/main.yml
+++ b/tests/integration/targets/vmware_guest_powerstate/tasks/main.yml
@@ -28,8 +28,11 @@
       num_cpus: 1
       scsi: paravirtual
     cdrom:
-      type: iso
-      iso_path: "[{{ ro_datastore }}] fedora.iso"
+      - type: iso
+        iso_path: "[{{ ro_datastore }}] fedora.iso"
+        controller_type: ide
+        controller_number: 0
+        unit_number: 0
     networks:
     - name: VM Network
 

--- a/tests/integration/targets/vmware_guest_tools_wait/tasks/main.yml
+++ b/tests/integration/targets/vmware_guest_tools_wait/tasks/main.yml
@@ -33,8 +33,11 @@
         num_cpus: 1
         scsi: paravirtual
       cdrom:
-        type: iso
-        iso_path: "[{{ ro_datastore }}] fedora.iso"
+        - type: iso
+          iso_path: "[{{ ro_datastore }}] fedora.iso"
+          controller_type: ide
+          controller_number: 0
+          unit_number: 0
       networks:
       - name: VM Network
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
vmware_guest recently added SATA controller support to cdroms, but the change only applies when the cdrom is provided as a list. This change will make the module treat a cdrom dict as a single-element list.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_guest
