### PR TITLE
tox: add add_docs environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,12 +253,7 @@ TBD
 ## Publishing New Version
 
 Prepare the release:
-- Refresh the README.md:
-    git clone https://github.com/ansible-network/collection_prep
-    git clone https://github.com/ansible-collections/vmware
-    # WARNING The next comment will remove ~/.ansible/collections/ansible_collections/community/vmware/ !
-    cd collection_prep
-    ./add_docs.py -p ../vmware
+- Refresh the README.md: `tox -e add_docs`
 - Refresh the changelog: `tox -e antsibull-changelog -- release --verbose --version 1.2.0`
 - Clean up the changelog fragments.
 - Commit everything and push a PR for review

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,9 @@ commands =
   antsibull-changelog lint
   ./check-ignores-order
 
+[testenv:add_docs]
+deps = git+https://github.com/ansible-network/collection_prep
+commands = collection_prep_add_docs -p .
 
 [testenv:antsibull-changelog]
 deps =


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/vmware/pull/374

Add a tox enviromment to run `add_docs.py`, this way we don't have
to manually create the virtualenv anymore.