### PR TITLE
Ignore leading and trailing whitespace when searching for objects

### DIFF
--- a/changelogs/fragments/335-vmware-strip-names-when-searching.yml
+++ b/changelogs/fragments/335-vmware-strip-names-when-searching.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - module_utils/vmware - Ignore leading and trailing whitespace when searching for objects (https://github.com/ansible-collections/vmware/issues/335)

--- a/plugins/module_utils/vmware.py
+++ b/plugins/module_utils/vmware.py
@@ -130,6 +130,8 @@ def find_object_by_name(content, name, obj_type, folder=None, recurse=True):
     if not isinstance(obj_type, list):
         obj_type = [obj_type]
 
+    name = name.strip()
+
     objects = get_all_objs(content, obj_type, folder=folder, recurse=recurse)
     for obj in objects:
         if obj.name == name:


### PR DESCRIPTION
##### SUMMARY
There is a problem when searching for vSphere objects when they have leading or trailing whitespace. For example, searching for 'Cluster-01 ' (with a trailing space) fails because vCenter will return 'Cluster-01' (without a trailing space) but module_utils.py compares the name literally. And 'Cluster-01 ' != 'Cluster-01'.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware

##### ADDITIONAL INFORMATION
Fixes #335 
