### PR TITLE
vmware_resource_pool: Add new allocation shares options for cpu and memory

### DIFF
--- a/changelogs/fragments/461_vmware_resource_pool.yml
+++ b/changelogs/fragments/461_vmware_resource_pool.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_resource_pool - Add new allocation shares options for cpu and memory(https://github.com/ansible-collections/community.vmware/pull/461).

--- a/changelogs/fragments/461_vmware_resource_pool.yml
+++ b/changelogs/fragments/461_vmware_resource_pool.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - vmware_resource_pool - Add new allocation shares options for cpu and memory(https://github.com/ansible-collections/community.vmware/pull/461).
+  - vmware_resource_pool - add new allocation shares options for cpu and memory(https://github.com/ansible-collections/community.vmware/pull/461).

--- a/plugins/modules/vmware_resource_pool.py
+++ b/plugins/modules/vmware_resource_pool.py
@@ -66,7 +66,7 @@ options:
     cpu_allocation_shares:
         description:
             - The number of cpu shares allocated.
-            - This value is only set if I(cpu_shares) is set to custom.
+            - This value is only set if I(cpu_shares) is set to C(custom).
         type: int
     mem_expandable_reservations:
         description:
@@ -97,7 +97,7 @@ options:
     mem_allocation_shares:
         description:
             - The number of memory shares allocated.
-            - This value is only set if I(mem_shares) is set to custom.
+            - This value is only set if I(mem_shares) is set to C(custom).
         type: int
     state:
         description:

--- a/plugins/modules/vmware_resource_pool.py
+++ b/plugins/modules/vmware_resource_pool.py
@@ -68,6 +68,8 @@ options:
             - The number of cpu shares allocated.
             - This value is only set if I(cpu_shares) is set to C(custom).
         type: int
+        default: 4000
+        version_added: '1.4.0'
     mem_expandable_reservations:
         description:
             - In a resource pool with an expandable reservation, the reservation on a resource pool can grow beyond the specified value.
@@ -99,6 +101,8 @@ options:
             - The number of memory shares allocated.
             - This value is only set if I(mem_shares) is set to C(custom).
         type: int
+        default: 163840
+        version_added: '1.4.0'
     state:
         description:
             - Add or remove the resource pool
@@ -264,10 +268,8 @@ class VMwareResourcePool(object):
         cpu_alloc.reservation = int(self.cpu_reservation)
         cpu_alloc_shares = vim.SharesInfo()
         if self.cpu_shares == 'custom':
-            cpu_alloc_shares.level = self.cpu_shares
             cpu_alloc_shares.shares = self.cpu_allocation_shares
-        else:
-            cpu_alloc_shares.level = self.cpu_shares
+        cpu_alloc_shares.level = self.cpu_shares
         cpu_alloc.shares = cpu_alloc_shares
         rp_spec.cpuAllocation = cpu_alloc
 
@@ -277,10 +279,8 @@ class VMwareResourcePool(object):
         mem_alloc.reservation = int(self.mem_reservation)
         mem_alloc_shares = vim.SharesInfo()
         if self.mem_shares == 'custom':
-            mem_alloc_shares.level = self.mem_shares
             mem_alloc_shares.shares = self.mem_allocation_shares
-        else:
-            mem_alloc_shares.level = self.mem_shares
+        mem_alloc_shares.level = self.mem_shares
         mem_alloc.shares = mem_alloc_shares
         rp_spec.memoryAllocation = mem_alloc
 
@@ -315,14 +315,14 @@ def main():
                               resource_pool=dict(required=True, type='str'),
                               mem_shares=dict(type='str', default="normal", choices=[
                                               'high', 'custom', 'normal', 'low']),
-                              mem_allocation_shares=dict(type='int'),
+                              mem_allocation_shares=dict(type='int', default=163840),
                               mem_limit=dict(type='int', default=-1),
                               mem_reservation=dict(type='int', default=0),
                               mem_expandable_reservations=dict(
                                   type='bool', default="True"),
                               cpu_shares=dict(type='str', default="normal", choices=[
                                               'high', 'custom', 'normal', 'low']),
-                              cpu_allocation_shares=dict(type='int'),
+                              cpu_allocation_shares=dict(type='int', default=4000),
                               cpu_limit=dict(type='int', default=-1),
                               cpu_reservation=dict(type='int', default=0),
                               cpu_expandable_reservations=dict(

--- a/tests/integration/targets/vmware_resource_pool/tasks/main.yml
+++ b/tests/integration/targets/vmware_resource_pool/tasks/main.yml
@@ -120,7 +120,7 @@
     that:
       - "{{ resource_result_0005.changed == true }}"
 
-# Testcase 0005: Add Resource pool with the mem_allocation_shares and cpu_allocation_shares parameters(idempotency check)
+# Testcase 0006: Add Resource pool with the mem_allocation_shares and cpu_allocation_shares parameters(idempotency check)
 - name: add resource pool
   vmware_resource_pool:
     validate_certs: False
@@ -137,13 +137,13 @@
     state: present
   register: resource_result_0006
 
-- name: ensure a resource pool is present
+- name: make sure a resource pool is not changing
   assert:
     that:
       - "{{ resource_result_0006.changed == false }}"
 
-# Testcase 0006: Remove Resource pool
-- name: remove resource pool again
+# Testcase 0007: Remove Resource pool
+- name: remove resource pool
   vmware_resource_pool:
     validate_certs: False
     hostname: "{{ vcenter_hostname }}"
@@ -159,3 +159,61 @@
   assert:
     that:
         - "{{ resource_result_0007.changed == true }}"
+
+# Testcase 0008: Add Resource pool without the mem_allocation_shares and cpu_allocation_shares parameters
+- name: add resource pool
+  vmware_resource_pool:
+    validate_certs: False
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter: "{{ dc1 }}"
+    cluster: "{{ ccr1 }}"
+    resource_pool: test_resource_0001
+    mem_shares: custom
+    cpu_shares: custom
+    state: present
+  register: resource_result_0008
+
+- name: ensure a resource pool is present
+  assert:
+    that:
+      - "{{ resource_result_0008.changed == true }}"
+
+# Testcase 0009: Add Resource pool without the mem_allocation_shares and cpu_allocation_shares parameters(idempotency check)
+- name: add resource pool
+  vmware_resource_pool:
+    validate_certs: False
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter: "{{ dc1 }}"
+    cluster: "{{ ccr1 }}"
+    resource_pool: test_resource_0001
+    mem_shares: custom
+    cpu_shares: custom
+    state: present
+  register: resource_result_0009
+
+- name: make sure a resource pool is not changing
+  assert:
+    that:
+      - "{{ resource_result_0009.changed == false }}"
+
+# Testcase 0010: Remove Resource pool
+- name: remove resource pool
+  vmware_resource_pool:
+    validate_certs: False
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter: "{{ dc1 }}"
+    cluster: "{{ ccr1 }}"
+    resource_pool: test_resource_0001
+    state: absent
+  register: resource_result_0010
+
+- name: check if resource pool is removed
+  assert:
+    that:
+        - "{{ resource_result_0010.changed == true }}"

--- a/tests/integration/targets/vmware_resource_pool/tasks/main.yml
+++ b/tests/integration/targets/vmware_resource_pool/tasks/main.yml
@@ -100,6 +100,7 @@
 
 # Testcase 0005: Add Resource pool with the mem_allocation_shares and cpu_allocation_shares parameters
 - name: add resource pool
+  vmware_resource_pool:
     validate_certs: False
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
@@ -119,6 +120,28 @@
     that:
       - "{{ resource_result_0005.changed == true }}"
 
+# Testcase 0005: Add Resource pool with the mem_allocation_shares and cpu_allocation_shares parameters(idempotency check)
+- name: add resource pool
+  vmware_resource_pool:
+    validate_certs: False
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter: "{{ dc1 }}"
+    cluster: "{{ ccr1 }}"
+    resource_pool: test_resource_0001
+    mem_shares: custom
+    mem_allocation_shares: 1000
+    cpu_shares: custom
+    cpu_allocation_shares: 1000
+    state: present
+  register: resource_result_0006
+
+- name: ensure a resource pool is present
+  assert:
+    that:
+      - "{{ resource_result_0006.changed == false }}"
+
 # Testcase 0006: Remove Resource pool
 - name: remove resource pool again
   vmware_resource_pool:
@@ -130,9 +153,9 @@
     cluster: "{{ ccr1 }}"
     resource_pool: test_resource_0001
     state: absent
-  register: resource_result_0006
+  register: resource_result_0007
 
 - name: check if resource pool is removed
   assert:
     that:
-        - "{{ resource_result_0006.changed == true }}"
+        - "{{ resource_result_0007.changed == true }}"

--- a/tests/integration/targets/vmware_resource_pool/tasks/main.yml
+++ b/tests/integration/targets/vmware_resource_pool/tasks/main.yml
@@ -63,7 +63,7 @@
 
 
 # Testcase 0003: Remove Resource pool
-- name: add resource pool again
+- name: remove resource pool again
   vmware_resource_pool:
     validate_certs: False
     hostname: "{{ vcenter_hostname }}"
@@ -81,7 +81,7 @@
         - "{{ resource_result_0003.changed == true }}"
 
 # Testcase 0004: Remove Resource pool again
-- name: add resource pool again
+- name: remove resource pool again
   vmware_resource_pool:
     validate_certs: False
     hostname: "{{ vcenter_hostname }}"
@@ -97,3 +97,42 @@
   assert:
     that:
         - "{{ resource_result_0004.changed == false }}"
+
+# Testcase 0005: Add Resource pool with the mem_allocation_shares and cpu_allocation_shares parameters
+- name: add resource pool
+    validate_certs: False
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter: "{{ dc1 }}"
+    cluster: "{{ ccr1 }}"
+    resource_pool: test_resource_0001
+    mem_shares: custom
+    mem_allocation_shares: 1000
+    cpu_shares: custom
+    cpu_allocation_shares: 1000
+    state: present
+  register: resource_result_0005
+
+- name: ensure a resource pool is present
+  assert:
+    that:
+      - "{{ resource_result_0005.changed == true }}"
+
+# Testcase 0006: Remove Resource pool
+- name: remove resource pool again
+  vmware_resource_pool:
+    validate_certs: False
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter: "{{ dc1 }}"
+    cluster: "{{ ccr1 }}"
+    resource_pool: test_resource_0001
+    state: absent
+  register: resource_result_0006
+
+- name: check if resource pool is removed
+  assert:
+    that:
+        - "{{ resource_result_0006.changed == true }}"


### PR DESCRIPTION
##### SUMMARY

This PR is to add new allocation shares options for cpu and memory to the vmware_resource_pool module.

fixes: https://github.com/ansible-collections/community.vmware/issues/444

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/modules/vmware_resource_pool.py
tests/integration/targets/vmware_resource_pool/tasks/main.yml

##### ADDITIONAL INFORMATION

tested on vCenter/ESXi 7.0