### PR TITLE
vmware_host_facts: add powerstate fact

### DIFF
--- a/changelogs/fragments/184_vmware_host_facts.yml
+++ b/changelogs/fragments/184_vmware_host_facts.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- vmware_host_facts - add powerstate fact about ESXi hostsystem with note about stale facts (https://github.com/ansible-collections/vmware/issues/184).

--- a/plugins/modules/vmware_host_facts.py
+++ b/plugins/modules/vmware_host_facts.py
@@ -9,12 +9,6 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-ANSIBLE_METADATA = {
-    'metadata_version': '1.1',
-    'status': ['preview'],
-    'supported_by': 'community'
-}
-
 DOCUMENTATION = r'''
 ---
 module: vmware_host_facts
@@ -26,6 +20,9 @@ description:
       module will throw an error.
     - VSAN facts added in 2.7 version.
     - SYSTEM fact uuid added in 2.10 version.
+    - Powerstate fact added in VMware collection 1.0.0.
+    - Please note that when ESXi host powerstate is C(poweredOff), facts are returned from vCenter and might be stale.
+      Users are recommended to check powerstate value and take appropriate decision in the playbook.
 author:
     - Wei Gao (@woshihaoren)
 requirements:
@@ -376,6 +373,7 @@ class VMwareHostFactManager(PyVmomi):
             'ansible_uptime': self.host.summary.quickStats.uptime,
             'ansible_in_maintenance_mode': self.host.runtime.inMaintenanceMode,
             'ansible_uuid': self.host.hardware.systemInfo.uuid,
+            'ansible_host_powerstate': self.host.runtime.powerState,
         }
         return facts
 


### PR DESCRIPTION
##### SUMMARY

When ESXi is poweredoff, vCenter provides a stale information about
ESXi hostsystem. Added fact about Powerstate and a note stating the
same.

Fixes: #184

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/184_vmware_host_facts.yml
plugins/modules/vmware_host_facts.py
