### PR TITLE
Update community.vmware.vmware_object_role_permission_module.rst

### DIFF
--- a/docs/community.vmware.vmware_object_role_permission_module.rst
+++ b/docs/community.vmware.vmware_object_role_permission_module.rst
@@ -318,6 +318,9 @@ Examples
 
     - name: Assign user to VM folder
       community.vmware.vmware_object_role_permission:
+        hostname: '{{ esxi_hostname }}'
+        username: '{{ esxi_username }}'
+        password: '{{ esxi_password }}'
         role: Admin
         principal: user_bob
         object_name: services
@@ -326,6 +329,9 @@ Examples
 
     - name: Remove user from VM folder
       community.vmware.vmware_object_role_permission:
+        hostname: '{{ esxi_hostname }}'
+        username: '{{ esxi_username }}'
+        password: '{{ esxi_password }}'
         role: Admin
         principal: user_bob
         object_name: services
@@ -334,6 +340,9 @@ Examples
 
     - name: Assign finance group to VM folder
       community.vmware.vmware_object_role_permission:
+        hostname: '{{ esxi_hostname }}'
+        username: '{{ esxi_username }}'
+        password: '{{ esxi_password }}'
         role: Limited Users
         group: finance
         object_name: Accounts
@@ -342,6 +351,9 @@ Examples
 
     - name: Assign view_user Read Only permission at root folder
       community.vmware.vmware_object_role_permission:
+        hostname: '{{ esxi_hostname }}'
+        username: '{{ esxi_username }}'
+        password: '{{ esxi_password }}'
         role: ReadOnly
         principal: view_user
         object_name: rootFolder


### PR DESCRIPTION
Examples missing required fields of hostname, username, and password, while other module examples include these.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds required fields to the examples section to match other module examples
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
community.vmware.vmware_object_role_permission

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
