### PR TITLE
WIP - DO - NOT - MERGE - vmware_guest: honor esxi_hostname without template

### DIFF
--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -3091,10 +3091,11 @@ class PyVmomiHelper(PyVmomi):
         clonespec = None
         clone_method = None
         try:
+            # Only select specific host when ESXi hostname is provided
+            if self.params['esxi_hostname']:
+                self.relospec.host = self.select_host()
+
             if self.params['template']:
-                # Only select specific host when ESXi hostname is provided
-                if self.params['esxi_hostname']:
-                    self.relospec.host = self.select_host()
                 self.relospec.datastore = datastore
 
                 # Convert disk present in template if is set


### PR DESCRIPTION
Use the `esxi_hostname` key to target the right host, even if
`template` key is not set.