### PR TITLE
vmware_guest_info: Add a new parameter to gather tag info

### DIFF
--- a/changelogs/fragments/vmware_guest_info.yml
+++ b/changelogs/fragments/vmware_guest_info.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- vmware_guest_info - added a new parameter to gather detailed information about tag from the given virtual machine.

--- a/tests/integration/targets/vmware_tag/tasks/tag_manager_ops.yml
+++ b/tests/integration/targets/vmware_tag/tasks/tag_manager_ops.yml
@@ -62,12 +62,26 @@
         name: "{{ vm_name }}"
       register: r
 
+    - name: Get detailed tags' information from a virtual machine
+      vmware_guest_info:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: no
+        name: "{{ vm_name }}"
+        tags: True
+        tag_details: True
+      register: tag_details
+
     - name: Check if tag information is available
       assert:
         that:
           - not r.changed
           - r['instance']['tags'] is defined
           - "{{ Tag_Name[0] in r['instance']['tags'] }}"
+          - not tag_details.changed
+          - tag_details['instance']['tags'] is defined
+          - "{{ Tag_Name[0] == tag_details['instance']['tags'][0]['name'] }}"
 
     - <<: *tag_assign
       name: Add tags to a virtual machine again


### PR DESCRIPTION
##### SUMMARY

vmware_guest_info returns tag information as a list of tag names.
With the new parameter 'tag_details', module returns detailed
information about tags and categories related to the given virtual machine.
This change is backward compatible and makes tag facts uniform across
all VMware modules.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/vmware_guest_info.yml
plugins/modules/vmware_guest_info.py
tests/integration/targets/vmware_tag/tasks/tag_manager_ops.yml
