### PR TITLE
vmware_object_role_permission: Missing required parameters in examples

### DIFF
--- a/changelogs/fragments/426_vmware_object_role_permission.yml
+++ b/changelogs/fragments/426_vmware_object_role_permission.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- vmware_object_role_permission - add missing required fields of hostname, username, and password to module examples (https://github.com/ansible-collections/community.vmware/issues/426).

--- a/plugins/modules/vmware_object_role_permission.py
+++ b/plugins/modules/vmware_object_role_permission.py
@@ -11,7 +11,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_object_role_permission
 short_description: Manage local roles on an ESXi host

--- a/plugins/modules/vmware_object_role_permission.py
+++ b/plugins/modules/vmware_object_role_permission.py
@@ -76,6 +76,9 @@ extends_documentation_fragment:
 EXAMPLES = '''
 - name: Assign user to VM folder
   community.vmware.vmware_object_role_permission:
+    hostname: '{{ esxi_hostname }}'
+    username: '{{ esxi_username }}'
+    password: '{{ esxi_password }}'
     role: Admin
     principal: user_bob
     object_name: services
@@ -84,6 +87,9 @@ EXAMPLES = '''
 
 - name: Remove user from VM folder
   community.vmware.vmware_object_role_permission:
+    hostname: '{{ esxi_hostname }}'
+    username: '{{ esxi_username }}'
+    password: '{{ esxi_password }}'
     role: Admin
     principal: user_bob
     object_name: services
@@ -92,6 +98,9 @@ EXAMPLES = '''
 
 - name: Assign finance group to VM folder
   community.vmware.vmware_object_role_permission:
+    hostname: '{{ esxi_hostname }}'
+    username: '{{ esxi_username }}'
+    password: '{{ esxi_password }}'
     role: Limited Users
     group: finance
     object_name: Accounts
@@ -100,6 +109,9 @@ EXAMPLES = '''
 
 - name: Assign view_user Read Only permission at root folder
   community.vmware.vmware_object_role_permission:
+    hostname: '{{ esxi_hostname }}'
+    username: '{{ esxi_username }}'
+    password: '{{ esxi_password }}'
     role: ReadOnly
     principal: view_user
     object_name: rootFolder

--- a/plugins/modules/vmware_object_role_permission.py
+++ b/plugins/modules/vmware_object_role_permission.py
@@ -73,7 +73,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Assign user to VM folder
   community.vmware.vmware_object_role_permission:
     hostname: '{{ esxi_hostname }}'


### PR DESCRIPTION
##### SUMMARY
Examples missing required fields of hostname, username, and password, while other module examples include these.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
vmware_object_role_permission

##### ADDITIONAL INFORMATION
Fixes #426 

Follo-up to PR #422 
