### PR TITLE
vmware_resource_pool: add a config changing feature

### DIFF
--- a/changelogs/fragments/469_vmware_resource_pool.yml
+++ b/changelogs/fragments/469_vmware_resource_pool.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_resource_pool - added a changing feature of resource pool config(https://github.com/ansible-collections/community.vmware/pull/469).

--- a/changelogs/fragments/469_vmware_resource_pool.yml
+++ b/changelogs/fragments/469_vmware_resource_pool.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - vmware_resource_pool - added a changing feature of resource pool config(https://github.com/ansible-collections/community.vmware/pull/469).
+  - vmware_resource_pool - added a changing feature of resource pool config (https://github.com/ansible-collections/community.vmware/pull/469).

--- a/plugins/modules/vmware_resource_pool.py
+++ b/plugins/modules/vmware_resource_pool.py
@@ -138,10 +138,16 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
+instance:
+    description: metadata about the new resource pool
+    returned: always
+    type: dict
+    sample: None
 resource_pool_config:
     description: config data about the resource pool
     returned: always
     type: dict
+    version_added: 1.4.0
     sample: >-
       {
         "_vimtype": "vim.ResourceConfigSpec",

--- a/plugins/modules/vmware_resource_pool.py
+++ b/plugins/modules/vmware_resource_pool.py
@@ -320,54 +320,52 @@ class VMwareResourcePool(PyVmomi):
 
         # check the difference between the existing config and the new config
         rp_spec = self.generate_rp_config()
-        resource_pool_obj = self.select_resource_pool()
-
-        if self.mem_shares and self.mem_shares != resource_pool_obj.config.memoryAllocation.shares.level:
+        if self.mem_shares and self.mem_shares != self.resource_pool_obj.config.memoryAllocation.shares.level:
             changed = True
             rp_spec.memoryAllocation.shares.level = self.mem_shares
 
         if self.mem_allocation_shares and self.mem_shares == 'custom':
-            if self.mem_allocation_shares != resource_pool_obj.config.memoryAllocation.shares.shares:
+            if self.mem_allocation_shares != self.resource_pool_obj.config.memoryAllocation.shares.shares:
                 changed = True
                 rp_spec.memoryAllocation.shares.shares = self.mem_allocation_shares
 
-        if self.mem_limit and self.mem_limit != resource_pool_obj.config.memoryAllocation.limit:
+        if self.mem_limit and self.mem_limit != self.resource_pool_obj.config.memoryAllocation.limit:
             changed = True
             rp_spec.memoryAllocation.limit = self.mem_limit
 
-        if self.mem_reservation and self.mem_reservation != resource_pool_obj.config.memoryAllocation.reservation:
+        if self.mem_reservation and self.mem_reservation != self.resource_pool_obj.config.memoryAllocation.reservation:
             changed = True
             rp_spec.memoryAllocation.reservation = self.mem_reservation
 
-        if self.mem_expandable_reservations != resource_pool_obj.config.memoryAllocation.expandableReservation:
+        if self.mem_expandable_reservations != self.resource_pool_obj.config.memoryAllocation.expandableReservation:
             changed = True
             rp_spec.memoryAllocation.expandableReservation = self.mem_expandable_reservations
 
-        if self.cpu_shares and self.cpu_shares != resource_pool_obj.config.cpuAllocation.shares.level:
+        if self.cpu_shares and self.cpu_shares != self.resource_pool_obj.config.cpuAllocation.shares.level:
             changed = True
             rp_spec.cpuAllocation.shares.level = self.cpu_shares
 
         if self.cpu_allocation_shares and self.cpu_shares == 'custom':
-            if self.cpu_allocation_shares != resource_pool_obj.config.cpuAllocation.shares.shares:
+            if self.cpu_allocation_shares != self.resource_pool_obj.config.cpuAllocation.shares.shares:
                 changed = True
                 rp_spec.cpuAllocation.shares.shares = self.cpu_allocation_shares
 
-        if self.cpu_limit and self.cpu_limit != resource_pool_obj.config.cpuAllocation.limit:
+        if self.cpu_limit and self.cpu_limit != self.resource_pool_obj.config.cpuAllocation.limit:
             changed = True
             rp_spec.cpuAllocation.limit = self.cpu_limit
 
-        if self.cpu_reservation and self.cpu_reservation != resource_pool_obj.config.cpuAllocation.reservation:
+        if self.cpu_reservation and self.cpu_reservation != self.resource_pool_obj.config.cpuAllocation.reservation:
             changed = True
             rp_spec.cpuAllocation.reservation = self.cpu_reservation
 
-        if self.cpu_expandable_reservations != resource_pool_obj.config.cpuAllocation.expandableReservation:
+        if self.cpu_expandable_reservations != self.resource_pool_obj.config.cpuAllocation.expandableReservation:
             changed = True
             rp_spec.cpuAllocation.expandableReservation = self.cpu_expandable_reservations
 
         if self.module.check_mode:
             self.module.exit_json(changed=changed)
 
-        resource_pool_obj.UpdateConfig(self.resource_pool, rp_spec)
+        self.resource_pool_obj.UpdateConfig(self.resource_pool, rp_spec)
 
         resource_pool_config = self.generate_rp_config_return_value(True)
         self.module.exit_json(changed=changed, resource_pool_config=resource_pool_config)
@@ -378,10 +376,9 @@ class VMwareResourcePool(PyVmomi):
         if self.module.check_mode:
             self.module.exit_json(changed=changed)
 
-        resource_pool_obj = self.select_resource_pool()
         resource_pool_config = self.generate_rp_config_return_value(True)
         try:
-            task = resource_pool_obj.Destroy()
+            task = self.resource_pool_obj.Destroy()
             success, result = wait_for_task(task)
 
         except Exception:
@@ -411,11 +408,11 @@ class VMwareResourcePool(PyVmomi):
         self.module.exit_json(changed=changed, resource_pool_config=resource_pool_config)
 
     def check_rp_state(self):
-        resource_pool_obj = self.select_resource_pool()
-        if resource_pool_obj is None:
+        self.resource_pool_obj = self.select_resource_pool()
+        if self.resource_pool_obj is None:
             return 'absent'
-        else:
-            return 'present'
+
+        return 'present'
 
 
 def main():

--- a/tests/integration/targets/vmware_resource_pool/aliases
+++ b/tests/integration/targets/vmware_resource_pool/aliases
@@ -1,4 +1,3 @@
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
-zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_resource_pool/tasks/main.yml
+++ b/tests/integration/targets/vmware_resource_pool/tasks/main.yml
@@ -8,212 +8,210 @@
     setup_attach_host: true
     setup_datastore: true
 
-# Testcase 0001: Add Resource pool
-- name: add resource pool
-  vmware_resource_pool:
-    validate_certs: False
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    datacenter: "{{ dc1 }}"
-    cluster: "{{ ccr1 }}"
-    resource_pool: test_resource_0001
-    mem_shares: normal
-    mem_limit: -1
-    mem_reservation: 0
-    mem_expandable_reservations: True
-    cpu_shares: normal
-    cpu_limit: -1
-    cpu_reservation: 0
-    cpu_expandable_reservations: True
-    state: present
-  register: resource_result_0001
+- name: set the vmware_resource_pool module default values
+  module_defaults:
+    vmware_resource_pool:
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      validate_certs: false
+      datacenter: "{{ dc1 }}"
+      cluster: "{{ ccr1 }}"
 
-- name: ensure a resource pool is present
-  assert:
-    that:
-        - "{{ resource_result_0001.changed == true }}"
+  block:
+    - name: add resource pool with check_mode
+      vmware_resource_pool:
+        resource_pool: test_resource_001
+      check_mode: true
+      register: resource_result_001
 
+    - assert:
+        that:
+          - resource_result_001.changed is sameas true
 
-# Testcase 0002: Add Resource pool again
-- name: add resource pool again
-  vmware_resource_pool:
-    validate_certs: False
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    datacenter: "{{ dc1 }}"
-    cluster: "{{ ccr1 }}"
-    resource_pool: test_resource_0001
-    mem_shares: normal
-    mem_limit: -1
-    mem_reservation: 0
-    mem_expandable_reservations: True
-    cpu_shares: normal
-    cpu_limit: -1
-    cpu_reservation: 0
-    cpu_expandable_reservations: True
-    state: present
-  register: resource_result_0002
+    - name: add resource pool
+      vmware_resource_pool:
+        resource_pool: test_resource_001
+      register: resource_result_002
 
-- name: check if nothing is changed
-  assert:
-    that:
-        - "{{ resource_result_0002.changed == false }}"
+    - assert:
+        that:
+          - resource_result_002.changed is sameas true
+          - resource_result_002.resource_pool_config is defined
+          - resource_result_002.resource_pool_config.name == "test_resource_001"
 
+    - name: add resource pool(idempotency check)
+      vmware_resource_pool:
+        resource_pool: test_resource_001
+      register: resource_result_003
 
-# Testcase 0003: Remove Resource pool
-- name: remove resource pool again
-  vmware_resource_pool:
-    validate_certs: False
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    datacenter: "{{ dc1 }}"
-    cluster: "{{ ccr1 }}"
-    resource_pool: test_resource_0001
-    state: absent
-  register: resource_result_0003
+    - assert:
+        that:
+          - resource_result_003.changed is sameas false
 
-- name: check if resource pool is removed
-  assert:
-    that:
-        - "{{ resource_result_0003.changed == true }}"
+    - name: change resource pool config with the custom default value and check_mode
+      vmware_resource_pool:
+        resource_pool: test_resource_001
+        mem_shares: custom
+        cpu_shares: custom
+      check_mode: true
+      register: resource_result_004
 
-# Testcase 0004: Remove Resource pool again
-- name: remove resource pool again
-  vmware_resource_pool:
-    validate_certs: False
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    datacenter: "{{ dc1 }}"
-    cluster: "{{ ccr1 }}"
-    resource_pool: test_resource_0001
-    state: absent
-  register: resource_result_0004
+    - assert:
+        that:
+          - resource_result_004.changed is sameas true
 
-- name: check if resource pool is already removed
-  assert:
-    that:
-        - "{{ resource_result_0004.changed == false }}"
+    - name: change resource pool config with the custom default value
+      vmware_resource_pool:
+        resource_pool: test_resource_001
+        mem_shares: custom
+        cpu_shares: custom
+      register: resource_result_005
 
-# Testcase 0005: Add Resource pool with the mem_allocation_shares and cpu_allocation_shares parameters
-- name: add resource pool
-  vmware_resource_pool:
-    validate_certs: False
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    datacenter: "{{ dc1 }}"
-    cluster: "{{ ccr1 }}"
-    resource_pool: test_resource_0001
-    mem_shares: custom
-    mem_allocation_shares: 1000
-    cpu_shares: custom
-    cpu_allocation_shares: 1000
-    state: present
-  register: resource_result_0005
+    - assert:
+        that:
+          - resource_result_005.changed is sameas true
+          - resource_result_005.resource_pool_config is defined
+          - resource_result_005.resource_pool_config.cpuAllocation.shares.level == 'custom'
+          - resource_result_005.resource_pool_config.cpuAllocation.shares.shares == 4000
+          - resource_result_005.resource_pool_config.memoryAllocation.shares.level == 'custom'
+          - resource_result_005.resource_pool_config.memoryAllocation.shares.shares == 163840
 
-- name: ensure a resource pool is present
-  assert:
-    that:
-      - "{{ resource_result_0005.changed == true }}"
+    - name: change resource pool config with the custom default value(idempotency check)
+      vmware_resource_pool:
+        resource_pool: test_resource_001
+        mem_shares: custom
+        cpu_shares: custom
+      register: resource_result_006
 
-# Testcase 0006: Add Resource pool with the mem_allocation_shares and cpu_allocation_shares parameters(idempotency check)
-- name: add resource pool
-  vmware_resource_pool:
-    validate_certs: False
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    datacenter: "{{ dc1 }}"
-    cluster: "{{ ccr1 }}"
-    resource_pool: test_resource_0001
-    mem_shares: custom
-    mem_allocation_shares: 1000
-    cpu_shares: custom
-    cpu_allocation_shares: 1000
-    state: present
-  register: resource_result_0006
+    - assert:
+        that:
+          - resource_result_006.changed is sameas false
+          - resource_result_006.resource_pool_config is defined
 
-- name: make sure a resource pool is not changing
-  assert:
-    that:
-      - "{{ resource_result_0006.changed == false }}"
+    - name: change resource pool config with the allocation_shares
+      vmware_resource_pool:
+        resource_pool: test_resource_001
+        mem_shares: custom
+        mem_allocation_shares: 1000
+        cpu_shares: custom
+        cpu_allocation_shares: 1000
+      register: resource_result_007
 
-# Testcase 0007: Remove Resource pool
-- name: remove resource pool
-  vmware_resource_pool:
-    validate_certs: False
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    datacenter: "{{ dc1 }}"
-    cluster: "{{ ccr1 }}"
-    resource_pool: test_resource_0001
-    state: absent
-  register: resource_result_0007
+    - assert:
+        that:
+          - resource_result_007.changed is sameas true
+          - resource_result_007.resource_pool_config is defined
+          - resource_result_007.resource_pool_config.cpuAllocation.shares.level == 'custom'
+          - resource_result_007.resource_pool_config.cpuAllocation.shares.shares == 1000
+          - resource_result_007.resource_pool_config.memoryAllocation.shares.level == 'custom'
+          - resource_result_007.resource_pool_config.memoryAllocation.shares.shares == 1000
 
-- name: check if resource pool is removed
-  assert:
-    that:
-        - "{{ resource_result_0007.changed == true }}"
+    - name: change resource pool config with the allocation_shares(idempotency check)
+      vmware_resource_pool:
+        resource_pool: test_resource_001
+        mem_shares: custom
+        mem_allocation_shares: 1000
+        cpu_shares: custom
+        cpu_allocation_shares: 1000
+      register: resource_result_008
 
-# Testcase 0008: Add Resource pool without the mem_allocation_shares and cpu_allocation_shares parameters
-- name: add resource pool
-  vmware_resource_pool:
-    validate_certs: False
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    datacenter: "{{ dc1 }}"
-    cluster: "{{ ccr1 }}"
-    resource_pool: test_resource_0001
-    mem_shares: custom
-    cpu_shares: custom
-    state: present
-  register: resource_result_0008
+    - assert:
+        that:
+          - resource_result_008.changed is sameas false
+          - resource_result_008.resource_pool_config is defined
 
-- name: ensure a resource pool is present
-  assert:
-    that:
-      - "{{ resource_result_0008.changed == true }}"
+    - name: change resource pool config with some option and check_mode
+      vmware_resource_pool:
+        resource_pool: test_resource_001
+        mem_shares: normal
+        mem_limit: 1
+        mem_reservation: 1
+        mem_expandable_reservations: false
+        cpu_shares: normal
+        cpu_limit: 1
+        cpu_reservation: 1
+        cpu_expandable_reservations: false
+      check_mode: true
+      register: resource_result_009
 
-# Testcase 0009: Add Resource pool without the mem_allocation_shares and cpu_allocation_shares parameters(idempotency check)
-- name: add resource pool
-  vmware_resource_pool:
-    validate_certs: False
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    datacenter: "{{ dc1 }}"
-    cluster: "{{ ccr1 }}"
-    resource_pool: test_resource_0001
-    mem_shares: custom
-    cpu_shares: custom
-    state: present
-  register: resource_result_0009
+    - assert:
+        that:
+          - resource_result_009.changed is sameas true
 
-- name: make sure a resource pool is not changing
-  assert:
-    that:
-      - "{{ resource_result_0009.changed == false }}"
+    - name: change resource pool config with some option
+      vmware_resource_pool:
+        resource_pool: test_resource_001
+        mem_shares: normal
+        mem_limit: 1
+        mem_reservation: 1
+        mem_expandable_reservations: false
+        cpu_shares: normal
+        cpu_limit: 1
+        cpu_reservation: 1
+        cpu_expandable_reservations: false
+      register: resource_result_010
 
-# Testcase 0010: Remove Resource pool
-- name: remove resource pool
-  vmware_resource_pool:
-    validate_certs: False
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    datacenter: "{{ dc1 }}"
-    cluster: "{{ ccr1 }}"
-    resource_pool: test_resource_0001
-    state: absent
-  register: resource_result_0010
+    - assert:
+        that:
+          - resource_result_010.changed is sameas true
+          - resource_result_010.resource_pool_config is defined
+          - resource_result_010.resource_pool_config.cpuAllocation.shares.level == 'normal'
+          - resource_result_010.resource_pool_config.cpuAllocation.limit == 1
+          - resource_result_010.resource_pool_config.cpuAllocation.reservation == 1
+          - resource_result_010.resource_pool_config.cpuAllocation.expandableReservation is sameas false
+          - resource_result_010.resource_pool_config.memoryAllocation.shares.level == 'normal'
+          - resource_result_010.resource_pool_config.memoryAllocation.limit == 1
+          - resource_result_010.resource_pool_config.memoryAllocation.reservation == 1
+          - resource_result_010.resource_pool_config.memoryAllocation.expandableReservation is sameas false
 
-- name: check if resource pool is removed
-  assert:
-    that:
-        - "{{ resource_result_0010.changed == true }}"
+    - name: change resource pool config with some option(idempotency check)
+      vmware_resource_pool:
+        resource_pool: test_resource_001
+        mem_shares: normal
+        mem_limit: 1
+        mem_reservation: 1
+        mem_expandable_reservations: false
+        cpu_shares: normal
+        cpu_limit: 1
+        cpu_reservation: 1
+        cpu_expandable_reservations: false
+      register: resource_result_011
+
+    - assert:
+        that:
+          - resource_result_011.changed is sameas false
+          - resource_result_011.resource_pool_config is defined
+
+    - name: remove resource pool with check_mode
+      vmware_resource_pool:
+        resource_pool: test_resource_001
+        state: absent
+      check_mode: true
+      register: resource_result_012
+
+    - assert:
+        that:
+          - resource_result_012.changed is sameas true
+
+    - name: remove resource pool
+      vmware_resource_pool:
+        resource_pool: test_resource_001
+        state: absent
+      register: resource_result_013
+
+    - assert:
+        that:
+          - resource_result_013.changed is sameas true
+          - resource_result_013.resource_pool_config is defined
+
+    - name: remove resource pool(idempotency check)
+      vmware_resource_pool:
+        resource_pool: test_resource_001
+        state: absent
+      register: resource_result_014
+
+    - assert:
+        that:
+          - resource_result_014.changed is sameas false
+          - resource_result_014.resource_pool_config is defined


### PR DESCRIPTION
##### SUMMARY

The vmware_resource_pool module hasn't had a config changing feature, so this PR adds it to the module.
The return key was written as `instance` in the RETURN block, but not defined in the module.  
So I changed the return key from `instance` to `resource_pool_config`.

The govcsim wasn't supported to change the expandableReservation, so I removed the govcsim from the alias file.  
The integration test for this module executes on vcenter_1esxi.

fixes: https://github.com/ansible-collections/community.vmware/issues/467

##### ISSUE TYPE

- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME

plugins/modules/vmware_resource_pool.py
tests/integration/targets/vmware_resource_pool/tasks/main.yml
tests/integration/targets/vmware_resource_pool/aliases

##### ADDITIONAL INFORMATION

tested on vCenter/ESXi 7.0