### PR TITLE
Update repo path in galaxy.yml

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -15,6 +15,6 @@ tags:
   - vmware
   - virtualization
 dependencies: {}
-repository: https://github.com/ansible-collections/vmware.git
-homepage: https://github.com/ansible-collections/vmware
-issues: https://github.com/ansible-collections/vmware/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc
+repository: https://github.com/ansible-collections/community.vmware.git
+homepage: https://github.com/ansible-collections/community.vmware
+issues: https://github.com/ansible-collections/community.vmware/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc


### PR DESCRIPTION
##### SUMMARY
Collection was moved to /community.vmware, galaxy still links to /vmware.  The redirect works but it could be confusing for users.


##### ISSUE TYPE
- Docs Pull Request


##### COMPONENT NAME
galaxy.yml

##### ADDITIONAL INFORMATION
How do you feel about the links in the changelog and some of the code comments that point to bugs on the old path?  I think it's probably ok to leave the changelog since it's historical and the comments aren't user facing, but I did notice them when I was looking.  For example:

```
CHANGELOG.rst:- Handle list items in vSphere schema while handling facts using to_json API (https://github.com/ansible-collections/vmware/issues/33).
CHANGELOG.rst:- In inventory plugin, serialize properties user specifies which are objects as dicts (https://github.com/ansible-collections/vmware/pull/58).
CHANGELOG.rst:- vmware_category - fix associable datatypes (https://github.com/ansible-collections/vmware/issues/197).
CHANGELOG.rst:- vmware_host_facts - handle facts when ESXi hostsystem is poweredoff (https://github.com/ansible-collections/vmware/issues/183).
...
plugins/modules/vmware_host_capability_facts.py:            # https://github.com/ansible-collections/vmware/pull/118
plugins/modules/vmware_host_capability_info.py:            # https://github.com/ansible-collections/vmware/pull/118

```