### PR TITLE
vmware_guest_video: Gather facts for poweredoff VM

### DIFF
--- a/changelogs/fragments/408_video_facts.yml
+++ b/changelogs/fragments/408_video_facts.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- vmware_guest_video - gather facts for video devices even if the virtual machine is poweredoff (https://github.com/ansible-collections/community.vmware/issues/408).


### PR DESCRIPTION
##### SUMMARY

Facts about video devices can be gathered for poweredoff VM.

Fixes: #408

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/408_video_facts.yml
plugins/modules/vmware_guest_video.py
