### PR TITLE
vmware_category: Add addition associable types

### DIFF
--- a/changelogs/fragments/454_vmware_category.yml
+++ b/changelogs/fragments/454_vmware_category.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- vmware_category - add additional associable object types (https://github.com/ansible-collections/community.vmware/issues/454).

--- a/plugins/modules/vmware_category.py
+++ b/plugins/modules/vmware_category.py
@@ -213,7 +213,7 @@ class VmwareCategory(VmwareRestClient):
                 elif lower_obj_type == 'distributed port group':
                     obj_types_set.append('DistributedVirtualPortgroup')
                 elif lower_obj_type == 'distributed switch':
-                    obj_types_set.append('VmwareDistributedVirtualSwitch')
+                    obj_types_set.extend(['VmwareDistributedVirtualSwitch', 'DistributedVirtualSwitch'])
                 elif lower_obj_type == 'host':
                     obj_types_set.append('HostSystem')
                 elif lower_obj_type == 'library item':
@@ -225,7 +225,7 @@ class VmwareCategory(VmwareRestClient):
                 elif lower_obj_type == 'virtual machine':
                     obj_types_set.append('VirtualMachine')
                 elif lower_obj_type == 'network':
-                    obj_types_set.append('Network')
+                    obj_types_set.extend(['Network', 'HostNetwork', 'OpaqueNetwork'])
                 elif lower_obj_type == 'host network':
                     obj_types_set.append('HostNetwork')
                 elif lower_obj_type == 'opaque network':


### PR DESCRIPTION
##### SUMMARY

Following associable types
* Network - 'Network', 'HostNetwork', 'OpaqueNetwork'
* Distributed switch - 'VmwareDistributedVirtualSwitch', 'DistributedVirtualSwitch'

Fixes: #454

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/454_vmware_category.yml
plugins/modules/vmware_category.py
