### PR TITLE
vca_*: use relative doc fragment name

### DIFF
--- a/plugins/modules/vca_fw.py
+++ b/plugins/modules/vca_fw.py
@@ -26,7 +26,7 @@ options:
       required: True
       default: false
 extends_documentation_fragment:
-- community.vmware.vca.documentation
+- vca.documentation
 
 '''
 

--- a/plugins/modules/vca_nat.py
+++ b/plugins/modules/vca_nat.py
@@ -30,7 +30,7 @@ options:
       required: True
       default: false
 extends_documentation_fragment:
-- community.vmware.vca.documentation
+- vca.documentation
 
 '''
 


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/674

Don't use the Full Qualified fragment name, this way we can run
`add_docs` even if if the collection is not installed.

Otherwise backtrace starting in `ansible/utils/plugin_docs.py`will
be raised.