### PR TITLE
vmware_guest_sendkey: Add sleep_time parameter

### DIFF
--- a/changelogs/fragments/404_vmware_guest_sendkey.yml
+++ b/changelogs/fragments/404_vmware_guest_sendkey.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- vmware_guest_sendkey - add sleep_time parameter to add delay in-between keys sent (https://github.com/ansible-collections/community.vmware/issues/404).


### PR DESCRIPTION
##### SUMMARY

API is faster than the keys/strings send to VM.
Adding sleep in between will help.

Fixes: #404

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/404_vmware_guest_sendkey.yml
plugins/modules/vmware_guest_sendkey.py
