### PR TITLE
vmware_deploy_ovf: support for networks with the same names in different datacenters

### DIFF
--- a/changelogs/fragments/vmware_deploy_ovf.yml
+++ b/changelogs/fragments/vmware_deploy_ovf.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- vmware_deploy_ovf - fixed network mapping in multi-datacenter environments

--- a/plugins/module_utils/vmware.py
+++ b/plugins/module_utils/vmware.py
@@ -194,8 +194,8 @@ def find_resource_pool_by_cluster(content, resource_pool_name='Resources', clust
     return find_object_by_name(content, resource_pool_name, [vim.ResourcePool], folder=cluster)
 
 
-def find_network_by_name(content, network_name):
-    return find_object_by_name(content, quote_obj_name(network_name), [vim.Network])
+def find_network_by_name(content, network_name, datacenter_name=None):
+    return find_object_by_name(content, quote_obj_name(network_name), [vim.Network], datacenter_name)
 
 
 def find_vm_by_id(content, vm_id, vm_id_type="vm_name", datacenter=None,

--- a/plugins/modules/vmware_deploy_ovf.py
+++ b/plugins/modules/vmware_deploy_ovf.py
@@ -357,7 +357,7 @@ class VMwareDeployOvf(PyVmomi):
             self.module.fail_json(msg='%(resource_pool)s could not be located' % self.params)
 
         for key, value in self.params['networks'].items():
-            network = find_network_by_name(self.content, value)
+            network = find_network_by_name(self.content, value, datacenter_name=self.datacenter)
             if not network:
                 self.module.fail_json(msg='%(network)s could not be located' % self.params)
             network_mapping = vim.OvfManager.NetworkMapping()


### PR DESCRIPTION
##### SUMMARY

Fixes an issue with vmware_deploy_ovf module throwing an error in cases when several datacenters have network(s) defined in mapping.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

plugins/module_utils/vmware.py
plugins/modules/vmware_deploy_ovf.py
