### PR TITLE
DOCUMENTATION and EXAMPLES blocks to 'r(raw)'

### DIFF
--- a/plugins/modules/vca_fw.py
+++ b/plugins/modules/vca_fw.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vca_fw
 deprecated:
@@ -30,7 +30,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 
 #Add a set of firewall rules
 

--- a/plugins/modules/vca_nat.py
+++ b/plugins/modules/vca_nat.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vca_nat
 deprecated:
@@ -34,7 +34,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 
 #An example for a source nat
 

--- a/plugins/modules/vca_vapp.py
+++ b/plugins/modules/vca_vapp.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vca_vapp
 deprecated:
@@ -103,7 +103,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Creates a new vApp in a VCA instance
   community.vmware.vca_vapp:
     vapp_name: tower

--- a/plugins/modules/vcenter_extension.py
+++ b/plugins/modules/vcenter_extension.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vcenter_extension
 short_description: Register/deregister vCenter Extensions
@@ -82,7 +82,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
     - name: Register vCenter Extension
       community.vmware.vcenter_extension:
          hostname: "{{ groups['vcsa'][0] }}"

--- a/plugins/modules/vcenter_extension.py
+++ b/plugins/modules/vcenter_extension.py
@@ -112,13 +112,13 @@ EXAMPLES = r'''
       register: deregister_extension
 '''
 
-RETURN = """
+RETURN = r'''
 result:
     description: information about performed operation
     returned: always
     type: str
     sample: "'com.acme.Extension' installed."
-"""
+'''
 
 try:
     from pyVmomi import vim

--- a/plugins/modules/vmware_cfg_backup.py
+++ b/plugins/modules/vmware_cfg_backup.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_cfg_backup
 short_description: Backup / Restore / Reset ESXi host configuration
@@ -53,7 +53,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Save the ESXi configuration locally by authenticating directly against the ESXi host
   community.vmware.vmware_cfg_backup:
     hostname: '{{ esxi_hostname }}'

--- a/plugins/modules/vmware_cfg_backup.py
+++ b/plugins/modules/vmware_cfg_backup.py
@@ -74,7 +74,7 @@ EXAMPLES = r'''
   delegate_to: localhost
 '''
 
-RETURN = '''
+RETURN = r'''
 dest_file:
     description: The full path of where the file holding the ESXi configurations was stored
     returned: changed

--- a/plugins/modules/vmware_cluster.py
+++ b/plugins/modules/vmware_cluster.py
@@ -227,7 +227,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = r"""
+EXAMPLES = r'''
 - name: Create Cluster
   community.vmware.vmware_cluster:
     hostname: '{{ vcenter_hostname }}'
@@ -268,7 +268,7 @@ EXAMPLES = r"""
     enable_vsan: yes
     state: absent
   delegate_to: localhost
-"""
+'''
 
 RETURN = r"""#
 """

--- a/plugins/modules/vmware_cluster.py
+++ b/plugins/modules/vmware_cluster.py
@@ -270,8 +270,8 @@ EXAMPLES = r'''
   delegate_to: localhost
 '''
 
-RETURN = r"""#
-"""
+RETURN = r'''#
+'''
 
 try:
     from pyVmomi import vim, vmodl

--- a/plugins/modules/vmware_cluster_drs.py
+++ b/plugins/modules/vmware_cluster_drs.py
@@ -110,8 +110,8 @@ EXAMPLES = r'''
   delegate_to: localhost
 '''
 
-RETURN = r"""#
-"""
+RETURN = r'''#
+'''
 
 try:
     from pyVmomi import vim, vmodl

--- a/plugins/modules/vmware_cluster_drs.py
+++ b/plugins/modules/vmware_cluster_drs.py
@@ -74,7 +74,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = r"""
+EXAMPLES = r'''
 - name: Enable DRS
   community.vmware.vmware_cluster_drs:
     hostname: '{{ vcenter_hostname }}'
@@ -108,7 +108,7 @@ EXAMPLES = r"""
     enable_drs: True
     drs_default_vm_behavior: partiallyAutomated
   delegate_to: localhost
-"""
+'''
 
 RETURN = r"""#
 """

--- a/plugins/modules/vmware_cluster_ha.py
+++ b/plugins/modules/vmware_cluster_ha.py
@@ -178,7 +178,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = r"""
+EXAMPLES = r'''
 - name: Enable HA without admission control
   community.vmware.vmware_cluster_ha:
     hostname: '{{ vcenter_hostname }}'
@@ -215,7 +215,7 @@ EXAMPLES = r"""
       cpu_failover_resources_percent: 50
       memory_failover_resources_percent: 50
   delegate_to: localhost
-"""
+'''
 
 RETURN = r"""#
 """

--- a/plugins/modules/vmware_cluster_ha.py
+++ b/plugins/modules/vmware_cluster_ha.py
@@ -217,8 +217,8 @@ EXAMPLES = r'''
   delegate_to: localhost
 '''
 
-RETURN = r"""#
-"""
+RETURN = r'''#
+'''
 
 try:
     from pyVmomi import vim, vmodl

--- a/plugins/modules/vmware_cluster_info.py
+++ b/plugins/modules/vmware_cluster_info.py
@@ -116,7 +116,7 @@ EXAMPLES = r'''
   register: cluster_info
 '''
 
-RETURN = """
+RETURN = r'''
 clusters:
     description: metadata about the available clusters
     returned: always
@@ -179,7 +179,7 @@ clusters:
             ],
         },
     }
-"""
+'''
 
 try:
     from pyVmomi import vim

--- a/plugins/modules/vmware_cluster_info.py
+++ b/plugins/modules/vmware_cluster_info.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_cluster_info
 short_description: Gather info about clusters available in given vCenter
@@ -70,7 +70,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Gather cluster info from given datacenter
   community.vmware.vmware_cluster_info:
     hostname: '{{ vcenter_hostname }}'

--- a/plugins/modules/vmware_cluster_vsan.py
+++ b/plugins/modules/vmware_cluster_vsan.py
@@ -116,8 +116,8 @@ EXAMPLES = r'''
   delegate_to: localhost
 '''
 
-RETURN = r"""#
-"""
+RETURN = r'''#
+'''
 
 import traceback
 

--- a/plugins/modules/vmware_cluster_vsan.py
+++ b/plugins/modules/vmware_cluster_vsan.py
@@ -80,7 +80,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = r"""
+EXAMPLES = r'''
 - name: Enable vSAN
   community.vmware.vmware_cluster_vsan:
     hostname: '{{ vcenter_hostname }}'
@@ -114,7 +114,7 @@ EXAMPLES = r"""
     enable_vsan: True
     vsan_auto_claim_storage: True
   delegate_to: localhost
-"""
+'''
 
 RETURN = r"""#
 """

--- a/plugins/modules/vmware_datacenter.py
+++ b/plugins/modules/vmware_datacenter.py
@@ -60,8 +60,8 @@ EXAMPLES = r'''
   register: datacenter_delete_result
 '''
 
-RETURN = """#
-"""
+RETURN = r'''#
+'''
 
 try:
     from pyVmomi import vim, vmodl

--- a/plugins/modules/vmware_datacenter.py
+++ b/plugins/modules/vmware_datacenter.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_datacenter
 short_description: Manage VMware vSphere Datacenters
@@ -39,7 +39,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Create Datacenter
   community.vmware.vmware_datacenter:
     hostname: '{{ vcenter_hostname }}'

--- a/plugins/modules/vmware_datacenter_info.py
+++ b/plugins/modules/vmware_datacenter_info.py
@@ -94,7 +94,7 @@ EXAMPLES = r'''
     - overallStatus
 '''
 
-RETURN = r"""
+RETURN = r'''
 datacenter_info:
   description: Information about datacenter
   returned: always
@@ -107,7 +107,7 @@ datacenter_info:
             "name": "Asia-Datacenter1"
         }
     ]
-"""
+'''
 
 try:
     from pyVmomi import vim

--- a/plugins/modules/vmware_datastore_cluster.py
+++ b/plugins/modules/vmware_datastore_cluster.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_datastore_cluster
 short_description: Manage VMware vSphere datastore clusters
@@ -94,7 +94,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Create datastore cluster and enable SDRS
   community.vmware.vmware_datastore_cluster:
     hostname: '{{ vcenter_hostname }}'

--- a/plugins/modules/vmware_datastore_cluster.py
+++ b/plugins/modules/vmware_datastore_cluster.py
@@ -127,13 +127,13 @@ EXAMPLES = r'''
   delegate_to: localhost
 '''
 
-RETURN = """
+RETURN = r'''
 result:
     description: information about datastore cluster operation
     returned: always
     type: str
     sample: "Datastore cluster 'DSC2' created successfully."
-"""
+'''
 
 try:
     from pyVmomi import vim

--- a/plugins/modules/vmware_datastore_info.py
+++ b/plugins/modules/vmware_datastore_info.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_datastore_info
 short_description: Gather info about datastores available in given vCenter
@@ -89,7 +89,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Gather info from standalone ESXi server having datacenter as 'ha-datacenter'
   community.vmware.vmware_datastore_info:
     hostname: '{{ vcenter_hostname }}'

--- a/plugins/modules/vmware_datastore_info.py
+++ b/plugins/modules/vmware_datastore_info.py
@@ -126,7 +126,7 @@ EXAMPLES = r'''
   register: info
 '''
 
-RETURN = """
+RETURN = r'''
 datastores:
     description: metadata about the available datastores
     returned: always
@@ -164,7 +164,7 @@ datastores:
             "url": "ds:///vmfs/volumes/420b3e73-67070776/"
         },
     ]
-"""
+'''
 
 try:
     from pyVmomi import vim

--- a/plugins/modules/vmware_datastore_maintenancemode.py
+++ b/plugins/modules/vmware_datastore_maintenancemode.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_datastore_maintenancemode
 short_description: Place a datastore into maintenance mode
@@ -53,7 +53,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Enter datastore into Maintenance Mode
   community.vmware.vmware_datastore_maintenancemode:
     hostname: '{{ vcenter_hostname }}'

--- a/plugins/modules/vmware_datastore_maintenancemode.py
+++ b/plugins/modules/vmware_datastore_maintenancemode.py
@@ -91,7 +91,7 @@ EXAMPLES = r'''
   delegate_to: localhost
 '''
 
-RETURN = '''
+RETURN = r'''
 datastore_status:
     description: Action taken for datastore
     returned: always

--- a/plugins/modules/vmware_dvs_host.py
+++ b/plugins/modules/vmware_dvs_host.py
@@ -11,7 +11,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_dvs_host
 short_description: Add or remove a host from distributed virtual switch
@@ -71,7 +71,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Add Host to dVS
   community.vmware.vmware_dvs_host:
     hostname: '{{ vcenter_hostname }}'

--- a/plugins/modules/vmware_dvs_portgroup.py
+++ b/plugins/modules/vmware_dvs_portgroup.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_dvs_portgroup
 short_description: Create or remove a Distributed vSwitch portgroup.
@@ -218,7 +218,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Create vlan portgroup
   community.vmware.vmware_dvs_portgroup:
     hostname: '{{ vcenter_hostname }}'

--- a/plugins/modules/vmware_dvswitch.py
+++ b/plugins/modules/vmware_dvswitch.py
@@ -226,7 +226,7 @@ EXAMPLES = r'''
   delegate_to: localhost
 '''
 
-RETURN = """
+RETURN = r'''
 result:
     description: information about performed operation
     returned: always
@@ -253,7 +253,7 @@ result:
         ],
         "version": "6.6.0"
     }
-"""
+'''
 
 try:
     from pyVmomi import vim, vmodl

--- a/plugins/modules/vmware_dvswitch.py
+++ b/plugins/modules/vmware_dvswitch.py
@@ -12,7 +12,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_dvswitch
 short_description: Create or remove a Distributed Switch
@@ -177,7 +177,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Create dvSwitch
   community.vmware.vmware_dvswitch:
     hostname: '{{ vcenter_hostname }}'

--- a/plugins/modules/vmware_dvswitch_info.py
+++ b/plugins/modules/vmware_dvswitch_info.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_dvswitch_info
 short_description: Gathers info dvswitch configurations
@@ -69,7 +69,7 @@ extends_documentation_fragment:
     - community.vmware.vmware.documentation
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Gather all registered dvswitch
   community.vmware.vmware_dvswitch_info:
     hostname: "{{ vcenter_hostname }}"

--- a/plugins/modules/vmware_dvswitch_info.py
+++ b/plugins/modules/vmware_dvswitch_info.py
@@ -116,7 +116,7 @@ EXAMPLES = r'''
   register: dvswitch_info
 '''
 
-RETURN = '''
+RETURN = r'''
 distributed_virtual_switches:
     description: list of dictionary of dvswitch and their information
     returned: always

--- a/plugins/modules/vmware_dvswitch_lacp.py
+++ b/plugins/modules/vmware_dvswitch_lacp.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_dvswitch_lacp
 short_description: Manage LACP configuration on a Distributed Switch
@@ -89,7 +89,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Enable enhanced mode on a Distributed Switch
   community.vmware.vmware_dvswitch_lacp:
     hostname: '{{ inventory_hostname }}'

--- a/plugins/modules/vmware_dvswitch_lacp.py
+++ b/plugins/modules/vmware_dvswitch_lacp.py
@@ -126,7 +126,7 @@ EXAMPLES = r'''
   with_items: "{{ vcenter_distributed_switches }}"
 '''
 
-RETURN = """
+RETURN = r'''
 result:
     description: information about performed operation
     returned: always
@@ -142,7 +142,7 @@ result:
         "support_mode": "enhanced",
         "result": "lacp lags changed"
     }
-"""
+'''
 
 try:
     from pyVmomi import vim, vmodl

--- a/plugins/modules/vmware_dvswitch_nioc.py
+++ b/plugins/modules/vmware_dvswitch_nioc.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_dvswitch_nioc
 short_description: Manage distributed switch Network IO Control
@@ -104,7 +104,7 @@ resources_changed:
     sample: [ "vmotion", "vsan" ]
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Enable NIOC
   community.vmware.vmware_dvswitch_nioc:
     hostname: '{{ vcenter_hostname }}'

--- a/plugins/modules/vmware_dvswitch_pvlans.py
+++ b/plugins/modules/vmware_dvswitch_pvlans.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_dvswitch_pvlans
 short_description: Manage Private VLAN configuration of a Distributed Switch
@@ -56,7 +56,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Create PVLANs on a Distributed Switch
   community.vmware.vmware_dvswitch_pvlans:
     hostname: '{{ inventory_hostname }}'

--- a/plugins/modules/vmware_dvswitch_pvlans.py
+++ b/plugins/modules/vmware_dvswitch_pvlans.py
@@ -99,7 +99,7 @@ EXAMPLES = r'''
   delegate_to: localhost
 '''
 
-RETURN = """
+RETURN = r'''
 result:
     description: information about performed operation
     returned: always
@@ -127,7 +127,7 @@ result:
         "private_vlans_previous": [],
         "result": "All private VLANs added"
     }
-"""
+'''
 
 try:
     from pyVmomi import vim

--- a/plugins/modules/vmware_dvswitch_uplink_pg.py
+++ b/plugins/modules/vmware_dvswitch_uplink_pg.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_dvswitch_uplink_pg
 short_description: Manage uplink portproup configuration of a Distributed Switch
@@ -126,7 +126,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Configure Uplink portgroup
   community.vmware.vmware_dvswitch_uplink_pg:
     hostname: '{{ inventory_hostname }}'

--- a/plugins/modules/vmware_dvswitch_uplink_pg.py
+++ b/plugins/modules/vmware_dvswitch_uplink_pg.py
@@ -159,7 +159,7 @@ EXAMPLES = r'''
   delegate_to: localhost
 '''
 
-RETURN = """
+RETURN = r'''
 result:
     description: information about performed operation
     returned: always
@@ -185,7 +185,7 @@ result:
             "4049-4092"
         ]
     }
-"""
+'''
 
 try:
     from pyVmomi import vim

--- a/plugins/modules/vmware_evc_mode.py
+++ b/plugins/modules/vmware_evc_mode.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_evc_mode
 short_description: Enable/Disable EVC mode on vCenter
@@ -49,7 +49,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
     - name: Enable EVC Mode
       community.vmware.vmware_evc_mode:
          hostname: "{{ groups['vcsa'][0] }}"

--- a/plugins/modules/vmware_evc_mode.py
+++ b/plugins/modules/vmware_evc_mode.py
@@ -74,13 +74,13 @@ EXAMPLES = r'''
       register: disable_evc
 '''
 
-RETURN = """
+RETURN = r'''
 result:
     description: information about performed operation
     returned: always
     type: str
     sample: "EVC Mode for 'intel-broadwell' has been enabled."
-"""
+'''
 
 
 from ansible.module_utils.basic import AnsibleModule

--- a/plugins/modules/vmware_guest_boot_facts.py
+++ b/plugins/modules/vmware_guest_boot_facts.py
@@ -15,7 +15,7 @@ ANSIBLE_METADATA = {
     'supported_by': 'community'
 }
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_guest_boot_facts
 deprecated:

--- a/plugins/modules/vmware_guest_boot_facts.py
+++ b/plugins/modules/vmware_guest_boot_facts.py
@@ -84,7 +84,7 @@ EXAMPLES = r'''
   register: vm_moid_boot_order_facts
 '''
 
-RETURN = r"""
+RETURN = r'''
 vm_boot_facts:
     description: metadata about boot order of virtual machine
     returned: always
@@ -103,7 +103,7 @@ vm_boot_facts:
         "current_boot_firmware": "bios",
         "current_secure_boot_enabled": false,
     }
-"""
+'''
 
 
 from ansible.module_utils.basic import AnsibleModule

--- a/plugins/modules/vmware_guest_boot_info.py
+++ b/plugins/modules/vmware_guest_boot_info.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_guest_boot_info
 short_description: Gather info about boot options for the given virtual machine

--- a/plugins/modules/vmware_guest_boot_info.py
+++ b/plugins/modules/vmware_guest_boot_info.py
@@ -75,7 +75,7 @@ EXAMPLES = r'''
   register: vm_moid_boot_order_info
 '''
 
-RETURN = r"""
+RETURN = r'''
 vm_boot_info:
     description: metadata about boot order of virtual machine
     returned: always
@@ -94,7 +94,7 @@ vm_boot_info:
         "current_boot_firmware": "bios",
         "current_secure_boot_enabled": false,
     }
-"""
+'''
 
 
 from ansible.module_utils.basic import AnsibleModule

--- a/plugins/modules/vmware_guest_boot_manager.py
+++ b/plugins/modules/vmware_guest_boot_manager.py
@@ -136,7 +136,7 @@ EXAMPLES = r'''
   register: vm_boot_order
 '''
 
-RETURN = r"""
+RETURN = r'''
 vm_boot_status:
     description: metadata about boot order of virtual machine
     returned: always
@@ -167,7 +167,7 @@ vm_boot_status:
             "disk"
         ],
     }
-"""
+'''
 
 
 from ansible.module_utils.basic import AnsibleModule

--- a/plugins/modules/vmware_guest_boot_manager.py
+++ b/plugins/modules/vmware_guest_boot_manager.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_guest_boot_manager
 short_description: Manage boot options for the given virtual machine

--- a/plugins/modules/vmware_guest_controller.py
+++ b/plugins/modules/vmware_guest_controller.py
@@ -167,7 +167,7 @@ EXAMPLES = r'''
   register: disk_controller_facts
 '''
 
-RETURN = """
+RETURN = r'''
 disk_controller_status:
     description: metadata about the virtual machine's existing disk controllers or after adding or removing operation
     returned: always
@@ -232,7 +232,7 @@ disk_controller_status:
             }
         }
     }
-"""
+'''
 
 try:
     from pyVmomi import vim

--- a/plugins/modules/vmware_guest_controller.py
+++ b/plugins/modules/vmware_guest_controller.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_guest_controller
 short_description: Manage disk or USB controllers related to virtual machine in given vCenter infrastructure
@@ -127,7 +127,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Add disk and USB 3.0 controllers for virtual machine located by name
   community.vmware.vmware_guest_controller:
     hostname: "{{ vcenter_hostname }}"

--- a/plugins/modules/vmware_guest_cross_vc_clone.py
+++ b/plugins/modules/vmware_guest_cross_vc_clone.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 module: vmware_guest_cross_vc_clone
 
 short_description: Cross-vCenter VM/template clone
@@ -114,7 +114,7 @@ author:
   - Anusha Hegde (@anusha94)
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 # Clone template
 - name: clone a template across VC
   community.vmware.vmware_guest_cross_vc_clone:

--- a/plugins/modules/vmware_guest_custom_attribute_defs.py
+++ b/plugins/modules/vmware_guest_custom_attribute_defs.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_guest_custom_attribute_defs
 short_description: Manage custom attributes definitions for virtual machine from VMware
@@ -45,7 +45,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Add VMware Attribute Definition
   community.vmware.vmware_guest_custom_attribute_defs:
     hostname: "{{ vcenter_hostname }}"

--- a/plugins/modules/vmware_guest_custom_attribute_defs.py
+++ b/plugins/modules/vmware_guest_custom_attribute_defs.py
@@ -67,13 +67,13 @@ EXAMPLES = r'''
   register: defs
 '''
 
-RETURN = """
+RETURN = r'''
 custom_attribute_defs:
     description: list of all current attribute definitions
     returned: always
     type: list
     sample: ["sample_5", "sample_4"]
-"""
+'''
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, vmware_argument_spec

--- a/plugins/modules/vmware_guest_custom_attributes.py
+++ b/plugins/modules/vmware_guest_custom_attributes.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_guest_custom_attributes
 short_description: Manage custom attributes from VMware for the given virtual machine
@@ -85,7 +85,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Add virtual machine custom attributes
   community.vmware.vmware_guest_custom_attributes:
     hostname: "{{ vcenter_hostname }}"

--- a/plugins/modules/vmware_guest_custom_attributes.py
+++ b/plugins/modules/vmware_guest_custom_attributes.py
@@ -139,7 +139,7 @@ EXAMPLES = r'''
   register: attributes
 '''
 
-RETURN = """
+RETURN = r'''
 custom_attributes:
     description: metadata about the virtual machine attributes
     returned: always
@@ -151,7 +151,7 @@ custom_attributes:
         "sample_2": "sample_2_value",
         "sample_3": "sample_3_value"
     }
-"""
+'''
 
 try:
     from pyVmomi import vim

--- a/plugins/modules/vmware_guest_customization_facts.py
+++ b/plugins/modules/vmware_guest_customization_facts.py
@@ -64,7 +64,7 @@ EXAMPLES = r'''
   register: custom_spec_facts
 '''
 
-RETURN = """
+RETURN = r'''
 custom_spec_facts:
     description: metadata about the customization specification
     returned: always
@@ -96,7 +96,7 @@ custom_spec_facts:
             "type": "Linux"
         },
     }
-"""
+'''
 
 try:
     from pyVmomi import vim

--- a/plugins/modules/vmware_guest_customization_facts.py
+++ b/plugins/modules/vmware_guest_customization_facts.py
@@ -14,7 +14,7 @@ ANSIBLE_METADATA = {
     'supported_by': 'community'
 }
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_guest_customization_facts
 deprecated:
@@ -43,7 +43,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Gather facts about all customization specification
   community.vmware.vmware_guest_customization_facts:
     hostname: "{{ vcenter_hostname }}"

--- a/plugins/modules/vmware_guest_customization_info.py
+++ b/plugins/modules/vmware_guest_customization_info.py
@@ -55,7 +55,7 @@ EXAMPLES = r'''
   register: custom_spec_info
 '''
 
-RETURN = """
+RETURN = r'''
 custom_spec_info:
     description: metadata about the customization specification
     returned: always
@@ -87,7 +87,7 @@ custom_spec_info:
             "type": "Linux"
         },
     }
-"""
+'''
 
 try:
     from pyVmomi import vim

--- a/plugins/modules/vmware_guest_customization_info.py
+++ b/plugins/modules/vmware_guest_customization_info.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_guest_customization_info
 short_description: Gather info about VM customization specifications
@@ -34,7 +34,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Gather info about all customization specification
   community.vmware.vmware_guest_customization_info:
     hostname: "{{ vcenter_hostname }}"

--- a/plugins/modules/vmware_guest_disk.py
+++ b/plugins/modules/vmware_guest_disk.py
@@ -279,7 +279,7 @@ EXAMPLES = r'''
   register: disk_facts
 '''
 
-RETURN = r"""
+RETURN = r'''
 disk_status:
     description: metadata about the virtual machine's disks after managing them
     returned: always
@@ -302,7 +302,7 @@ disk_status:
             "unit_number": 0
         },
     }
-"""
+'''
 
 import re
 try:

--- a/plugins/modules/vmware_guest_disk_facts.py
+++ b/plugins/modules/vmware_guest_disk_facts.py
@@ -15,7 +15,7 @@ ANSIBLE_METADATA = {
     'supported_by': 'community'
 }
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_guest_disk_facts
 deprecated:
@@ -82,7 +82,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Gather disk facts from virtual machine using UUID
   community.vmware.vmware_guest_disk_facts:
     hostname: "{{ vcenter_hostname }}"

--- a/plugins/modules/vmware_guest_disk_facts.py
+++ b/plugins/modules/vmware_guest_disk_facts.py
@@ -117,7 +117,7 @@ EXAMPLES = r'''
   register: disk_facts
 '''
 
-RETURN = """
+RETURN = r'''
 guest_disk_facts:
     description: metadata about the virtual machine's disks
     returned: always
@@ -161,7 +161,7 @@ guest_disk_facts:
             "unit_number": 1
         },
     }
-"""
+'''
 
 try:
     from pyVmomi import vim

--- a/plugins/modules/vmware_guest_disk_info.py
+++ b/plugins/modules/vmware_guest_disk_info.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_guest_disk_info
 short_description: Gather info about disks of given virtual machine
@@ -73,7 +73,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Gather disk info from virtual machine using UUID
   community.vmware.vmware_guest_disk_info:
     hostname: "{{ vcenter_hostname }}"

--- a/plugins/modules/vmware_guest_disk_info.py
+++ b/plugins/modules/vmware_guest_disk_info.py
@@ -108,7 +108,7 @@ EXAMPLES = r'''
   register: disk_info
 '''
 
-RETURN = """
+RETURN = r'''
 guest_disk_info:
     description: metadata about the virtual machine's disks
     returned: always
@@ -154,7 +154,7 @@ guest_disk_info:
             "unit_number": 1
         },
     }
-"""
+'''
 
 try:
     from pyVmomi import vim

--- a/plugins/modules/vmware_guest_file_operation.py
+++ b/plugins/modules/vmware_guest_file_operation.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_guest_file_operation
 short_description: Files operation in a VMware guest operating system without network
@@ -156,7 +156,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Create directory inside a vm
   community.vmware.vmware_guest_file_operation:
     hostname: "{{ vcenter_hostname }}"

--- a/plugins/modules/vmware_guest_find.py
+++ b/plugins/modules/vmware_guest_find.py
@@ -63,7 +63,7 @@ EXAMPLES = r'''
   register: vm_folder
 '''
 
-RETURN = r"""
+RETURN = r'''
 folders:
     description: List of folders for user specified virtual machine
     returned: on success
@@ -71,7 +71,7 @@ folders:
     sample: [
         '/DC0/vm',
     ]
-"""
+'''
 
 
 from ansible.module_utils.basic import AnsibleModule

--- a/plugins/modules/vmware_guest_find.py
+++ b/plugins/modules/vmware_guest_find.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_guest_find
 short_description: Find the folder path(s) for a virtual machine by name or UUID

--- a/plugins/modules/vmware_guest_info.py
+++ b/plugins/modules/vmware_guest_info.py
@@ -162,7 +162,7 @@ EXAMPLES = r'''
   register: moid_info
 '''
 
-RETURN = """
+RETURN = r'''
 instance:
     description: metadata about the virtual machine
     returned: always
@@ -223,7 +223,7 @@ instance:
         "moid": "vm-42",
         "vimref": "vim.VirtualMachine:vm-42"
     }
-"""
+'''
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_text

--- a/plugins/modules/vmware_guest_info.py
+++ b/plugins/modules/vmware_guest_info.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_guest_info
 short_description: Gather info about a single VM
@@ -109,7 +109,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Gather info from standalone ESXi server having datacenter as 'ha-datacenter'
   community.vmware.vmware_guest_info:
     hostname: "{{ vcenter_hostname }}"

--- a/plugins/modules/vmware_guest_move.py
+++ b/plugins/modules/vmware_guest_move.py
@@ -124,7 +124,7 @@ EXAMPLES = r'''
   register: facts
 '''
 
-RETURN = """
+RETURN = r'''
 instance:
     description: metadata about the virtual machine
     returned: always
@@ -172,7 +172,7 @@ instance:
         "module_hw": true,
         "snapshots": []
     }
-"""
+'''
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native

--- a/plugins/modules/vmware_guest_network.py
+++ b/plugins/modules/vmware_guest_network.py
@@ -201,7 +201,7 @@ extends_documentation_fragment:
 - community.vmware.vmware.documentation
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: change network for 00:50:56:11:22:33 on vm01.domain.fake
   community.vmware.vmware_guest_network:
     hostname: "{{ vcenter_hostname }}"

--- a/plugins/modules/vmware_guest_network.py
+++ b/plugins/modules/vmware_guest_network.py
@@ -254,7 +254,7 @@ EXAMPLES = r'''
       connected: true
 '''
 
-RETURN = '''
+RETURN = r'''
 network_info:
   description: metadata about the virtual machine network adapters
   returned: always

--- a/plugins/modules/vmware_guest_register_operation.py
+++ b/plugins/modules/vmware_guest_register_operation.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 module: vmware_guest_register_operation
 short_description: VM inventory registration operation
 author:
@@ -87,7 +87,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Register VM to inventory
   community.vmware.vmware_guest_register_operation:
     hostname: "{{ vcenter_hostname }}"

--- a/plugins/modules/vmware_guest_screenshot.py
+++ b/plugins/modules/vmware_guest_screenshot.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_guest_screenshot
 short_description: Create a screenshot of the Virtual Machine console.
@@ -83,7 +83,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: take a screenshot of the virtual machine console
   community.vmware.vmware_guest_screenshot:
     validate_certs: no

--- a/plugins/modules/vmware_guest_screenshot.py
+++ b/plugins/modules/vmware_guest_screenshot.py
@@ -111,7 +111,7 @@ EXAMPLES = r'''
   register: take_screenshot
 '''
 
-RETURN = """
+RETURN = r'''
 screenshot_info:
     description: display the facts of captured virtual machine screenshot file
     returned: always
@@ -126,7 +126,7 @@ screenshot_info:
             "download_local_path": "/tmp/",
             "download_file_size": 2367,
     }
-"""
+'''
 
 try:
     from pyVmomi import vim, vmodl

--- a/plugins/modules/vmware_guest_sendkey.py
+++ b/plugins/modules/vmware_guest_sendkey.py
@@ -141,7 +141,7 @@ EXAMPLES = r'''
   register: keys_num_sent
 '''
 
-RETURN = r"""
+RETURN = r'''
 sendkey_info:
     description: display the keys and the number of keys sent to the virtual machine
     returned: always
@@ -158,7 +158,7 @@ sendkey_info:
             "keys_send_number": 4,
             "returned_keys_send_number": 4,
     }
-"""
+'''
 
 import time
 try:

--- a/plugins/modules/vmware_guest_serial_port.py
+++ b/plugins/modules/vmware_guest_serial_port.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_guest_serial_port
 short_description: Manage serial ports on an existing VM
@@ -120,7 +120,7 @@ author:
   - Anusha Hegde (@anusha94)
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 # Create serial ports
 - name: Create multiple serial ports with Backing type - network, pipe, device and file
   community.vmware.vmware_guest_serial_port:

--- a/plugins/modules/vmware_guest_snapshot.py
+++ b/plugins/modules/vmware_guest_snapshot.py
@@ -232,7 +232,7 @@ EXAMPLES = r'''
     delegate_to: localhost
 '''
 
-RETURN = """
+RETURN = r'''
 snapshot_results:
     description: metadata about the virtual machine snapshots
     returned: always
@@ -262,7 +262,7 @@ snapshot_results:
           }
       ]
     }
-"""
+'''
 
 import time
 try:

--- a/plugins/modules/vmware_guest_snapshot.py
+++ b/plugins/modules/vmware_guest_snapshot.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_guest_snapshot
 short_description: Manages virtual machines snapshots in vCenter
@@ -130,7 +130,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
   - name: Create a snapshot
     community.vmware.vmware_guest_snapshot:
       hostname: "{{ vcenter_hostname }}"

--- a/plugins/modules/vmware_guest_snapshot_info.py
+++ b/plugins/modules/vmware_guest_snapshot_info.py
@@ -94,7 +94,7 @@ EXAMPLES = r'''
   register: snapshot_info
 '''
 
-RETURN = """
+RETURN = r'''
 guest_snapshots:
     description: metadata about the snapshot information
     returned: always
@@ -117,7 +117,7 @@ guest_snapshots:
             }
         ]
     }
-"""
+'''
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, list_snapshots, vmware_argument_spec

--- a/plugins/modules/vmware_guest_snapshot_info.py
+++ b/plugins/modules/vmware_guest_snapshot_info.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_guest_snapshot_info
 short_description: Gather info about virtual machine's snapshots in vCenter
@@ -71,7 +71,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Gather snapshot information about the virtual machine in the given vCenter
   community.vmware.vmware_guest_snapshot_info:
     hostname: "{{ vcenter_hostname }}"

--- a/plugins/modules/vmware_guest_tools_info.py
+++ b/plugins/modules/vmware_guest_tools_info.py
@@ -95,7 +95,7 @@ EXAMPLES = r'''
   register: vmtools_info
 '''
 
-RETURN = """
+RETURN = r'''
 vmtools_info:
     description: metadata about the VMware tools installed in virtual machine
     returned: always
@@ -118,7 +118,7 @@ vmtools_info:
         "vm_tools_version": 10341,
         "vm_tools_version_status": "guestToolsCurrent"
     }
-"""
+'''
 
 
 from ansible.module_utils.basic import AnsibleModule

--- a/plugins/modules/vmware_guest_tools_info.py
+++ b/plugins/modules/vmware_guest_tools_info.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_guest_tools_info
 short_description: Gather info about VMware tools installed in VM
@@ -73,7 +73,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Gather VMware tools info installed in VM specified by uuid
   community.vmware.vmware_guest_tools_info:
     hostname: "{{ vcenter_hostname }}"

--- a/plugins/modules/vmware_guest_tools_upgrade.py
+++ b/plugins/modules/vmware_guest_tools_upgrade.py
@@ -110,7 +110,7 @@ EXAMPLES = r'''
   delegate_to: localhost
 '''
 
-RETURN = ''' # '''
+RETURN = r''' # '''
 
 
 from ansible.module_utils.basic import AnsibleModule

--- a/plugins/modules/vmware_guest_tools_upgrade.py
+++ b/plugins/modules/vmware_guest_tools_upgrade.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_guest_tools_upgrade
 short_description: Module to upgrade VMTools
@@ -79,7 +79,7 @@ author:
     - Mike Klebolt (@MikeKlebolt) <michael.klebolt@centurylink.com>
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Get VM UUID
   vmware_guest_facts:
     hostname: "{{ vcenter_hostname }}"

--- a/plugins/modules/vmware_guest_tools_wait.py
+++ b/plugins/modules/vmware_guest_tools_wait.py
@@ -8,7 +8,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_guest_tools_wait
 short_description: Wait for VMware tools to become available
@@ -74,7 +74,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Wait for VMware tools to become available by UUID
   vmware_guest_facts:
     hostname: "{{ vcenter_hostname }}"

--- a/plugins/modules/vmware_guest_tools_wait.py
+++ b/plugins/modules/vmware_guest_tools_wait.py
@@ -120,13 +120,13 @@ EXAMPLES = r'''
   register: facts
 '''
 
-RETURN = """
+RETURN = r'''
 instance:
     description: metadata about the virtual machine
     returned: always
     type: dict
     sample: None
-"""
+'''
 
 import datetime
 import time

--- a/plugins/modules/vmware_guest_video.py
+++ b/plugins/modules/vmware_guest_video.py
@@ -151,7 +151,7 @@ EXAMPLES = r'''
   register: video_facts
 '''
 
-RETURN = r"""
+RETURN = r'''
 video_status:
     description: metadata about the virtual machine's video card after managing them
     returned: always
@@ -164,7 +164,7 @@ video_status:
         "renderer_3D": "automatic",
         "video_memory": 8192
     }
-"""
+'''
 
 try:
     from pyVmomi import vim

--- a/plugins/modules/vmware_guest_vnc.py
+++ b/plugins/modules/vmware_guest_vnc.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_guest_vnc
 short_description: Manages VNC remote display on virtual machines in vCenter
@@ -89,7 +89,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Enable VNC remote display on the VM
   community.vmware.vmware_guest_vnc:
     hostname: "{{ vcenter_hostname }}"

--- a/plugins/modules/vmware_guest_vnc.py
+++ b/plugins/modules/vmware_guest_vnc.py
@@ -130,7 +130,7 @@ EXAMPLES = r'''
   register: vnc_result
 '''
 
-RETURN = '''
+RETURN = r'''
 changed:
   description: If anything changed on VM's extraConfig.
   returned: always

--- a/plugins/modules/vmware_host_auto_start.py
+++ b/plugins/modules/vmware_host_auto_start.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 module: vmware_host_auto_start
 short_description: Manage the auto power ON or OFF for vm on ESXi host
 author:
@@ -131,7 +131,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 ---
 - name: Update for system defaults config.
   community.vmware.vmware_host_auto_start:

--- a/plugins/modules/vmware_host_auto_start.py
+++ b/plugins/modules/vmware_host_auto_start.py
@@ -161,7 +161,7 @@ EXAMPLES = r'''
       wait_for_heartbeat: yes
 '''
 
-RETURN = '''
+RETURN = r'''
 system_defaults_config:
   description: Parameter return when system defaults config is changed.
   returned: changed

--- a/plugins/modules/vmware_host_iscsi.py
+++ b/plugins/modules/vmware_host_iscsi.py
@@ -7,7 +7,7 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 module: vmware_host_iscsi
 short_description: Manage the iSCSI configuration of ESXi host
 author:
@@ -263,7 +263,7 @@ extends_documentation_fragment:
 - community.vmware.vmware.documentation
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Enable iSCSI of ESXi
   vmware_host_iscsi:
     hostname: "{{ vcenter_hostname }}"

--- a/plugins/modules/vmware_host_iscsi.py
+++ b/plugins/modules/vmware_host_iscsi.py
@@ -344,7 +344,7 @@ EXAMPLES = r'''
     state: absent
 '''
 
-RETURN = '''
+RETURN = r'''
 iscsi_properties:
   description: Parameter return when system defaults config is changed.
   returned: changed

--- a/plugins/modules/vmware_host_iscsi_info.py
+++ b/plugins/modules/vmware_host_iscsi_info.py
@@ -38,7 +38,7 @@ EXAMPLES = r'''
   register: iscsi_info
 '''
 
-RETURN = '''
+RETURN = r'''
 iscsi_properties:
   description: dictionary of current iSCSI information
   returned: always

--- a/plugins/modules/vmware_host_iscsi_info.py
+++ b/plugins/modules/vmware_host_iscsi_info.py
@@ -7,7 +7,7 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 module: vmware_host_iscsi_info
 short_description: Gather iSCSI configuration information of ESXi host
 author:
@@ -27,7 +27,7 @@ extends_documentation_fragment:
   - community.vmware.vmware.documentation
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Gather iSCSI configuration information of ESXi host
   community.vmware.vmware.vmware_host_iscsi_info:
     hostname: "{{ vcenter_hostname }}"

--- a/plugins/modules/vmware_host_logbundle.py
+++ b/plugins/modules/vmware_host_logbundle.py
@@ -135,7 +135,7 @@ EXAMPLES = r'''
       - VirtualMachines:VirtualMachineStats
 '''
 
-RETURN = '''
+RETURN = r'''
 dest:
     description: saved path of a logbundle file for ESXi
     returned: on success

--- a/plugins/modules/vmware_host_logbundle.py
+++ b/plugins/modules/vmware_host_logbundle.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_host_logbundle
 short_description: Fetch logbundle file from ESXi
@@ -112,7 +112,7 @@ extends_documentation_fragment:
     - community.vmware.vmware.documentation
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: fetch logbundle file from ESXi
   community.vmware.vmware_host_logbundle:
     hostname: "{{ vcenter_hostname }}"

--- a/plugins/modules/vmware_host_logbundle_info.py
+++ b/plugins/modules/vmware_host_logbundle_info.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_host_logbundle_info
 short_description: Gathers manifest info for logbundle
@@ -29,7 +29,7 @@ extends_documentation_fragment:
     - community.vmware.vmware.documentation
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: fetch the manifests for logbundle from ESXi
   community.vmware.vmware_host_logbundle_info:
     hostname: "{{ vcenter_hostname }}"

--- a/plugins/modules/vmware_host_logbundle_info.py
+++ b/plugins/modules/vmware_host_logbundle_info.py
@@ -40,7 +40,7 @@ EXAMPLES = r'''
   register: fetch_manifests_result
 '''
 
-RETURN = '''
+RETURN = r'''
 manifests:
     description: list of dictionary of manifest information for logbundle
     returned: always

--- a/plugins/modules/vmware_host_sriov.py
+++ b/plugins/modules/vmware_host_sriov.py
@@ -105,7 +105,7 @@ EXAMPLES = r'''
     num_virt_func: 0
 '''
 
-RETURN = r"""
+RETURN = r'''
 host_sriov_diff:
     description:
     - contains info about SR-IOV status on vmnic before, after and requested changes
@@ -147,7 +147,7 @@ host_sriov_diff:
             }
         }
     }
-"""
+'''
 
 
 try:

--- a/plugins/modules/vmware_host_sriov.py
+++ b/plugins/modules/vmware_host_sriov.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = r"""
+DOCUMENTATION = r'''
 ---
 module: vmware_host_sriov
 short_description: Manage SR-IOV settings on host
@@ -56,9 +56,9 @@ options:
     required: False
 extends_documentation_fragment:
 - community.vmware.vmware.documentation
-"""
+'''
 
-EXAMPLES = r"""
+EXAMPLES = r'''
 - name: enable SR-IOV on vmnic0 with 8 functions
   community.vmware.vmware_host_sriov:
     hostname: "{{ vcenter_hostname }}"
@@ -103,7 +103,7 @@ EXAMPLES = r"""
     vmnic: vmnic0
     sriov_on: false
     num_virt_func: 0
-"""
+'''
 
 RETURN = r"""
 host_sriov_diff:

--- a/plugins/modules/vmware_local_role_facts.py
+++ b/plugins/modules/vmware_local_role_facts.py
@@ -15,7 +15,7 @@ ANSIBLE_METADATA = {
 }
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_local_role_facts
 deprecated:
@@ -39,7 +39,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Gather facts about local role from an ESXi
   community.vmware.vmware_local_role_facts:
     hostname: '{{ esxi_hostname }}'

--- a/plugins/modules/vmware_local_user_facts.py
+++ b/plugins/modules/vmware_local_user_facts.py
@@ -15,7 +15,7 @@ ANSIBLE_METADATA = {
 }
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_local_user_facts
 deprecated:

--- a/plugins/modules/vmware_local_user_info.py
+++ b/plugins/modules/vmware_local_user_info.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_local_user_info
 short_description: Gather info about users on the given ESXi host

--- a/plugins/modules/vmware_local_user_manager.py
+++ b/plugins/modules/vmware_local_user_manager.py
@@ -10,7 +10,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_local_user_manager
 short_description: Manage local users on an ESXi host
@@ -51,7 +51,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Add local user to ESXi
   community.vmware.vmware_local_user_manager:
     hostname: esxi_hostname

--- a/plugins/modules/vmware_local_user_manager.py
+++ b/plugins/modules/vmware_local_user_manager.py
@@ -61,7 +61,7 @@ EXAMPLES = r'''
   delegate_to: localhost
 '''
 
-RETURN = '''# '''
+RETURN = r'''# '''
 
 try:
     from pyVmomi import vim, vmodl

--- a/plugins/modules/vmware_maintenancemode.py
+++ b/plugins/modules/vmware_maintenancemode.py
@@ -80,7 +80,7 @@ EXAMPLES = r'''
   delegate_to: localhost
 '''
 
-RETURN = '''
+RETURN = r'''
 hostsystem:
     description: Name of vim reference
     returned: always

--- a/plugins/modules/vmware_maintenancemode.py
+++ b/plugins/modules/vmware_maintenancemode.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_maintenancemode
 short_description: Place a host into maintenance mode
@@ -66,7 +66,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Enter VSAN-Compliant Maintenance Mode
   community.vmware.vmware_maintenancemode:
     hostname: "{{ vcenter_hostname }}"

--- a/plugins/modules/vmware_migrate_vmk.py
+++ b/plugins/modules/vmware_migrate_vmk.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_migrate_vmk
 short_description: Migrate a VMK interface from VSS to VDS
@@ -58,7 +58,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Migrate Management vmk
   community.vmware.vmware_migrate_vmk:
     hostname: "{{ vcenter_hostname }}"

--- a/plugins/modules/vmware_resource_pool.py
+++ b/plugins/modules/vmware_resource_pool.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_resource_pool
 short_description: Add/remove resource pools to/from vCenter
@@ -102,7 +102,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Add resource pool to vCenter
   community.vmware.vmware_resource_pool:
     hostname: '{{ vcenter_hostname }}'

--- a/plugins/modules/vmware_resource_pool.py
+++ b/plugins/modules/vmware_resource_pool.py
@@ -123,13 +123,13 @@ EXAMPLES = r'''
   delegate_to: localhost
 '''
 
-RETURN = """
+RETURN = r'''
 instance:
     description: metadata about the new resource pool
     returned: always
     type: dict
     sample: None
-"""
+'''
 
 try:
     from pyVmomi import vim, vmodl

--- a/plugins/modules/vmware_target_canonical_facts.py
+++ b/plugins/modules/vmware_target_canonical_facts.py
@@ -13,7 +13,7 @@ ANSIBLE_METADATA = {
     'supported_by': 'community'
 }
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_target_canonical_facts
 deprecated:
@@ -55,7 +55,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Get Canonical name of particular target on particular ESXi host system
   community.vmware.vmware_target_canonical_facts:
     hostname: '{{ vcenter_hostname }}'

--- a/plugins/modules/vmware_target_canonical_facts.py
+++ b/plugins/modules/vmware_target_canonical_facts.py
@@ -82,7 +82,7 @@ EXAMPLES = r'''
   delegate_to: localhost
 '''
 
-RETURN = r"""
+RETURN = r'''
 canonical:
     description: metadata about SCSI Target device
     returned: if host system and target id is given
@@ -113,7 +113,7 @@ scsi_tgt_facts:
             }
         },
     }
-"""
+'''
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, vmware_argument_spec

--- a/plugins/modules/vmware_target_canonical_info.py
+++ b/plugins/modules/vmware_target_canonical_info.py
@@ -72,7 +72,7 @@ EXAMPLES = r'''
   delegate_to: localhost
 '''
 
-RETURN = r"""
+RETURN = r'''
 canonical:
     description: metadata about SCSI Target device
     returned: if host system and target id is given
@@ -103,7 +103,7 @@ scsi_tgt_info:
             }
         },
     }
-"""
+'''
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, vmware_argument_spec

--- a/plugins/modules/vmware_target_canonical_info.py
+++ b/plugins/modules/vmware_target_canonical_info.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_target_canonical_info
 short_description: Return canonical (NAA) from an ESXi host system
@@ -45,7 +45,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Get Canonical name of particular target on particular ESXi host system
   community.vmware.vmware_target_canonical_info:
     hostname: '{{ vcenter_hostname }}'

--- a/plugins/modules/vmware_vm_vss_dvs_migrate.py
+++ b/plugins/modules/vmware_vm_vss_dvs_migrate.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_vm_vss_dvs_migrate
 short_description: Migrates a virtual machine from a standard vswitch to distributed
@@ -37,7 +37,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Migrate VCSA to vDS
   community.vmware.vmware_vm_vss_dvs_migrate:
     hostname: '{{ vcenter_hostname }}'

--- a/plugins/modules/vmware_vmkernel_ip_config.py
+++ b/plugins/modules/vmware_vmkernel_ip_config.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_vmkernel_ip_config
 short_description: Configure the VMkernel IP Address
@@ -43,7 +43,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 # Example command from Ansible Playbook
 
 - name: Configure IP address on ESX host

--- a/plugins/modules/vmware_vmotion.py
+++ b/plugins/modules/vmware_vmotion.py
@@ -74,7 +74,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Perform vMotion of virtual machine
   community.vmware.vmware_vmotion:
     hostname: '{{ vcenter_hostname }}'

--- a/plugins/modules/vmware_vmotion.py
+++ b/plugins/modules/vmware_vmotion.py
@@ -128,7 +128,7 @@ EXAMPLES = r'''
   delegate_to: localhost
 '''
 
-RETURN = '''
+RETURN = r'''
 running_host:
     description: List the host the virtual machine is registered to
     returned: changed or success

--- a/plugins/modules/vmware_vsan_cluster.py
+++ b/plugins/modules/vmware_vsan_cluster.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_vsan_cluster
 short_description: Configure VSAN clustering on an ESXi host
@@ -32,7 +32,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Configure VMware VSAN Cluster
   hosts: deploy_node
   tags:

--- a/plugins/modules/vmware_vsan_health_info.py
+++ b/plugins/modules/vmware_vsan_health_info.py
@@ -54,7 +54,7 @@ EXAMPLES = r'''
     fetch_from_cache: False
 '''
 
-RETURN = '''
+RETURN = r'''
 vsan_health_info:
     description: vSAN cluster health info
     returned: on success

--- a/plugins/modules/vmware_vsan_health_info.py
+++ b/plugins/modules/vmware_vsan_health_info.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_vsan_health_info
 
@@ -42,7 +42,7 @@ author:
     - Erwan Quelin (@equelin)
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Gather health info from a vSAN's cluster
   hosts: localhost
   gather_facts: 'no'

--- a/plugins/modules/vmware_vspan_session.py
+++ b/plugins/modules/vmware_vspan_session.py
@@ -210,8 +210,8 @@ EXAMPLES = r'''
   delegate_to: localhost
 '''
 
-RETURN = r"""#
-"""
+RETURN = r'''#
+'''
 
 try:
     from pyVmomi import vim

--- a/plugins/modules/vmware_vswitch.py
+++ b/plugins/modules/vmware_vswitch.py
@@ -110,13 +110,13 @@ EXAMPLES = r'''
   delegate_to: localhost
 '''
 
-RETURN = r"""
+RETURN = r'''
 result:
     description: information about performed operation
     returned: always
     type: str
     sample: "vSwitch 'vSwitch_1002' is created successfully"
-"""
+'''
 
 try:
     from pyVmomi import vim, vmodl

--- a/plugins/modules/vsphere_copy.py
+++ b/plugins/modules/vsphere_copy.py
@@ -58,7 +58,7 @@ extends_documentation_fragment:
 
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Copy file to datastore using delegate_to
   community.vmware.vsphere_copy:
     hostname: '{{ vcenter_hostname }}'


### PR DESCRIPTION
##### SUMMARY
It looks like you want to have the DOCUMENTATION and EXAMPLES blocks of modules to be 'r(raw)' strings... I don't know why, but if you want to have it like this we should do this consistently.

##### ISSUE TYPE
- Docs Pull Request

##### ADDITIONAL INFORMATION
Fixes #435 