### PR TITLE
Update links after renaming the repo

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,12 +11,12 @@ v1.2.0
 Minor Changes
 -------------
 
-- vmware_cluster_ha - treat truthy advanced options ('true', 'false') as strings instead of booleans (https://github.com/ansible-collections/vmware/issues/286).
-- vmware_cluster_vsan - implement advanced VSAN options (https://github.com/ansible-collections/vmware/issues/260).
+- vmware_cluster_ha - treat truthy advanced options ('true', 'false') as strings instead of booleans (https://github.com/ansible-collections/community.vmware/issues/286).
+- vmware_cluster_vsan - implement advanced VSAN options (https://github.com/ansible-collections/community.vmware/issues/260).
 - vmware_cluster_vsan - requires the vSAN Management SDK, which needs to be downloaded from VMware and installed manually.
 - vmware_content_deploy_ovf_template - requires the resource_pool parameter.
-- vmware_guest_disk - add backing_uuid value to return (https://github.com/ansible-collections/vmware/pull/348).
-- vmware_guest_serial_port - ensure we can run the module two times in a row without unexpected side effect(https://github.com/ansible-collections/vmware/pull/358).
+- vmware_guest_disk - add backing_uuid value to return (https://github.com/ansible-collections/community.vmware/pull/348).
+- vmware_guest_serial_port - ensure we can run the module two times in a row without unexpected side effect(https://github.com/ansible-collections/community.vmware/pull/358).
 
 Deprecated Features
 -------------------
@@ -26,8 +26,8 @@ Deprecated Features
 Bugfixes
 --------
 
-- vmware_content_deploy_ovf_template - fixed issue where wrong resource pool identifier was returned when same resource pool name was used across clusters in the same datacenter (https://github.com/ansible-collections/vmware/pull/363)
-- vmware_vmkernel - fixed issue where Repl and ReplNFC services were not being identified as enabled on a vmk interface (https://github.com/ansible-collections/vmware/issues/362).
+- vmware_content_deploy_ovf_template - fixed issue where wrong resource pool identifier was returned when same resource pool name was used across clusters in the same datacenter (https://github.com/ansible-collections/community.vmware/pull/363)
+- vmware_vmkernel - fixed issue where Repl and ReplNFC services were not being identified as enabled on a vmk interface (https://github.com/ansible-collections/community.vmware/issues/362).
 
 v1.1.0
 ======
@@ -38,9 +38,9 @@ Minor Changes
 - Added module to be able to create, update, or delete VMware VM storage policies for virtual machines.
 - vmware_cluster_info - added ``properties`` and ``schema`` options and supported the getting of clusters resource summary information.
 - vmware_content_deploy_ovf_template - handle exception while deploying VM using OVF template.
-- vmware_content_deploy_template - handle exception while deploying VM (https://github.com/ansible-collections/vmware/issues/182).
+- vmware_content_deploy_template - handle exception while deploying VM (https://github.com/ansible-collections/community.vmware/issues/182).
 - vmware_dvs_portgroup - Added support for distributed port group with private VLAN.
-- vmware_guest_snapshot_info - Document that `folder` is required if the VM `name` is defined (https://github.com/ansible-collections/vmware/issues/243)
+- vmware_guest_snapshot_info - Document that `folder` is required if the VM `name` is defined (https://github.com/ansible-collections/community.vmware/issues/243)
 - vmware_host_iscsi - a new module for the ESXi hosts that is dedicated to the management of the iSCSI configuration
 - vmware_migrate_vmk - allow migration from a VMware vSphere Distrubuted Switch to a ESXi Standard Switch
 - vmware_vcenter_settings_info - a new module for gather information about vCenter settings
@@ -72,10 +72,10 @@ Removed Features (previously deprecated)
 Bugfixes
 --------
 
-- vmware_content_deploy_ovf_template - use datastore_id in deployment_spec (https://github.com/ansible-collections/vmware/pull/287).
-- vmware_dvs_portgroup_find - Fix comparison between str and int on method vlan_match (https://github.com/ansible-collections/vmware/pull/52).
-- vmware_guest - cdrom.controller_number, cdrom.unit_number are handled as integer. (https://github.com/ansible-collections/vmware/issues/274).
-- vmware_vm_inventory - CustomFieldManager is not present in ESXi, handle this condition (https://github.com/ansible-collections/vmware/issues/269).
+- vmware_content_deploy_ovf_template - use datastore_id in deployment_spec (https://github.com/ansible-collections/community.vmware/pull/287).
+- vmware_dvs_portgroup_find - Fix comparison between str and int on method vlan_match (https://github.com/ansible-collections/community.vmware/pull/52).
+- vmware_guest - cdrom.controller_number, cdrom.unit_number are handled as integer. (https://github.com/ansible-collections/community.vmware/issues/274).
+- vmware_vm_inventory - CustomFieldManager is not present in ESXi, handle this condition (https://github.com/ansible-collections/community.vmware/issues/269).
 
 v1.0.0
 ======
@@ -84,7 +84,7 @@ Minor Changes
 -------------
 
 - A `vmware` module_defaults group has been added to simplify parameters for multiple VMware tasks. This group includes all VMware modules.
-- Add a flag 'force_upgrade' to force VMware tools upgrade installation (https://github.com/ansible-collections/vmware/issues/75).
+- Add a flag 'force_upgrade' to force VMware tools upgrade installation (https://github.com/ansible-collections/community.vmware/issues/75).
 - Add powerstates to match vmware_guest_powerstate module with vmware_guest (https://github.com/ansible/ansible/issues/55653).
 - Added a timeout parameter `wait_for_ip_address_timeout` for `wait_for_ip_address` for longer-running tasks in vmware_guest.
 - Added missing backing_disk_mode information about disk which was removed by mistake in vmware_guest_disk_info.
@@ -96,7 +96,7 @@ Minor Changes
 - Removed ANSIBLE_METADATA from all the modules.
 - Return additional information about hosts inside the cluster using vmware_cluster_info.
 - Update Module examples with FQCN.
-- Update README.md for installing any third party required Python libraries using pip (https://github.com/ansible-collections/vmware/issues/154).
+- Update README.md for installing any third party required Python libraries using pip (https://github.com/ansible-collections/community.vmware/issues/154).
 - add storage_provisioning type into vmware_content_deploy_ovf_template.
 - add vmware_content_deploy_ovf_template module for creating VMs from OVF templates
 - new code module for new feature for operations of VCenter infra profile config.
@@ -121,12 +121,12 @@ Minor Changes
 - vmware_guest_custom_attributes does not require VM name (https://github.com/ansible/ansible/issues/63222).
 - vmware_guest_disk - Add `destroy` option which allows to remove a disk without deleting the VMDK file.
 - vmware_guest_disk - Add `filename` option which allows to create a disk from an existing VMDK.
-- vmware_guest_disk - add support for setting the sharing/multi-writer mode of virtual disks (https://github.com/ansible-collections/vmware/issues/212)
+- vmware_guest_disk - add support for setting the sharing/multi-writer mode of virtual disks (https://github.com/ansible-collections/community.vmware/issues/212)
 - vmware_guest_network - network adapters can be configured without lists
 - vmware_guest_network - network_info returns a list of dictionaries for ease of use
 - vmware_guest_network - put deprecation warning for the networks parameter
 - vmware_guest_tools_wait now exposes a ``timeout`` parameter that allow the user to adjust the timeout (second).
-- vmware_host_active_directory - Fail when there are unrecoverable problems with AD membership instead of reporting a change that doesn't take place (https://github.com/ansible-collections/vmware/issues/59).
+- vmware_host_active_directory - Fail when there are unrecoverable problems with AD membership instead of reporting a change that doesn't take place (https://github.com/ansible-collections/community.vmware/issues/59).
 - vmware_host_dns - New module replacing vmware_dns_config with increased functionality.
 - vmware_host_dns can now set the following empty values, ``domain``, ``search_domains`` and ``dns_servers``.
 - vmware_host_facts - added ``properties`` and ``schema`` options.
@@ -162,10 +162,10 @@ Bugfixes
 - Fixed typo in vmware_guest_powerstate module (https://github.com/ansible/ansible/issues/65161).
 - Handle Base64 Binary while JSON serialization in vmware_vm_inventory.
 - Handle NoneType error when accessing service system info in vmware_host_service_info module (https://github.com/ansible/ansible/issues/67615).
-- Handle list items in vSphere schema while handling facts using to_json API (https://github.com/ansible-collections/vmware/issues/33).
+- Handle list items in vSphere schema while handling facts using to_json API (https://github.com/ansible-collections/community.vmware/issues/33).
 - Handle multiple tags name with different category id in vmware_tag module (https://github.com/ansible/ansible/issues/66340).
 - Handle slashes in VMware network name (https://github.com/ansible/ansible/issues/64399).
-- In inventory plugin, serialize properties user specifies which are objects as dicts (https://github.com/ansible-collections/vmware/pull/58).
+- In inventory plugin, serialize properties user specifies which are objects as dicts (https://github.com/ansible-collections/community.vmware/pull/58).
 - In vmware_guest_network module use appropriate network while creating or reconfiguring (https://github.com/ansible/ansible/issues/65968).
 - Made vmnics attributes optional when creating DVS as they are optional on the API and GUI as well.
 - VMware Guest Inventory plugin enhancements and features.
@@ -174,7 +174,7 @@ Bugfixes
 - `vmware_content_deploy_template`'s `cluster` argument no longer fails with an error message about resource pools.
 - return correct datastore cluster placement recommendations during when adding disk using the vmware_guest_disk module
 - vmware - Ensure we can use the modules with Python < 2.7.9 or RHEL/CentOS < 7.4, this as soon as ``validate_certs`` is disabled.
-- vmware_category - fix associable datatypes (https://github.com/ansible-collections/vmware/issues/197).
+- vmware_category - fix associable datatypes (https://github.com/ansible-collections/community.vmware/issues/197).
 - vmware_content_deploy_template - Added param content_library to the main function
 - vmware_deploy_ovf - Fixed ova deploy error occur if vm exists
 - vmware_dvs_portgroup - Implemented configuration changes on an existing Distributed vSwitch portgroup.
@@ -185,7 +185,7 @@ Bugfixes
 - vmware_guest - Updated reference link to vapp_properties property
 - vmware_host_capability_facts - Fixed vSphere API legacy version errors occur in pyvmomi 7.0 and later
 - vmware_host_capability_info - Fixed vSphere API legacy version errors occur in pyvmomi 7.0 and later
-- vmware_host_facts - handle facts when ESXi hostsystem is poweredoff (https://github.com/ansible-collections/vmware/issues/183).
+- vmware_host_facts - handle facts when ESXi hostsystem is poweredoff (https://github.com/ansible-collections/community.vmware/issues/183).
 - vmware_host_firewall_manager - Ensure we can set rule with no ``allowed_hosts`` key (https://github.com/ansible/ansible/issues/61332)
 - vmware_host_firewall_manager - Fixed creating IP specific firewall rules with Python 2 (https://github.com/ansible/ansible/issues/67303)
 - vmware_host_vmhba_info - fixed node_wwn and port_wwn for FC HBA to hexadecimal format(https://github.com/ansible/ansible/issues/63045).

--- a/README.md
+++ b/README.md
@@ -53,190 +53,190 @@ If you are working on developing and/or testing VMware community collection, you
 ### Connection plugins
 Name | Description
 --- | ---
-[community.vmware.vmware_tools](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_tools_connection.rst)|Execute tasks inside a VM via VMware Tools
+[community.vmware.vmware_tools](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_tools_connection.rst)|Execute tasks inside a VM via VMware Tools
 
 ### Httpapi plugins
 Name | Description
 --- | ---
-[community.vmware.vmware](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_httpapi.rst)|HttpApi Plugin for VMware REST API
+[community.vmware.vmware](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_httpapi.rst)|HttpApi Plugin for VMware REST API
 
 ### Modules
 Name | Description
 --- | ---
-[community.vmware.vca_fw](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vca_fw_module.rst)|add remove firewall rules in a gateway  in a vca
-[community.vmware.vca_nat](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vca_nat_module.rst)|add remove nat rules in a gateway  in a vca
-[community.vmware.vca_vapp](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vca_vapp_module.rst)|Manages vCloud Air vApp instances.
-[community.vmware.vcenter_extension](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vcenter_extension_module.rst)|Register/deregister vCenter Extensions
-[community.vmware.vcenter_extension_facts](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vcenter_extension_facts_module.rst)|Gather facts vCenter extensions
-[community.vmware.vcenter_extension_info](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vcenter_extension_info_module.rst)|Gather info vCenter extensions
-[community.vmware.vcenter_folder](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vcenter_folder_module.rst)|Manage folders on given datacenter
-[community.vmware.vcenter_license](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vcenter_license_module.rst)|Manage VMware vCenter license keys
-[community.vmware.vmware_about_facts](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_about_facts_module.rst)|Provides information about VMware server to which user is connecting to
-[community.vmware.vmware_about_info](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_about_info_module.rst)|Provides information about VMware server to which user is connecting to
-[community.vmware.vmware_category](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_category_module.rst)|Manage VMware categories
-[community.vmware.vmware_category_facts](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_category_facts_module.rst)|Gather facts about VMware tag categories
-[community.vmware.vmware_category_info](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_category_info_module.rst)|Gather info about VMware tag categories
-[community.vmware.vmware_cfg_backup](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_cfg_backup_module.rst)|Backup / Restore / Reset ESXi host configuration
-[community.vmware.vmware_cluster](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_cluster_module.rst)|Manage VMware vSphere clusters
-[community.vmware.vmware_cluster_drs](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_cluster_drs_module.rst)|Manage Distributed Resource Scheduler (DRS) on VMware vSphere clusters
-[community.vmware.vmware_cluster_ha](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_cluster_ha_module.rst)|Manage High Availability (HA) on VMware vSphere clusters
-[community.vmware.vmware_cluster_info](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_cluster_info_module.rst)|Gather info about clusters available in given vCenter
-[community.vmware.vmware_cluster_vsan](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_cluster_vsan_module.rst)|Manages virtual storage area network (vSAN) configuration on VMware vSphere clusters
-[community.vmware.vmware_content_deploy_ovf_template](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_content_deploy_ovf_template_module.rst)|Deploy Virtual Machine from ovf template stored in content library.
-[community.vmware.vmware_content_deploy_template](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_content_deploy_template_module.rst)|Deploy Virtual Machine from template stored in content library.
-[community.vmware.vmware_content_library_info](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_content_library_info_module.rst)|Gather information about VMWare Content Library
-[community.vmware.vmware_content_library_manager](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_content_library_manager_module.rst)|Create, update and delete VMware content library
-[community.vmware.vmware_datacenter](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_datacenter_module.rst)|Manage VMware vSphere Datacenters
-[community.vmware.vmware_datacenter_info](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_datacenter_info_module.rst)|Gather information about VMware vSphere Datacenters
-[community.vmware.vmware_datastore_cluster](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_datastore_cluster_module.rst)|Manage VMware vSphere datastore clusters
-[community.vmware.vmware_datastore_info](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_datastore_info_module.rst)|Gather info about datastores available in given vCenter
-[community.vmware.vmware_datastore_maintenancemode](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_datastore_maintenancemode_module.rst)|Place a datastore into maintenance mode
-[community.vmware.vmware_deploy_ovf](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_deploy_ovf_module.rst)|Deploys a VMware virtual machine from an OVF or OVA file
-[community.vmware.vmware_dns_config](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_dns_config_module.rst)|Manage VMware ESXi DNS Configuration
-[community.vmware.vmware_drs_group](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_drs_group_module.rst)|Creates vm/host group in a given cluster.
-[community.vmware.vmware_drs_group_facts](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_drs_group_facts_module.rst)|Gathers facts about DRS VM/Host groups on the given cluster
-[community.vmware.vmware_drs_group_info](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_drs_group_info_module.rst)|Gathers info about DRS VM/Host groups on the given cluster
-[community.vmware.vmware_drs_rule_facts](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_drs_rule_facts_module.rst)|Gathers facts about DRS rule on the given cluster
-[community.vmware.vmware_drs_rule_info](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_drs_rule_info_module.rst)|Gathers info about DRS rule on the given cluster
-[community.vmware.vmware_dvs_host](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_dvs_host_module.rst)|Add or remove a host from distributed virtual switch
-[community.vmware.vmware_dvs_portgroup](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_dvs_portgroup_module.rst)|Create or remove a Distributed vSwitch portgroup.
-[community.vmware.vmware_dvs_portgroup_facts](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_dvs_portgroup_facts_module.rst)|Gathers facts DVS portgroup configurations
-[community.vmware.vmware_dvs_portgroup_find](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_dvs_portgroup_find_module.rst)|Find portgroup(s) in a VMware environment
-[community.vmware.vmware_dvs_portgroup_info](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_dvs_portgroup_info_module.rst)|Gathers info DVS portgroup configurations
-[community.vmware.vmware_dvswitch](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_dvswitch_module.rst)|Create or remove a Distributed Switch
-[community.vmware.vmware_dvswitch_info](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_dvswitch_info_module.rst)|Gathers info dvswitch configurations
-[community.vmware.vmware_dvswitch_lacp](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_dvswitch_lacp_module.rst)|Manage LACP configuration on a Distributed Switch
-[community.vmware.vmware_dvswitch_nioc](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_dvswitch_nioc_module.rst)|Manage distributed switch Network IO Control
-[community.vmware.vmware_dvswitch_pvlans](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_dvswitch_pvlans_module.rst)|Manage Private VLAN configuration of a Distributed Switch
-[community.vmware.vmware_dvswitch_uplink_pg](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_dvswitch_uplink_pg_module.rst)|Manage uplink portproup configuration of a Distributed Switch
-[community.vmware.vmware_evc_mode](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_evc_mode_module.rst)|Enable/Disable EVC mode on vCenter
-[community.vmware.vmware_export_ovf](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_export_ovf_module.rst)|Exports a VMware virtual machine to an OVF file, device files and a manifest file
-[community.vmware.vmware_folder_info](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_folder_info_module.rst)|Provides information about folders in a datacenter
-[community.vmware.vmware_guest](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_guest_module.rst)|Manages virtual machines in vCenter
-[community.vmware.vmware_guest_boot_facts](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_guest_boot_facts_module.rst)|Gather facts about boot options for the given virtual machine
-[community.vmware.vmware_guest_boot_info](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_guest_boot_info_module.rst)|Gather info about boot options for the given virtual machine
-[community.vmware.vmware_guest_boot_manager](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_guest_boot_manager_module.rst)|Manage boot options for the given virtual machine
-[community.vmware.vmware_guest_controller](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_guest_controller_module.rst)|Manage disk or USB controllers related to virtual machine in given vCenter infrastructure
-[community.vmware.vmware_guest_cross_vc_clone](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_guest_cross_vc_clone_module.rst)|Cross-vCenter VM/template clone
-[community.vmware.vmware_guest_custom_attribute_defs](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_guest_custom_attribute_defs_module.rst)|Manage custom attributes definitions for virtual machine from VMware
-[community.vmware.vmware_guest_custom_attributes](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_guest_custom_attributes_module.rst)|Manage custom attributes from VMware for the given virtual machine
-[community.vmware.vmware_guest_customization_facts](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_guest_customization_facts_module.rst)|Gather facts about VM customization specifications
-[community.vmware.vmware_guest_customization_info](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_guest_customization_info_module.rst)|Gather info about VM customization specifications
-[community.vmware.vmware_guest_disk](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_guest_disk_module.rst)|Manage disks related to virtual machine in given vCenter infrastructure
-[community.vmware.vmware_guest_disk_facts](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_guest_disk_facts_module.rst)|Gather facts about disks of given virtual machine
-[community.vmware.vmware_guest_disk_info](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_guest_disk_info_module.rst)|Gather info about disks of given virtual machine
-[community.vmware.vmware_guest_file_operation](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_guest_file_operation_module.rst)|Files operation in a VMware guest operating system without network
-[community.vmware.vmware_guest_find](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_guest_find_module.rst)|Find the folder path(s) for a virtual machine by name or UUID
-[community.vmware.vmware_guest_info](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_guest_info_module.rst)|Gather info about a single VM
-[community.vmware.vmware_guest_move](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_guest_move_module.rst)|Moves virtual machines in vCenter
-[community.vmware.vmware_guest_network](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_guest_network_module.rst)|Manage network adapters of specified virtual machine in given vCenter infrastructure
-[community.vmware.vmware_guest_powerstate](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_guest_powerstate_module.rst)|Manages power states of virtual machines in vCenter
-[community.vmware.vmware_guest_register_operation](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_guest_register_operation_module.rst)|VM inventory registration operation
-[community.vmware.vmware_guest_screenshot](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_guest_screenshot_module.rst)|Create a screenshot of the Virtual Machine console.
-[community.vmware.vmware_guest_sendkey](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_guest_sendkey_module.rst)|Send USB HID codes to the Virtual Machine's keyboard.
-[community.vmware.vmware_guest_serial_port](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_guest_serial_port_module.rst)|Manage serial ports on an existing VM
-[community.vmware.vmware_guest_snapshot](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_guest_snapshot_module.rst)|Manages virtual machines snapshots in vCenter
-[community.vmware.vmware_guest_snapshot_info](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_guest_snapshot_info_module.rst)|Gather info about virtual machine's snapshots in vCenter
-[community.vmware.vmware_guest_tools_info](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_guest_tools_info_module.rst)|Gather info about VMware tools installed in VM
-[community.vmware.vmware_guest_tools_upgrade](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_guest_tools_upgrade_module.rst)|Module to upgrade VMTools
-[community.vmware.vmware_guest_tools_wait](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_guest_tools_wait_module.rst)|Wait for VMware tools to become available
-[community.vmware.vmware_guest_video](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_guest_video_module.rst)|Modify video card configurations of specified virtual machine in given vCenter infrastructure
-[community.vmware.vmware_guest_vnc](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_guest_vnc_module.rst)|Manages VNC remote display on virtual machines in vCenter
-[community.vmware.vmware_host](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_host_module.rst)|Add, remove, or move an ESXi host to, from, or within vCenter
-[community.vmware.vmware_host_acceptance](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_host_acceptance_module.rst)|Manage the host acceptance level of an ESXi host
-[community.vmware.vmware_host_active_directory](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_host_active_directory_module.rst)|Joins an ESXi host system to an Active Directory domain or leaves it
-[community.vmware.vmware_host_auto_start](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_host_auto_start_module.rst)|Manage the auto power ON or OFF for vm on ESXi host
-[community.vmware.vmware_host_capability_facts](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_host_capability_facts_module.rst)|Gathers facts about an ESXi host's capability information
-[community.vmware.vmware_host_capability_info](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_host_capability_info_module.rst)|Gathers info about an ESXi host's capability information
-[community.vmware.vmware_host_config_facts](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_host_config_facts_module.rst)|Gathers facts about an ESXi host's advance configuration information
-[community.vmware.vmware_host_config_info](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_host_config_info_module.rst)|Gathers info about an ESXi host's advance configuration information
-[community.vmware.vmware_host_config_manager](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_host_config_manager_module.rst)|Manage advanced system settings of an ESXi host
-[community.vmware.vmware_host_datastore](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_host_datastore_module.rst)|Manage a datastore on ESXi host
-[community.vmware.vmware_host_dns](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_host_dns_module.rst)|Manage DNS configuration of an ESXi host system
-[community.vmware.vmware_host_dns_facts](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_host_dns_facts_module.rst)|Gathers facts about an ESXi host's DNS configuration information
-[community.vmware.vmware_host_dns_info](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_host_dns_info_module.rst)|Gathers info about an ESXi host's DNS configuration information
-[community.vmware.vmware_host_facts](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_host_facts_module.rst)|Gathers facts about remote ESXi hostsystem
-[community.vmware.vmware_host_feature_facts](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_host_feature_facts_module.rst)|Gathers facts about an ESXi host's feature capability information
-[community.vmware.vmware_host_feature_info](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_host_feature_info_module.rst)|Gathers info about an ESXi host's feature capability information
-[community.vmware.vmware_host_firewall_facts](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_host_firewall_facts_module.rst)|Gathers facts about an ESXi host's firewall configuration information
-[community.vmware.vmware_host_firewall_info](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_host_firewall_info_module.rst)|Gathers info about an ESXi host's firewall configuration information
-[community.vmware.vmware_host_firewall_manager](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_host_firewall_manager_module.rst)|Manage firewall configurations about an ESXi host
-[community.vmware.vmware_host_hyperthreading](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_host_hyperthreading_module.rst)|Enables/Disables Hyperthreading optimization for an ESXi host system
-[community.vmware.vmware_host_ipv6](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_host_ipv6_module.rst)|Enables/Disables IPv6 support for an ESXi host system
-[community.vmware.vmware_host_iscsi](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_host_iscsi_module.rst)|Manage the iSCSI configuration of ESXi host
-[community.vmware.vmware_host_kernel_manager](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_host_kernel_manager_module.rst)|Manage kernel module options on ESXi hosts
-[community.vmware.vmware_host_lockdown](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_host_lockdown_module.rst)|Manage administrator permission for the local administrative account for the ESXi host
-[community.vmware.vmware_host_logbundle](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_host_logbundle_module.rst)|Fetch logbundle file from ESXi
-[community.vmware.vmware_host_logbundle_info](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_host_logbundle_info_module.rst)|Gathers manifest info for logbundle
-[community.vmware.vmware_host_ntp](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_host_ntp_module.rst)|Manage NTP server configuration of an ESXi host
-[community.vmware.vmware_host_ntp_facts](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_host_ntp_facts_module.rst)|Gathers facts about NTP configuration on an ESXi host
-[community.vmware.vmware_host_ntp_info](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_host_ntp_info_module.rst)|Gathers info about NTP configuration on an ESXi host
-[community.vmware.vmware_host_package_facts](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_host_package_facts_module.rst)|Gathers facts about available packages on an ESXi host
-[community.vmware.vmware_host_package_info](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_host_package_info_module.rst)|Gathers info about available packages on an ESXi host
-[community.vmware.vmware_host_powermgmt_policy](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_host_powermgmt_policy_module.rst)|Manages the Power Management Policy of an ESXI host system
-[community.vmware.vmware_host_powerstate](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_host_powerstate_module.rst)|Manages power states of host systems in vCenter
-[community.vmware.vmware_host_scanhba](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_host_scanhba_module.rst)|Rescan host HBA's and optionally refresh the storage system
-[community.vmware.vmware_host_service_facts](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_host_service_facts_module.rst)|Gathers facts about an ESXi host's services
-[community.vmware.vmware_host_service_info](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_host_service_info_module.rst)|Gathers info about an ESXi host's services
-[community.vmware.vmware_host_service_manager](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_host_service_manager_module.rst)|Manage services on a given ESXi host
-[community.vmware.vmware_host_snmp](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_host_snmp_module.rst)|Configures SNMP on an ESXi host system
-[community.vmware.vmware_host_sriov](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_host_sriov_module.rst)|Manage SR-IOV settings on host
-[community.vmware.vmware_host_ssl_facts](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_host_ssl_facts_module.rst)|Gather facts of ESXi host system about SSL
-[community.vmware.vmware_host_ssl_info](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_host_ssl_info_module.rst)|Gather info of ESXi host system about SSL
-[community.vmware.vmware_host_vmhba_facts](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_host_vmhba_facts_module.rst)|Gathers facts about vmhbas available on the given ESXi host
-[community.vmware.vmware_host_vmhba_info](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_host_vmhba_info_module.rst)|Gathers info about vmhbas available on the given ESXi host
-[community.vmware.vmware_host_vmnic_facts](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_host_vmnic_facts_module.rst)|Gathers facts about vmnics available on the given ESXi host
-[community.vmware.vmware_host_vmnic_info](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_host_vmnic_info_module.rst)|Gathers info about vmnics available on the given ESXi host
-[community.vmware.vmware_local_role_facts](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_local_role_facts_module.rst)|Gather facts about local roles on an ESXi host
-[community.vmware.vmware_local_role_info](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_local_role_info_module.rst)|Gather info about local roles on an ESXi host
-[community.vmware.vmware_local_role_manager](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_local_role_manager_module.rst)|Manage local roles on an ESXi host
-[community.vmware.vmware_local_user_facts](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_local_user_facts_module.rst)|Gather facts about users on the given ESXi host
-[community.vmware.vmware_local_user_info](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_local_user_info_module.rst)|Gather info about users on the given ESXi host
-[community.vmware.vmware_local_user_manager](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_local_user_manager_module.rst)|Manage local users on an ESXi host
-[community.vmware.vmware_maintenancemode](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_maintenancemode_module.rst)|Place a host into maintenance mode
-[community.vmware.vmware_migrate_vmk](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_migrate_vmk_module.rst)|Migrate a VMK interface from VSS to VDS
-[community.vmware.vmware_object_rename](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_object_rename_module.rst)|Renames VMware objects
-[community.vmware.vmware_object_role_permission](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_object_role_permission_module.rst)|Manage local roles on an ESXi host
-[community.vmware.vmware_portgroup](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_portgroup_module.rst)|Create a VMware portgroup
-[community.vmware.vmware_portgroup_facts](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_portgroup_facts_module.rst)|Gathers facts about an ESXi host's Port Group configuration
-[community.vmware.vmware_portgroup_info](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_portgroup_info_module.rst)|Gathers info about an ESXi host's Port Group configuration
-[community.vmware.vmware_resource_pool](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_resource_pool_module.rst)|Add/remove resource pools to/from vCenter
-[community.vmware.vmware_resource_pool_facts](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_resource_pool_facts_module.rst)|Gathers facts about resource pool information
-[community.vmware.vmware_resource_pool_info](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_resource_pool_info_module.rst)|Gathers info about resource pool information
-[community.vmware.vmware_tag](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_tag_module.rst)|Manage VMware tags
-[community.vmware.vmware_tag_info](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_tag_info_module.rst)|Manage VMware tag info
-[community.vmware.vmware_tag_manager](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_tag_manager_module.rst)|Manage association of VMware tags with VMware objects
-[community.vmware.vmware_target_canonical_facts](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_target_canonical_facts_module.rst)|Return canonical (NAA) from an ESXi host system
-[community.vmware.vmware_target_canonical_info](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_target_canonical_info_module.rst)|Return canonical (NAA) from an ESXi host system
-[community.vmware.vmware_vc_infraprofile_info](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_vc_infraprofile_info_module.rst)|List and Export VMware vCenter infra profile configs.
-[community.vmware.vmware_vcenter_settings](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_vcenter_settings_module.rst)|Configures general settings on a vCenter server
-[community.vmware.vmware_vcenter_settings_info](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_vcenter_settings_info_module.rst)|Gather info vCenter settings
-[community.vmware.vmware_vcenter_statistics](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_vcenter_statistics_module.rst)|Configures statistics on a vCenter server
-[community.vmware.vmware_vm_host_drs_rule](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_vm_host_drs_rule_module.rst)|Creates vm/host group in a given cluster
-[community.vmware.vmware_vm_info](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_vm_info_module.rst)|Return basic info pertaining to a VMware machine guest
-[community.vmware.vmware_vm_shell](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_vm_shell_module.rst)|Run commands in a VMware guest operating system
-[community.vmware.vmware_vm_storage_policy](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_vm_storage_policy_module.rst)|Create vSphere storage policies
-[community.vmware.vmware_vm_storage_policy_info](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_vm_storage_policy_info_module.rst)|Gather information about vSphere storage profile defined storage policy information.
-[community.vmware.vmware_vm_vm_drs_rule](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_vm_vm_drs_rule_module.rst)|Configure VMware DRS Affinity rule for virtual machine in given cluster
-[community.vmware.vmware_vm_vss_dvs_migrate](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_vm_vss_dvs_migrate_module.rst)|Migrates a virtual machine from a standard vswitch to distributed
-[community.vmware.vmware_vmkernel](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_vmkernel_module.rst)|Manages a VMware VMkernel Adapter of an ESXi host.
-[community.vmware.vmware_vmkernel_facts](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_vmkernel_facts_module.rst)|Gathers VMKernel facts about an ESXi host
-[community.vmware.vmware_vmkernel_info](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_vmkernel_info_module.rst)|Gathers VMKernel info about an ESXi host
-[community.vmware.vmware_vmkernel_ip_config](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_vmkernel_ip_config_module.rst)|Configure the VMkernel IP Address
-[community.vmware.vmware_vmotion](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_vmotion_module.rst)|Move a virtual machine using vMotion, and/or its vmdks using storage vMotion.
-[community.vmware.vmware_vsan_cluster](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_vsan_cluster_module.rst)|Configure VSAN clustering on an ESXi host
-[community.vmware.vmware_vsan_health_info](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_vsan_health_info_module.rst)|Gather information about a VMware vSAN cluster's health
-[community.vmware.vmware_vspan_session](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_vspan_session_module.rst)|Create or remove a Port Mirroring session.
-[community.vmware.vmware_vswitch](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_vswitch_module.rst)|Manage a VMware Standard Switch to an ESXi host.
-[community.vmware.vmware_vswitch_facts](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_vswitch_facts_module.rst)|Gathers facts about an ESXi host's vswitch configurations
-[community.vmware.vmware_vswitch_info](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_vswitch_info_module.rst)|Gathers info about an ESXi host's vswitch configurations
-[community.vmware.vsphere_copy](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vsphere_copy_module.rst)|Copy a file to a VMware datastore
-[community.vmware.vsphere_file](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vsphere_file_module.rst)|Manage files on a vCenter datastore
+[community.vmware.vca_fw](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vca_fw_module.rst)|add remove firewall rules in a gateway  in a vca
+[community.vmware.vca_nat](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vca_nat_module.rst)|add remove nat rules in a gateway  in a vca
+[community.vmware.vca_vapp](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vca_vapp_module.rst)|Manages vCloud Air vApp instances.
+[community.vmware.vcenter_extension](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vcenter_extension_module.rst)|Register/deregister vCenter Extensions
+[community.vmware.vcenter_extension_facts](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vcenter_extension_facts_module.rst)|Gather facts vCenter extensions
+[community.vmware.vcenter_extension_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vcenter_extension_info_module.rst)|Gather info vCenter extensions
+[community.vmware.vcenter_folder](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vcenter_folder_module.rst)|Manage folders on given datacenter
+[community.vmware.vcenter_license](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vcenter_license_module.rst)|Manage VMware vCenter license keys
+[community.vmware.vmware_about_facts](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_about_facts_module.rst)|Provides information about VMware server to which user is connecting to
+[community.vmware.vmware_about_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_about_info_module.rst)|Provides information about VMware server to which user is connecting to
+[community.vmware.vmware_category](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_category_module.rst)|Manage VMware categories
+[community.vmware.vmware_category_facts](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_category_facts_module.rst)|Gather facts about VMware tag categories
+[community.vmware.vmware_category_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_category_info_module.rst)|Gather info about VMware tag categories
+[community.vmware.vmware_cfg_backup](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_cfg_backup_module.rst)|Backup / Restore / Reset ESXi host configuration
+[community.vmware.vmware_cluster](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_cluster_module.rst)|Manage VMware vSphere clusters
+[community.vmware.vmware_cluster_drs](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_cluster_drs_module.rst)|Manage Distributed Resource Scheduler (DRS) on VMware vSphere clusters
+[community.vmware.vmware_cluster_ha](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_cluster_ha_module.rst)|Manage High Availability (HA) on VMware vSphere clusters
+[community.vmware.vmware_cluster_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_cluster_info_module.rst)|Gather info about clusters available in given vCenter
+[community.vmware.vmware_cluster_vsan](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_cluster_vsan_module.rst)|Manages virtual storage area network (vSAN) configuration on VMware vSphere clusters
+[community.vmware.vmware_content_deploy_ovf_template](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_content_deploy_ovf_template_module.rst)|Deploy Virtual Machine from ovf template stored in content library.
+[community.vmware.vmware_content_deploy_template](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_content_deploy_template_module.rst)|Deploy Virtual Machine from template stored in content library.
+[community.vmware.vmware_content_library_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_content_library_info_module.rst)|Gather information about VMWare Content Library
+[community.vmware.vmware_content_library_manager](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_content_library_manager_module.rst)|Create, update and delete VMware content library
+[community.vmware.vmware_datacenter](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_datacenter_module.rst)|Manage VMware vSphere Datacenters
+[community.vmware.vmware_datacenter_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_datacenter_info_module.rst)|Gather information about VMware vSphere Datacenters
+[community.vmware.vmware_datastore_cluster](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_datastore_cluster_module.rst)|Manage VMware vSphere datastore clusters
+[community.vmware.vmware_datastore_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_datastore_info_module.rst)|Gather info about datastores available in given vCenter
+[community.vmware.vmware_datastore_maintenancemode](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_datastore_maintenancemode_module.rst)|Place a datastore into maintenance mode
+[community.vmware.vmware_deploy_ovf](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_deploy_ovf_module.rst)|Deploys a VMware virtual machine from an OVF or OVA file
+[community.vmware.vmware_dns_config](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_dns_config_module.rst)|Manage VMware ESXi DNS Configuration
+[community.vmware.vmware_drs_group](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_drs_group_module.rst)|Creates vm/host group in a given cluster.
+[community.vmware.vmware_drs_group_facts](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_drs_group_facts_module.rst)|Gathers facts about DRS VM/Host groups on the given cluster
+[community.vmware.vmware_drs_group_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_drs_group_info_module.rst)|Gathers info about DRS VM/Host groups on the given cluster
+[community.vmware.vmware_drs_rule_facts](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_drs_rule_facts_module.rst)|Gathers facts about DRS rule on the given cluster
+[community.vmware.vmware_drs_rule_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_drs_rule_info_module.rst)|Gathers info about DRS rule on the given cluster
+[community.vmware.vmware_dvs_host](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_dvs_host_module.rst)|Add or remove a host from distributed virtual switch
+[community.vmware.vmware_dvs_portgroup](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_dvs_portgroup_module.rst)|Create or remove a Distributed vSwitch portgroup.
+[community.vmware.vmware_dvs_portgroup_facts](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_dvs_portgroup_facts_module.rst)|Gathers facts DVS portgroup configurations
+[community.vmware.vmware_dvs_portgroup_find](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_dvs_portgroup_find_module.rst)|Find portgroup(s) in a VMware environment
+[community.vmware.vmware_dvs_portgroup_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_dvs_portgroup_info_module.rst)|Gathers info DVS portgroup configurations
+[community.vmware.vmware_dvswitch](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_dvswitch_module.rst)|Create or remove a Distributed Switch
+[community.vmware.vmware_dvswitch_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_dvswitch_info_module.rst)|Gathers info dvswitch configurations
+[community.vmware.vmware_dvswitch_lacp](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_dvswitch_lacp_module.rst)|Manage LACP configuration on a Distributed Switch
+[community.vmware.vmware_dvswitch_nioc](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_dvswitch_nioc_module.rst)|Manage distributed switch Network IO Control
+[community.vmware.vmware_dvswitch_pvlans](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_dvswitch_pvlans_module.rst)|Manage Private VLAN configuration of a Distributed Switch
+[community.vmware.vmware_dvswitch_uplink_pg](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_dvswitch_uplink_pg_module.rst)|Manage uplink portproup configuration of a Distributed Switch
+[community.vmware.vmware_evc_mode](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_evc_mode_module.rst)|Enable/Disable EVC mode on vCenter
+[community.vmware.vmware_export_ovf](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_export_ovf_module.rst)|Exports a VMware virtual machine to an OVF file, device files and a manifest file
+[community.vmware.vmware_folder_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_folder_info_module.rst)|Provides information about folders in a datacenter
+[community.vmware.vmware_guest](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_guest_module.rst)|Manages virtual machines in vCenter
+[community.vmware.vmware_guest_boot_facts](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_guest_boot_facts_module.rst)|Gather facts about boot options for the given virtual machine
+[community.vmware.vmware_guest_boot_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_guest_boot_info_module.rst)|Gather info about boot options for the given virtual machine
+[community.vmware.vmware_guest_boot_manager](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_guest_boot_manager_module.rst)|Manage boot options for the given virtual machine
+[community.vmware.vmware_guest_controller](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_guest_controller_module.rst)|Manage disk or USB controllers related to virtual machine in given vCenter infrastructure
+[community.vmware.vmware_guest_cross_vc_clone](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_guest_cross_vc_clone_module.rst)|Cross-vCenter VM/template clone
+[community.vmware.vmware_guest_custom_attribute_defs](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_guest_custom_attribute_defs_module.rst)|Manage custom attributes definitions for virtual machine from VMware
+[community.vmware.vmware_guest_custom_attributes](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_guest_custom_attributes_module.rst)|Manage custom attributes from VMware for the given virtual machine
+[community.vmware.vmware_guest_customization_facts](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_guest_customization_facts_module.rst)|Gather facts about VM customization specifications
+[community.vmware.vmware_guest_customization_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_guest_customization_info_module.rst)|Gather info about VM customization specifications
+[community.vmware.vmware_guest_disk](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_guest_disk_module.rst)|Manage disks related to virtual machine in given vCenter infrastructure
+[community.vmware.vmware_guest_disk_facts](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_guest_disk_facts_module.rst)|Gather facts about disks of given virtual machine
+[community.vmware.vmware_guest_disk_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_guest_disk_info_module.rst)|Gather info about disks of given virtual machine
+[community.vmware.vmware_guest_file_operation](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_guest_file_operation_module.rst)|Files operation in a VMware guest operating system without network
+[community.vmware.vmware_guest_find](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_guest_find_module.rst)|Find the folder path(s) for a virtual machine by name or UUID
+[community.vmware.vmware_guest_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_guest_info_module.rst)|Gather info about a single VM
+[community.vmware.vmware_guest_move](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_guest_move_module.rst)|Moves virtual machines in vCenter
+[community.vmware.vmware_guest_network](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_guest_network_module.rst)|Manage network adapters of specified virtual machine in given vCenter infrastructure
+[community.vmware.vmware_guest_powerstate](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_guest_powerstate_module.rst)|Manages power states of virtual machines in vCenter
+[community.vmware.vmware_guest_register_operation](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_guest_register_operation_module.rst)|VM inventory registration operation
+[community.vmware.vmware_guest_screenshot](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_guest_screenshot_module.rst)|Create a screenshot of the Virtual Machine console.
+[community.vmware.vmware_guest_sendkey](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_guest_sendkey_module.rst)|Send USB HID codes to the Virtual Machine's keyboard.
+[community.vmware.vmware_guest_serial_port](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_guest_serial_port_module.rst)|Manage serial ports on an existing VM
+[community.vmware.vmware_guest_snapshot](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_guest_snapshot_module.rst)|Manages virtual machines snapshots in vCenter
+[community.vmware.vmware_guest_snapshot_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_guest_snapshot_info_module.rst)|Gather info about virtual machine's snapshots in vCenter
+[community.vmware.vmware_guest_tools_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_guest_tools_info_module.rst)|Gather info about VMware tools installed in VM
+[community.vmware.vmware_guest_tools_upgrade](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_guest_tools_upgrade_module.rst)|Module to upgrade VMTools
+[community.vmware.vmware_guest_tools_wait](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_guest_tools_wait_module.rst)|Wait for VMware tools to become available
+[community.vmware.vmware_guest_video](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_guest_video_module.rst)|Modify video card configurations of specified virtual machine in given vCenter infrastructure
+[community.vmware.vmware_guest_vnc](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_guest_vnc_module.rst)|Manages VNC remote display on virtual machines in vCenter
+[community.vmware.vmware_host](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_module.rst)|Add, remove, or move an ESXi host to, from, or within vCenter
+[community.vmware.vmware_host_acceptance](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_acceptance_module.rst)|Manage the host acceptance level of an ESXi host
+[community.vmware.vmware_host_active_directory](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_active_directory_module.rst)|Joins an ESXi host system to an Active Directory domain or leaves it
+[community.vmware.vmware_host_auto_start](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_auto_start_module.rst)|Manage the auto power ON or OFF for vm on ESXi host
+[community.vmware.vmware_host_capability_facts](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_capability_facts_module.rst)|Gathers facts about an ESXi host's capability information
+[community.vmware.vmware_host_capability_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_capability_info_module.rst)|Gathers info about an ESXi host's capability information
+[community.vmware.vmware_host_config_facts](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_config_facts_module.rst)|Gathers facts about an ESXi host's advance configuration information
+[community.vmware.vmware_host_config_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_config_info_module.rst)|Gathers info about an ESXi host's advance configuration information
+[community.vmware.vmware_host_config_manager](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_config_manager_module.rst)|Manage advanced system settings of an ESXi host
+[community.vmware.vmware_host_datastore](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_datastore_module.rst)|Manage a datastore on ESXi host
+[community.vmware.vmware_host_dns](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_dns_module.rst)|Manage DNS configuration of an ESXi host system
+[community.vmware.vmware_host_dns_facts](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_dns_facts_module.rst)|Gathers facts about an ESXi host's DNS configuration information
+[community.vmware.vmware_host_dns_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_dns_info_module.rst)|Gathers info about an ESXi host's DNS configuration information
+[community.vmware.vmware_host_facts](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_facts_module.rst)|Gathers facts about remote ESXi hostsystem
+[community.vmware.vmware_host_feature_facts](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_feature_facts_module.rst)|Gathers facts about an ESXi host's feature capability information
+[community.vmware.vmware_host_feature_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_feature_info_module.rst)|Gathers info about an ESXi host's feature capability information
+[community.vmware.vmware_host_firewall_facts](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_firewall_facts_module.rst)|Gathers facts about an ESXi host's firewall configuration information
+[community.vmware.vmware_host_firewall_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_firewall_info_module.rst)|Gathers info about an ESXi host's firewall configuration information
+[community.vmware.vmware_host_firewall_manager](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_firewall_manager_module.rst)|Manage firewall configurations about an ESXi host
+[community.vmware.vmware_host_hyperthreading](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_hyperthreading_module.rst)|Enables/Disables Hyperthreading optimization for an ESXi host system
+[community.vmware.vmware_host_ipv6](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_ipv6_module.rst)|Enables/Disables IPv6 support for an ESXi host system
+[community.vmware.vmware_host_iscsi](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_iscsi_module.rst)|Manage the iSCSI configuration of ESXi host
+[community.vmware.vmware_host_kernel_manager](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_kernel_manager_module.rst)|Manage kernel module options on ESXi hosts
+[community.vmware.vmware_host_lockdown](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_lockdown_module.rst)|Manage administrator permission for the local administrative account for the ESXi host
+[community.vmware.vmware_host_logbundle](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_logbundle_module.rst)|Fetch logbundle file from ESXi
+[community.vmware.vmware_host_logbundle_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_logbundle_info_module.rst)|Gathers manifest info for logbundle
+[community.vmware.vmware_host_ntp](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_ntp_module.rst)|Manage NTP server configuration of an ESXi host
+[community.vmware.vmware_host_ntp_facts](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_ntp_facts_module.rst)|Gathers facts about NTP configuration on an ESXi host
+[community.vmware.vmware_host_ntp_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_ntp_info_module.rst)|Gathers info about NTP configuration on an ESXi host
+[community.vmware.vmware_host_package_facts](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_package_facts_module.rst)|Gathers facts about available packages on an ESXi host
+[community.vmware.vmware_host_package_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_package_info_module.rst)|Gathers info about available packages on an ESXi host
+[community.vmware.vmware_host_powermgmt_policy](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_powermgmt_policy_module.rst)|Manages the Power Management Policy of an ESXI host system
+[community.vmware.vmware_host_powerstate](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_powerstate_module.rst)|Manages power states of host systems in vCenter
+[community.vmware.vmware_host_scanhba](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_scanhba_module.rst)|Rescan host HBA's and optionally refresh the storage system
+[community.vmware.vmware_host_service_facts](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_service_facts_module.rst)|Gathers facts about an ESXi host's services
+[community.vmware.vmware_host_service_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_service_info_module.rst)|Gathers info about an ESXi host's services
+[community.vmware.vmware_host_service_manager](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_service_manager_module.rst)|Manage services on a given ESXi host
+[community.vmware.vmware_host_snmp](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_snmp_module.rst)|Configures SNMP on an ESXi host system
+[community.vmware.vmware_host_sriov](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_sriov_module.rst)|Manage SR-IOV settings on host
+[community.vmware.vmware_host_ssl_facts](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_ssl_facts_module.rst)|Gather facts of ESXi host system about SSL
+[community.vmware.vmware_host_ssl_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_ssl_info_module.rst)|Gather info of ESXi host system about SSL
+[community.vmware.vmware_host_vmhba_facts](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_vmhba_facts_module.rst)|Gathers facts about vmhbas available on the given ESXi host
+[community.vmware.vmware_host_vmhba_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_vmhba_info_module.rst)|Gathers info about vmhbas available on the given ESXi host
+[community.vmware.vmware_host_vmnic_facts](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_vmnic_facts_module.rst)|Gathers facts about vmnics available on the given ESXi host
+[community.vmware.vmware_host_vmnic_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_vmnic_info_module.rst)|Gathers info about vmnics available on the given ESXi host
+[community.vmware.vmware_local_role_facts](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_local_role_facts_module.rst)|Gather facts about local roles on an ESXi host
+[community.vmware.vmware_local_role_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_local_role_info_module.rst)|Gather info about local roles on an ESXi host
+[community.vmware.vmware_local_role_manager](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_local_role_manager_module.rst)|Manage local roles on an ESXi host
+[community.vmware.vmware_local_user_facts](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_local_user_facts_module.rst)|Gather facts about users on the given ESXi host
+[community.vmware.vmware_local_user_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_local_user_info_module.rst)|Gather info about users on the given ESXi host
+[community.vmware.vmware_local_user_manager](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_local_user_manager_module.rst)|Manage local users on an ESXi host
+[community.vmware.vmware_maintenancemode](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_maintenancemode_module.rst)|Place a host into maintenance mode
+[community.vmware.vmware_migrate_vmk](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_migrate_vmk_module.rst)|Migrate a VMK interface from VSS to VDS
+[community.vmware.vmware_object_rename](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_object_rename_module.rst)|Renames VMware objects
+[community.vmware.vmware_object_role_permission](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_object_role_permission_module.rst)|Manage local roles on an ESXi host
+[community.vmware.vmware_portgroup](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_portgroup_module.rst)|Create a VMware portgroup
+[community.vmware.vmware_portgroup_facts](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_portgroup_facts_module.rst)|Gathers facts about an ESXi host's Port Group configuration
+[community.vmware.vmware_portgroup_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_portgroup_info_module.rst)|Gathers info about an ESXi host's Port Group configuration
+[community.vmware.vmware_resource_pool](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_resource_pool_module.rst)|Add/remove resource pools to/from vCenter
+[community.vmware.vmware_resource_pool_facts](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_resource_pool_facts_module.rst)|Gathers facts about resource pool information
+[community.vmware.vmware_resource_pool_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_resource_pool_info_module.rst)|Gathers info about resource pool information
+[community.vmware.vmware_tag](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_tag_module.rst)|Manage VMware tags
+[community.vmware.vmware_tag_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_tag_info_module.rst)|Manage VMware tag info
+[community.vmware.vmware_tag_manager](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_tag_manager_module.rst)|Manage association of VMware tags with VMware objects
+[community.vmware.vmware_target_canonical_facts](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_target_canonical_facts_module.rst)|Return canonical (NAA) from an ESXi host system
+[community.vmware.vmware_target_canonical_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_target_canonical_info_module.rst)|Return canonical (NAA) from an ESXi host system
+[community.vmware.vmware_vc_infraprofile_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_vc_infraprofile_info_module.rst)|List and Export VMware vCenter infra profile configs.
+[community.vmware.vmware_vcenter_settings](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_vcenter_settings_module.rst)|Configures general settings on a vCenter server
+[community.vmware.vmware_vcenter_settings_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_vcenter_settings_info_module.rst)|Gather info vCenter settings
+[community.vmware.vmware_vcenter_statistics](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_vcenter_statistics_module.rst)|Configures statistics on a vCenter server
+[community.vmware.vmware_vm_host_drs_rule](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_vm_host_drs_rule_module.rst)|Creates vm/host group in a given cluster
+[community.vmware.vmware_vm_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_vm_info_module.rst)|Return basic info pertaining to a VMware machine guest
+[community.vmware.vmware_vm_shell](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_vm_shell_module.rst)|Run commands in a VMware guest operating system
+[community.vmware.vmware_vm_storage_policy](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_vm_storage_policy_module.rst)|Create vSphere storage policies
+[community.vmware.vmware_vm_storage_policy_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_vm_storage_policy_info_module.rst)|Gather information about vSphere storage profile defined storage policy information.
+[community.vmware.vmware_vm_vm_drs_rule](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_vm_vm_drs_rule_module.rst)|Configure VMware DRS Affinity rule for virtual machine in given cluster
+[community.vmware.vmware_vm_vss_dvs_migrate](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_vm_vss_dvs_migrate_module.rst)|Migrates a virtual machine from a standard vswitch to distributed
+[community.vmware.vmware_vmkernel](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_vmkernel_module.rst)|Manages a VMware VMkernel Adapter of an ESXi host.
+[community.vmware.vmware_vmkernel_facts](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_vmkernel_facts_module.rst)|Gathers VMKernel facts about an ESXi host
+[community.vmware.vmware_vmkernel_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_vmkernel_info_module.rst)|Gathers VMKernel info about an ESXi host
+[community.vmware.vmware_vmkernel_ip_config](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_vmkernel_ip_config_module.rst)|Configure the VMkernel IP Address
+[community.vmware.vmware_vmotion](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_vmotion_module.rst)|Move a virtual machine using vMotion, and/or its vmdks using storage vMotion.
+[community.vmware.vmware_vsan_cluster](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_vsan_cluster_module.rst)|Configure VSAN clustering on an ESXi host
+[community.vmware.vmware_vsan_health_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_vsan_health_info_module.rst)|Gather information about a VMware vSAN cluster's health
+[community.vmware.vmware_vspan_session](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_vspan_session_module.rst)|Create or remove a Port Mirroring session.
+[community.vmware.vmware_vswitch](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_vswitch_module.rst)|Manage a VMware Standard Switch to an ESXi host.
+[community.vmware.vmware_vswitch_facts](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_vswitch_facts_module.rst)|Gathers facts about an ESXi host's vswitch configurations
+[community.vmware.vmware_vswitch_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_vswitch_info_module.rst)|Gathers info about an ESXi host's vswitch configurations
+[community.vmware.vsphere_copy](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vsphere_copy_module.rst)|Copy a file to a VMware datastore
+[community.vmware.vsphere_file](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vsphere_file_module.rst)|Manage files on a vCenter datastore
 
 ### Inventory plugins
 Name | Description
 --- | ---
-[community.vmware.vmware_vm_inventory](https://github.com/ansible-collections/vmware/blob/main/docs/community.vmware.vmware_vm_inventory_inventory.rst)|VMware Guest inventory source
+[community.vmware.vmware_vm_inventory](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_vm_inventory_inventory.rst)|VMware Guest inventory source
 
 <!--end collection content-->
 
@@ -255,7 +255,7 @@ TBD
 Prepare the release:
 - Refresh the README.md:
     git clone https://github.com/ansible-network/collection_prep
-    git clone https://github.com/ansible-collections/vmware
+    git clone https://github.com/ansible-collections/community.vmware
     # WARNING The next comment will remove ~/.ansible/collections/ansible_collections/community/vmware/ !
     cd collection_prep
     ./add_docs.py -p ../vmware

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -14,12 +14,12 @@ releases:
       - Handle NoneType error when accessing service system info in vmware_host_service_info
         module (https://github.com/ansible/ansible/issues/67615).
       - Handle list items in vSphere schema while handling facts using to_json API
-        (https://github.com/ansible-collections/vmware/issues/33).
+        (https://github.com/ansible-collections/community.vmware/issues/33).
       - Handle multiple tags name with different category id in vmware_tag module
         (https://github.com/ansible/ansible/issues/66340).
       - Handle slashes in VMware network name (https://github.com/ansible/ansible/issues/64399).
       - In inventory plugin, serialize properties user specifies which are objects
-        as dicts (https://github.com/ansible-collections/vmware/pull/58).
+        as dicts (https://github.com/ansible-collections/community.vmware/pull/58).
       - In vmware_guest_network module use appropriate network while creating or reconfiguring
         (https://github.com/ansible/ansible/issues/65968).
       - Made vmnics attributes optional when creating DVS as they are optional on
@@ -34,7 +34,7 @@ releases:
         disk using the vmware_guest_disk module
       - vmware - Ensure we can use the modules with Python < 2.7.9 or RHEL/CentOS
         < 7.4, this as soon as ``validate_certs`` is disabled.
-      - vmware_category - fix associable datatypes (https://github.com/ansible-collections/vmware/issues/197).
+      - vmware_category - fix associable datatypes (https://github.com/ansible-collections/community.vmware/issues/197).
       - vmware_content_deploy_template - Added param content_library to the main function
       - vmware_deploy_ovf - Fixed ova deploy error occur if vm exists
       - vmware_dvs_portgroup - Implemented configuration changes on an existing Distributed
@@ -49,7 +49,7 @@ releases:
         in pyvmomi 7.0 and later
       - vmware_host_capability_info - Fixed vSphere API legacy version errors occur
         in pyvmomi 7.0 and later
-      - vmware_host_facts - handle facts when ESXi hostsystem is poweredoff (https://github.com/ansible-collections/vmware/issues/183).
+      - vmware_host_facts - handle facts when ESXi hostsystem is poweredoff (https://github.com/ansible-collections/community.vmware/issues/183).
       - vmware_host_firewall_manager - Ensure we can set rule with no ``allowed_hosts``
         key (https://github.com/ansible/ansible/issues/61332)
       - vmware_host_firewall_manager - Fixed creating IP specific firewall rules with
@@ -69,7 +69,7 @@ releases:
       minor_changes:
       - A `vmware` module_defaults group has been added to simplify parameters for
         multiple VMware tasks. This group includes all VMware modules.
-      - Add a flag 'force_upgrade' to force VMware tools upgrade installation (https://github.com/ansible-collections/vmware/issues/75).
+      - Add a flag 'force_upgrade' to force VMware tools upgrade installation (https://github.com/ansible-collections/community.vmware/issues/75).
       - Add powerstates to match vmware_guest_powerstate module with vmware_guest
         (https://github.com/ansible/ansible/issues/55653).
       - Added a timeout parameter `wait_for_ip_address_timeout` for `wait_for_ip_address`
@@ -87,7 +87,7 @@ releases:
       - Return additional information about hosts inside the cluster using vmware_cluster_info.
       - Update Module examples with FQCN.
       - Update README.md for installing any third party required Python libraries
-        using pip (https://github.com/ansible-collections/vmware/issues/154).
+        using pip (https://github.com/ansible-collections/community.vmware/issues/154).
       - add storage_provisioning type into vmware_content_deploy_ovf_template.
       - add vmware_content_deploy_ovf_template module for creating VMs from OVF templates
       - new code module for new feature for operations of VCenter infra profile config.
@@ -121,7 +121,7 @@ releases:
       - vmware_guest_disk - Add `filename` option which allows to create a disk from
         an existing VMDK.
       - vmware_guest_disk - add support for setting the sharing/multi-writer mode
-        of virtual disks (https://github.com/ansible-collections/vmware/issues/212)
+        of virtual disks (https://github.com/ansible-collections/community.vmware/issues/212)
       - vmware_guest_network - network adapters can be configured without lists
       - vmware_guest_network - network_info returns a list of dictionaries for ease
         of use
@@ -129,7 +129,7 @@ releases:
       - vmware_guest_tools_wait now exposes a ``timeout`` parameter that allow the
         user to adjust the timeout (second).
       - vmware_host_active_directory - Fail when there are unrecoverable problems
-        with AD membership instead of reporting a change that doesn't take place (https://github.com/ansible-collections/vmware/issues/59).
+        with AD membership instead of reporting a change that doesn't take place (https://github.com/ansible-collections/community.vmware/issues/59).
       - vmware_host_dns - New module replacing vmware_dns_config with increased functionality.
       - vmware_host_dns can now set the following empty values, ``domain``, ``search_domains``
         and ``dns_servers``.
@@ -263,13 +263,13 @@ releases:
         removed; use the suboptions ``ip_address`` and ``subnet_mask`` of the ``network``
         option instead.
       bugfixes:
-      - vmware_content_deploy_ovf_template - use datastore_id in deployment_spec (https://github.com/ansible-collections/vmware/pull/287).
+      - vmware_content_deploy_ovf_template - use datastore_id in deployment_spec (https://github.com/ansible-collections/community.vmware/pull/287).
       - vmware_dvs_portgroup_find - Fix comparison between str and int on method vlan_match
-        (https://github.com/ansible-collections/vmware/pull/52).
+        (https://github.com/ansible-collections/community.vmware/pull/52).
       - vmware_guest - cdrom.controller_number, cdrom.unit_number are handled as integer.
-        (https://github.com/ansible-collections/vmware/issues/274).
+        (https://github.com/ansible-collections/community.vmware/issues/274).
       - vmware_vm_inventory - CustomFieldManager is not present in ESXi, handle this
-        condition (https://github.com/ansible-collections/vmware/issues/269).
+        condition (https://github.com/ansible-collections/community.vmware/issues/269).
       deprecated_features:
       - The vmware_dns_config module has been deprecated and will be removed in a
         later release; use vmware_host_dns instead.
@@ -286,11 +286,11 @@ releases:
         the getting of clusters resource summary information.
       - vmware_content_deploy_ovf_template - handle exception while deploying VM using
         OVF template.
-      - vmware_content_deploy_template - handle exception while deploying VM (https://github.com/ansible-collections/vmware/issues/182).
+      - vmware_content_deploy_template - handle exception while deploying VM (https://github.com/ansible-collections/community.vmware/issues/182).
       - vmware_dvs_portgroup - Added support for distributed port group with private
         VLAN.
       - vmware_guest_snapshot_info - Document that `folder` is required if the VM
-        `name` is defined (https://github.com/ansible-collections/vmware/issues/243)
+        `name` is defined (https://github.com/ansible-collections/community.vmware/issues/243)
       - vmware_host_iscsi - a new module for the ESXi hosts that is dedicated to the
         management of the iSCSI configuration
       - vmware_migrate_vmk - allow migration from a VMware vSphere Distrubuted Switch
@@ -322,22 +322,22 @@ releases:
       bugfixes:
       - vmware_content_deploy_ovf_template - fixed issue where wrong resource pool
         identifier was returned when same resource pool name was used across clusters
-        in the same datacenter (https://github.com/ansible-collections/vmware/pull/363)
+        in the same datacenter (https://github.com/ansible-collections/community.vmware/pull/363)
       - vmware_vmkernel - fixed issue where Repl and ReplNFC services were not being
-        identified as enabled on a vmk interface (https://github.com/ansible-collections/vmware/issues/362).
+        identified as enabled on a vmk interface (https://github.com/ansible-collections/community.vmware/issues/362).
       deprecated_features:
       - vmware_guest - deprecate specifying CDROM configuration as a dict, instead
         use a list.
       minor_changes:
       - vmware_cluster_ha - treat truthy advanced options ('true', 'false') as strings
-        instead of booleans (https://github.com/ansible-collections/vmware/issues/286).
-      - vmware_cluster_vsan - implement advanced VSAN options (https://github.com/ansible-collections/vmware/issues/260).
+        instead of booleans (https://github.com/ansible-collections/community.vmware/issues/286).
+      - vmware_cluster_vsan - implement advanced VSAN options (https://github.com/ansible-collections/community.vmware/issues/260).
       - vmware_cluster_vsan - requires the vSAN Management SDK, which needs to be
         downloaded from VMware and installed manually.
       - vmware_content_deploy_ovf_template - requires the resource_pool parameter.
-      - vmware_guest_disk - add backing_uuid value to return (https://github.com/ansible-collections/vmware/pull/348).
+      - vmware_guest_disk - add backing_uuid value to return (https://github.com/ansible-collections/community.vmware/pull/348).
       - vmware_guest_serial_port - ensure we can run the module two times in a row
-        without unexpected side effect(https://github.com/ansible-collections/vmware/pull/358).
+        without unexpected side effect(https://github.com/ansible-collections/community.vmware/pull/358).
     fragments:
     - 163-vmware_content_deploy_ovf_template.py.yml
     - 260-vmware_cluster_vsan.yml

--- a/changelogs/fragments/335-vmware-strip-names-when-searching.yml
+++ b/changelogs/fragments/335-vmware-strip-names-when-searching.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - module_utils/vmware - Ignore leading and trailing whitespace when searching for objects (https://github.com/ansible-collections/vmware/issues/335)
+  - module_utils/vmware - Ignore leading and trailing whitespace when searching for objects (https://github.com/ansible-collections/community.vmware/issues/335)

--- a/changelogs/fragments/366-vmware_cluster_info.yml
+++ b/changelogs/fragments/366-vmware_cluster_info.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - vmware_cluster_info - Fixed issue of a cluster name doesn't URL-decode(https://github.com/ansible-collections/vmware/pull/366)
+  - vmware_cluster_info - Fixed issue of a cluster name doesn't URL-decode(https://github.com/ansible-collections/community.vmware/pull/366)

--- a/changelogs/fragments/368-vmware_guest_customization_info.yml
+++ b/changelogs/fragments/368-vmware_guest_customization_info.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - vmware_guest_customization_info - Fixed to get values properly for LinuxPrep and SysPrep parameters(https://github.com/ansible-collections/vmware/pull/368)
+  - vmware_guest_customization_info - Fixed to get values properly for LinuxPrep and SysPrep parameters(https://github.com/ansible-collections/community.vmware/pull/368)

--- a/changelogs/fragments/380-vmware-handle-special-characters.yml
+++ b/changelogs/fragments/380-vmware-handle-special-characters.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - "``module_utils/vmware.py`` handles an object name using special characters that URL-decoded(https://github.com/ansible-collections/vmware/pull/380)."
+  - "``module_utils/vmware.py`` handles an object name using special characters that URL-decoded(https://github.com/ansible-collections/community.vmware/pull/380)."

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -15,6 +15,6 @@ tags:
   - vmware
   - virtualization
 dependencies: {}
-repository: https://github.com/ansible-collections/vmware.git
-homepage: https://github.com/ansible-collections/vmware
-issues: https://github.com/ansible-collections/vmware/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc
+repository: https://github.com/ansible-collections/community.vmware.git
+homepage: https://github.com/ansible-collections/community.vmware
+issues: https://github.com/ansible-collections/community.vmware/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc

--- a/plugins/modules/vmware_host_capability_facts.py
+++ b/plugins/modules/vmware_host_capability_facts.py
@@ -204,7 +204,7 @@ class CapabilityFactsManager(PyVmomi):
             #   checkpointFtSupported => smpFtSupported
             #   checkpointFtSupported => smpFtCompatibilityIssues.
             # So add `checkpointFtSupported` and `checkpointFtCompatibilityIssues` keys for compatibility with previous versions.
-            # https://github.com/ansible-collections/vmware/pull/118
+            # https://github.com/ansible-collections/community.vmware/pull/118
             hosts_capability_facts[host.name]['checkpointFtSupported'] = hosts_capability_facts[host.name]['smpFtSupported']
             hosts_capability_facts[host.name]['checkpointFtCompatibilityIssues'] = hosts_capability_facts[host.name]['smpFtCompatibilityIssues']
 

--- a/plugins/modules/vmware_host_capability_info.py
+++ b/plugins/modules/vmware_host_capability_info.py
@@ -195,7 +195,7 @@ class CapabilityInfoManager(PyVmomi):
             #   checkpointFtSupported => smpFtSupported
             #   checkpointFtSupported => smpFtCompatibilityIssues.
             # So add `checkpointFtSupported` and `checkpointFtCompatibilityIssues` keys for compatibility with previous versions.
-            # https://github.com/ansible-collections/vmware/pull/118
+            # https://github.com/ansible-collections/community.vmware/pull/118
             hosts_capability_info[host.name]['checkpointFtSupported'] = hosts_capability_info[host.name]['smpFtSupported']
             hosts_capability_info[host.name]['checkpointFtCompatibilityIssues'] = hosts_capability_info[host.name]['smpFtCompatibilityIssues']
 

--- a/tests/integration/targets/vmware_cluster_facts/tasks/main.yml
+++ b/tests/integration/targets/vmware_cluster_facts/tasks/main.yml
@@ -56,7 +56,7 @@
   name: Ensure facts are gathered for the given cluster in check mode
 
 
-# Disabled until we get a fix for https://github.com/ansible-collections/vmware/issues/301
+# Disabled until we get a fix for https://github.com/ansible-collections/community.vmware/issues/301
 #- when: vcsim is not defined
 #  block:
 #  - import_role:

--- a/tests/integration/targets/vmware_cluster_info/tasks/main.yml
+++ b/tests/integration/targets/vmware_cluster_info/tasks/main.yml
@@ -103,7 +103,7 @@
       - not cluster_result.changed
   loop: "{{ cluster_result.clusters.keys() }}"
 
-# Disabled until we get a fix for https://github.com/ansible-collections/vmware/issues/301
+# Disabled until we get a fix for https://github.com/ansible-collections/community.vmware/issues/301
 #- when: vcsim is not defined
 #  block:
 #  - import_role:

--- a/tests/integration/targets/vmware_guest_info/tasks/main.yml
+++ b/tests/integration/targets/vmware_guest_info/tasks/main.yml
@@ -99,7 +99,7 @@
       - "guest_info_0001['instance']['vimref'] is defined"
       - "guest_info_0002b['instance']['overallStatus'] is not defined"
 
-# https://github.com/ansible-collections/vmware/issues/33
+# https://github.com/ansible-collections/community.vmware/issues/33
 - name: Get specific details about VM using the vsphere output schema
   vmware_guest_info:
     validate_certs: False

--- a/tests/integration/targets/vmware_host_service_manager/aliases
+++ b/tests/integration/targets/vmware_host_service_manager/aliases
@@ -1,5 +1,5 @@
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
-# see: https://github.com/ansible-collections/vmware/issues/101
+# see: https://github.com/ansible-collections/community.vmware/issues/101
 disabled


### PR DESCRIPTION
##### SUMMARY
After renaming this repository from `vmware` to `community.vmware` (#151), we should update links accordingly.

##### ISSUE TYPE
- Docs Pull Request

##### ADDITIONAL INFORMATION
```
grep -R https://github.com/ansible-collections/vmware * | cut -d ':' -f 1 | sort | uniq | while read FILE
do
  sed -i 's#https://github.com/ansible-collections/vmware#https://github.com/ansible-collections/community.vmware#' $FILE
done
```