### PR TITLE
vmware_tag_manager: Add new parameter 'moid'

### DIFF
--- a/changelogs/fragments/430_vmware_tag_manager.yml
+++ b/changelogs/fragments/430_vmware_tag_manager.yml
@@ -1,0 +1,4 @@
+bugfixes:
+- vmware_tag_manager - added new parameter 'moid' to identify VMware object to tag (https://github.com/ansible-collections/community.vmware/issues/430).
+- vmware_folder_info - added the flat_folder_info in the return value.
+- vmware_vm_info - added the moid information in the return value.

--- a/plugins/modules/vmware_vm_info.py
+++ b/plugins/modules/vmware_vm_info.py
@@ -25,6 +25,7 @@ author:
 notes:
 - Tested on ESXi 6.7, vSphere 5.5 and vSphere 6.5
 - From 2.8 and onwards, information are returned as list of dict instead of dict.
+- Fact about C(moid) added in VMware collection 1.4.0.
 requirements:
 - python >= 2.6
 - PyVmomi
@@ -187,7 +188,8 @@ virtual_machines:
                 "id": "urn:vmomi:InventoryServiceTag:43737ec0-b832-4abf-abb1-fd2448ce3b26:GLOBAL",
                 "name": "tag_0001"
             }
-        ]
+        ],
+        "moid": "vm-24"
     }
   ]
 '''
@@ -291,6 +293,7 @@ class VmwareVmInfo(PyVmomi):
                 "attributes": vm_attributes,
                 "tags": vm_tags,
                 "folder": vm_folder,
+                "moid": vm._moId,
             }
 
             vm_type = self.module.params.get('vm_type')

--- a/tests/integration/targets/vmware_folder_info/tasks/main.yml
+++ b/tests/integration/targets/vmware_folder_info/tasks/main.yml
@@ -19,7 +19,7 @@
   vcenter_folder:
     <<: *vcenter_folder_data
     folder_name: "child_folder"
-    parent_folder: "toplevel"    
+    parent_folder: "toplevel"
 
 # Testcase 0001: Get details about folders
 - name: get info about folders
@@ -34,6 +34,7 @@
       - "{{ item }} is defined"
   with_items:
   - folder_info_0001['folder_info']
+  - folder_info_0001['flat_folder_info']
   - folder_info_0001['folder_info']['datastoreFolders']
   - folder_info_0001['folder_info']['hostFolders']
   - folder_info_0001['folder_info']['vmFolders']

--- a/tests/integration/targets/vmware_tag_manager/tasks/main.yml
+++ b/tests/integration/targets/vmware_tag_manager/tasks/main.yml
@@ -9,7 +9,6 @@
     setup_datastore: true
     setup_virtualmachines: true
 
-
 - set_fact:
     cat_one: category_1003
     tag_one: tag:1003

--- a/tests/integration/targets/vmware_tag_manager/tasks/tag_manager_dict.yml
+++ b/tests/integration/targets/vmware_tag_manager/tasks/tag_manager_dict.yml
@@ -42,7 +42,9 @@
       validate_certs: False
     register: vm_info
 
-  - set_fact: vm_name="{{ vm_info['virtual_machines'][0]['guest_name'] }}"
+  - set_fact:
+      vm_name: "{{ vm_info['virtual_machines'][0]['guest_name'] }}"
+      vm_moid: "{{ vm_info['virtual_machines'][0]['moid'] }}"
 
   - name: Assign tag to given virtual machine
     vmware_tag_manager:
@@ -92,6 +94,25 @@
       state: remove
     register: vm_tag_info
 
+  - name: Assign tag to given virtual machine using moid
+    vmware_tag_manager:
+      hostname: '{{ vcenter_hostname }}'
+      username: '{{ vcenter_username }}'
+      password: '{{ vcenter_password }}'
+      validate_certs: no
+      tag_names:
+        - category: "{{ cat_one }}"
+          tag: "{{ tag_one }}"
+      moid: "{{ vm_moid }}"
+      object_type: VirtualMachine
+      state: add
+    register: vm_tag_info
+
+  - name: Check if we assigned correct tags
+    assert:
+      that:
+        - vm_tag_info.changed
+
   - name: Remove tag to datastore
     vmware_tag_manager:
       hostname: '{{ vcenter_hostname }}'
@@ -105,6 +126,20 @@
       object_type: Datastore
       state: remove
     register: datastore_tag_info
+
+  - name: Remove tag to given virtual machine
+    vmware_tag_manager:
+      hostname: '{{ vcenter_hostname }}'
+      username: '{{ vcenter_username }}'
+      password: '{{ vcenter_password }}'
+      validate_certs: no
+      tag_names:
+        - category: "{{ cat_one }}"
+          tag: "{{ tag_one }}"
+      object_name: "{{ vm_name }}"
+      object_type: VirtualMachine
+      state: remove
+    register: vm_tag_info
 
   - name: Check if we removed correct tag
     assert:


### PR DESCRIPTION
##### SUMMARY

Users can now specify 'moid' of VMware object to identify
objects uniquely.

Fixes: #430

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/430_vmware_tag_manager.yml
plugins/modules/vmware_folder_info.py
plugins/modules/vmware_tag_manager.py
plugins/modules/vmware_vm_info.py
tests/integration/targets/vmware_folder_info/tasks/main.yml
tests/integration/targets/vmware_tag_manager/tasks/main.yml
tests/integration/targets/vmware_tag_manager/tasks/tag_manager_dict.yml
