### PR TITLE
Fix for issue #216 vmware_guest ignores esxi_hostname during VM creation

### DIFF
--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -3160,7 +3160,13 @@ class PyVmomiHelper(PyVmomi):
 
                 clone_method = 'CreateVM_Task'
                 try:
-                    task = destfolder.CreateVM_Task(config=self.configspec, pool=resource_pool)
+                    if self.params['esxi_hostname']:
+                        task = destfolder.CreateVM_Task(
+                            config=self.configspec, pool=resource_pool, host=self.select_host()
+                        )
+                    else:
+                        task = destfolder.CreateVM_Task(config=self.configspec, pool=resource_pool)
+
                 except vmodl.fault.InvalidRequest as e:
                     self.module.fail_json(msg="Failed to create virtual machine due to invalid configuration "
                                               "parameter %s" % to_native(e.msg))


### PR DESCRIPTION
During VM creation from template esxi selected via relocate spec and _esxi_hostname_ works as expected.
But during VM creation without template via `CreateVM_Task()` esxi doesn't specified at all and it selected from resource pool, in that way _esxi_hostname_ completely ignored.

##### SUMMARY
Fixes #216 
provide _host_ argument for `CreateVM_Task()` in case if  _self.params['esxi_hostname']_ specified.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_guest.py

##### ADDITIONAL INFORMATION
Details of issue specified in #216 after that changes I tested VM creation with same playbook more than ten times, VM always created on esxi specified in _esxi_hostname_ variable.
Verbose output after host creation pasted below:
```changed: [fvsvms004e.scl.example.org] => {
    "changed": true,
    "instance": {
        "annotation": "",
        "current_snapshot": null,
        "customvalues": {},
        "guest_consolidation_needed": false,
        "guest_question": null,
        "guest_tools_status": "guestToolsNotRunning",
        "guest_tools_version": "0",
        "hw_cluster": "fgv002.scl",
        "hw_cores_per_socket": 16,
        "hw_datastores": [
            "scl_fgv002_fcdatastore003"
        ],
        "hw_esxi_host": "esxi383.scl.example.org",
        "hw_eth0": {
            "addresstype": "assigned",
            "ipaddresses": null,
            "label": "Network adapter 1",
            "macaddress": "00:50:56:ad:a2:cd",
            "macaddress_dash": "00-50-56-ad-a2-cd",
            "portgroup_key": null,
            "portgroup_portkey": null,
            "summary": "VLAN84"
        },
        "hw_files": [
            "[scl_fgv002_fcdatastore003] fvsvms004e.scl.example.org/fvsvms004e.scl.example.org.vmx",
            "[scl_fgv002_fcdatastore003] fvsvms004e.scl.example.org/fvsvms004e.scl.example.org.vmsd",
            "[scl_fgv002_fcdatastore003] fvsvms004e.scl.example.org/fvsvms004e.scl.example.org.vmdk"
        ],
        "hw_folder": "/SCL/vm/FVS",
        "hw_guest_full_name": null,
        "hw_guest_ha_state": null,
        "hw_guest_id": null,
        "hw_interfaces": [
            "eth0"
        ],
        "hw_is_template": false,
        "hw_memtotal_mb": 32768,
        "hw_name": "fvsvms004e.scl.example.org",
        "hw_power_status": "poweredOff",
        "hw_processor_count": 16,
        "hw_product_uuid": "422df320-8a29-fed1-100f-c39f02ff044e",
        "hw_version": "vmx-13",
        "instance_uuid": "502d9efd-125b-1584-7e63-825705ca59b8",
        "ipv4": null,
        "ipv6": null,
        "module_hw": true,
        "moid": "vm-9314",
        "snapshots": [],
        "vimref": "vim.VirtualMachine:vm-9314",
        "vnc": {}
    },
    "invocation": {
        "module_args": {
            "annotation": null,
            "cdrom": [],
            "cluster": null,
            "convert": null,
            "customization": {},
            "customization_spec": null,
            "customvalues": [],
            "datacenter": "SCL",
            "datastore": null,
            "delete_from_inventory": false,
            "disk": [
                {
                    "autoselect_datastore": false,
                    "datastore": "scl_fgv002_fcdatastore003",
                    "size_gb": 150,
                    "type": "thin"
                }
            ],
            "esxi_hostname": "esxi383.scl.example.org",
            "folder": "/FVS",
            "force": false,
            "guest_id": "centos6_64Guest",
            "hardware": {
                "boot_firmware": "bios",
                "memory_mb": "32768",
                "num_cpu_cores_per_socket": 16,
                "num_cpus": 16,
                "scsi": "lsilogic",
                "version": 13
            },
            "hostname": "vcenter001.scl.example.org",
            "is_template": false,
            "linked_clone": false,
            "name": "fvsvms004e.scl.example.org",
            "name_match": "first",
            "networks": [
                {
                    "name": "VLAN84",
                    "start_connected": true,
                    "type": "dhcp"
                }
            ],
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "port": 443,
            "proxy_host": null,
            "proxy_port": null,
            "resource_pool": null,
            "snapshot_src": null,
            "state": "poweredoff",
            "state_change_timeout": 0,
            "template": null,
            "use_instance_uuid": false,
            "username": "USERNAME",
            "uuid": null,
            "validate_certs": false,
            "vapp_properties": [],
            "wait_for_customization": false,
            "wait_for_customization_timeout": 3600,
            "wait_for_ip_address": false,
            "wait_for_ip_address_timeout": 300
        }
    }
}
```
