### PR TITLE
Fix the special characters aren't decoded by the find_obj method

### DIFF
--- a/changelogs/fragments/460_module_utils_vmware.yml
+++ b/changelogs/fragments/460_module_utils_vmware.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Fixed the find_obj method in the ``module_utils/vmware.py`` to handle an object name using special characters that URL-decoded(https://github.com/ansible-collections/community.vmware/pull/460)."

--- a/plugins/module_utils/vmware.py
+++ b/plugins/module_utils/vmware.py
@@ -103,7 +103,7 @@ def wait_for_vm_ip(content, vm, timeout=300):
 def find_obj(content, vimtype, name, first=True, folder=None):
     container = content.viewManager.CreateContainerView(folder or content.rootFolder, recursive=True, type=vimtype)
     # Get all objects matching type (and name if given)
-    obj_list = [obj for obj in container.view if not name or to_text(obj.name) == to_text(name)]
+    obj_list = [obj for obj in container.view if not name or to_text(unquote(obj.name)) == to_text(unquote(name))]
     container.Destroy()
 
     # Return first match or None

--- a/tests/integration/targets/vmware_guest/tasks/network_with_dvpg.yml
+++ b/tests/integration/targets/vmware_guest/tasks/network_with_dvpg.yml
@@ -135,6 +135,72 @@
     - assert:
         that:
           - not (no_vm_result is changed)
+
+    - name: Integration test for issue 457(https://github.com/ansible-collections/community.vmware/issues/457)
+      block:
+        - name: Create a new dvportgroup with '/' in the name
+          vmware_dvs_portgroup:
+            hostname: "{{ vcenter_hostname }}"
+            username: "{{ vcenter_username }}"
+            password: "{{ vcenter_password }}"
+            validate_certs: no
+            switch_name: "{{ dvswitch1 }}"
+            portgroup_name: "192.168.0.0/24"
+            vlan_id: 0
+            portgroup_type: earlyBinding
+            num_ports: 8
+            state: present
+          register: create_dvportgroup_result
+
+        - assert:
+            that:
+              - create_dvportgroup_result.changed is sameas true
+
+        - name: Deploy VM with '/' in the portgroup name
+          vmware_guest:
+            hostname: "{{ vcenter_hostname }}"
+            username: "{{ vcenter_username }}"
+            password: "{{ vcenter_password }}"
+            validate_certs: False
+            datacenter: "{{ dc1 }}"
+            esxi_hostname: "{{ esxi1 }}"
+            state: poweredon
+            folder: "{{ f0 }}"
+            name: test_vm_slash
+            disk:
+              - size: 10mb
+                datastore: "{{ rw_datastore }}"
+            guest_id: rhel7_64guest
+            hardware:
+              memory_mb: 128
+              num_cpus: 1
+            networks:
+              - name: '192.168.0.0/24'
+                device_type: "vmxnet3"
+          register: deploy_vm_slash_result
+
+        - assert:
+            that:
+              - deploy_vm_slash_result.changed is sameas true
+
+        - name: Delete the dvportgroup with ‘/‘ in the name
+          vmware_dvs_portgroup:
+            hostname: "{{ vcenter_hostname }}"
+            username: "{{ vcenter_username }}"
+            password: "{{ vcenter_password }}"
+            validate_certs: no
+            switch_name: "{{ dvswitch1 }}"
+            portgroup_name: "192.168.0.0/24"
+            vlan_id: 0
+            portgroup_type: earlyBinding
+            num_ports: 8
+            state: absent
+          register: delete_dvportgroup_result
+    
+        - assert:
+            that:
+              - delete_dvportgroup_result.changed is sameas true
+
   always:
     - when: vcsim is not defined
       name: Remove VM to free the portgroup
@@ -150,3 +216,4 @@
         - test_vm1
         - test_vm2
         - test_vm3
+        - test_vm_slash

--- a/tests/integration/targets/vmware_guest/tasks/network_with_dvpg.yml
+++ b/tests/integration/targets/vmware_guest/tasks/network_with_dvpg.yml
@@ -138,7 +138,7 @@
 
     - name: Integration test for issue 457(https://github.com/ansible-collections/community.vmware/issues/457)
       block:
-        - name: Create a new dvportgroup with '/' in the name
+        - name: Create a new dvportgroup with / in the name
           vmware_dvs_portgroup:
             hostname: "{{ vcenter_hostname }}"
             username: "{{ vcenter_username }}"
@@ -156,7 +156,7 @@
             that:
               - create_dvportgroup_result.changed is sameas true
 
-        - name: Deploy VM with '/' in the portgroup name
+        - name: Deploy VM with / in the portgroup name
           vmware_guest:
             hostname: "{{ vcenter_hostname }}"
             username: "{{ vcenter_username }}"
@@ -183,7 +183,7 @@
             that:
               - deploy_vm_slash_result.changed is sameas true
 
-        - name: Delete the dvportgroup with ‘/‘ in the name
+        - name: Delete the dvportgroup with / in the name
           vmware_dvs_portgroup:
             hostname: "{{ vcenter_hostname }}"
             username: "{{ vcenter_username }}"

--- a/tests/integration/targets/vmware_guest/tasks/network_with_portgroup.yml
+++ b/tests/integration/targets/vmware_guest/tasks/network_with_portgroup.yml
@@ -45,3 +45,85 @@
 - assert:
     that:
       - vm_with_portgroup is changed
+
+- name: Integration test for issue 457(https://github.com/ansible-collections/community.vmware/issues/457)
+  when: vcsim is not defined
+  block:
+    - name: Create a new portgroup with '/' in the name
+      vmware_portgroup:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: no
+        hosts:
+          - "{{ esxi1 }}"
+        switch: "{{ switch1 }}"
+        portgroup: "192.168.0.0/24"
+      register: create_portgroup_result
+
+    - assert:
+        that:
+          - create_portgroup_result.changed is sameas true
+
+    - name: Deploy VM with '/' in the portgroup name
+      vmware_guest:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: False
+        datacenter: "{{ dc1 }}"
+        esxi_hostname: "{{ esxi1 }}"
+        state: poweredon
+        folder: "{{ f0 }}"
+        name: test_vm_slash
+        disk:
+          - size: 10mb
+            datastore: "{{ rw_datastore }}"
+        guest_id: rhel7_64guest
+        hardware:
+          memory_mb: 128
+          num_cpus: 1
+        networks:
+          - name: '192.168.0.0/24'
+            device_type: "vmxnet3"
+      register: deploy_vm_slash_result
+
+    - assert:
+        that:
+          - deploy_vm_slash_result.changed is sameas true
+
+    - name: Destroy the test_vm_slash VM
+      vmware_guest:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: False
+        datacenter: "{{ dc1 }}"
+        esxi_hostname: "{{ esxi1 }}"
+        state: poweredon
+        folder: "{{ f0 }}"
+        name: test_vm_slash
+        force: true
+        state: absent
+      register: destroy_tset_vm_slash_result
+
+    - assert:
+        that:
+          - destroy_tset_vm_slash_result.changed is sameas true
+
+    - name: Delete the portgroup with ‘/‘ in the name
+      vmware_portgroup:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: no
+        hosts:
+          - "{{ esxi1 }}"
+        switch: "{{ switch1 }}"
+        portgroup: "192.168.0.0/24"
+        state: absent
+      register: delete_portgroup_result
+
+    - assert:
+        that:
+          - delete_portgroup_result.changed is sameas true

--- a/tests/integration/targets/vmware_guest/tasks/network_with_portgroup.yml
+++ b/tests/integration/targets/vmware_guest/tasks/network_with_portgroup.yml
@@ -49,7 +49,7 @@
 - name: Integration test for issue 457(https://github.com/ansible-collections/community.vmware/issues/457)
   when: vcsim is not defined
   block:
-    - name: Create a new portgroup with '/' in the name
+    - name: Create a new portgroup with / in the name
       vmware_portgroup:
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
@@ -65,7 +65,7 @@
         that:
           - create_portgroup_result.changed is sameas true
 
-    - name: Deploy VM with '/' in the portgroup name
+    - name: Deploy VM with / in the portgroup name
       vmware_guest:
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
@@ -111,7 +111,7 @@
         that:
           - destroy_tset_vm_slash_result.changed is sameas true
 
-    - name: Delete the portgroup with ‘/‘ in the name
+    - name: Delete the portgroup with / in the name
       vmware_portgroup:
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"


### PR DESCRIPTION
##### SUMMARY

This PR is to fix the find_obj method can URL decode of special characters.  
By this cause, the vmware_guest module hasn't available the special characters in a portgroup name

fixes: https://github.com/ansible-collections/community.vmware/issues/457

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

plugins/module_utils/vmware.py
tests/integration/targets/vmware_guest/tasks/network_with_dvpg.yml
tests/integration/targets/vmware_guest/tasks/network_with_portgroup.yml

##### ADDITIONAL INFORMATION

tested on vCenter/ESXi 7.0