### PR TITLE
vmware_vm_inventory: Add support for category

### DIFF
--- a/changelogs/fragments/350_vmware_vm_inventory.yml
+++ b/changelogs/fragments/350_vmware_vm_inventory.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- vmware_vm_inventory - support for categories and tag, category relation (https://github.com/ansible-collections/community.vmware/issues/350).

--- a/tests/integration/targets/inventory_vmware_vm_inventory/playbook/test_options.yml
+++ b/tests/integration/targets/inventory_vmware_vm_inventory/playbook/test_options.yml
@@ -212,6 +212,8 @@
       assert:
         that:
           - "'tags' in test_host.value"
+          - "'categories' in test_host.value"
+          - "'tag_category' in test_host.value"
       when: not (vcsim is defined)
 
 


### PR DESCRIPTION
##### SUMMARY

Now, vmware_vm_category can retrive categories and
related to tags.

Fixes: #350

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/350_vmware_vm_inventory.yml
plugins/inventory/vmware_vm_inventory.py
tests/integration/targets/inventory_vmware_vm_inventory/playbook/test_options.yml
