### PR TITLE
vmware_content_deploy_ovf_template: Make parameter optional

### DIFF
--- a/changelogs/fragments/420_resource_pool.yml
+++ b/changelogs/fragments/420_resource_pool.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- vmware_content_deploy_ovf_template - make resource pool, host, cluster optional parameter and add check (https://github.com/ansible-collections/community.vmware/issues/420).


### PR DESCRIPTION
##### SUMMARY

* Marked Hostname, Resource pool name and cluster name as optional
* Added appropriate check, doc changes and warning message
* User either has to specify cluster name or host name with resource pool name

Fixes: #420

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/420_resource_pool.yml
plugins/modules/vmware_content_deploy_ovf_template.py
