### PR TITLE
vmware_content_deploy_template: Make parameter optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Name | Description
 [community.vmware.vmware_drs_group](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_drs_group_module.rst)|Creates vm/host group in a given cluster.
 [community.vmware.vmware_drs_group_facts](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_drs_group_facts_module.rst)|Gathers facts about DRS VM/Host groups on the given cluster
 [community.vmware.vmware_drs_group_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_drs_group_info_module.rst)|Gathers info about DRS VM/Host groups on the given cluster
-[community.vmware.vmware_drs_group_manager](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_drs_group_manager_module.rst)|Manage VMs/Hosts group in the DRS group.
+[community.vmware.vmware_drs_group_manager](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_drs_group_manager_module.rst)|Manage VMs and Hosts in DRS group.
 [community.vmware.vmware_drs_rule_facts](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_drs_rule_facts_module.rst)|Gathers facts about DRS rule on the given cluster
 [community.vmware.vmware_drs_rule_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_drs_rule_info_module.rst)|Gathers info about DRS rule on the given cluster
 [community.vmware.vmware_dvs_host](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_dvs_host_module.rst)|Add or remove a host from distributed virtual switch

--- a/changelogs/fragments/397_vmware_content.yml
+++ b/changelogs/fragments/397_vmware_content.yml
@@ -1,0 +1,3 @@
+minor_changes:
+- vmware_content_deploy_template - make resource pool, host, cluster, datastore optional parameter and add check (https://github.com/ansible-collections/community.vmware/issues/397).
+- vmware_content_deploy_template - add datastore cluster parameter (https://github.com/ansible-collections/community.vmware/issues/397).

--- a/docs/community.vmware.vmware_content_deploy_template_module.rst
+++ b/docs/community.vmware.vmware_content_deploy_template_module.rst
@@ -57,6 +57,7 @@ Parameters
                 </td>
                 <td>
                         <div>Name of the cluster in datacenter in which to place deployed VM.</div>
+                        <div>Required if <em>resource_pool</em> is not specified.</div>
                 </td>
             </tr>
             <tr>
@@ -98,13 +99,32 @@ Parameters
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
-                         / <span style="color: red">required</span>
                     </div>
                 </td>
                 <td>
                 </td>
                 <td>
                         <div>Name of the datastore to store deployed VM and disk.</div>
+                        <div>Required if <em>datastore_cluster</em> is not provided.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>datastore_cluster</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.7.0</div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Name of the datastore cluster to store deployed VM and disk.</div>
+                        <div>Please make sure Storage DRS is active for recommended datastore from the given datastore cluster.</div>
+                        <div>If Storage DRS is not enabled, datastore with largest free storage space is selected.</div>
+                        <div>Required if <em>datastore</em> is not provided.</div>
                 </td>
             </tr>
             <tr>
@@ -130,13 +150,14 @@ Parameters
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
-                         / <span style="color: red">required</span>
                     </div>
                 </td>
                 <td>
                 </td>
                 <td>
                         <div>Name of the ESX Host in datacenter in which to place deployed VM.</div>
+                        <div>The host has to be a member of the cluster that contains the resource pool.</div>
+                        <div>Required with <em>resource_pool</em> to find resource pool details. This will be used as additional information when there are resource pools with same name.</div>
                 </td>
             </tr>
             <tr>
@@ -237,7 +258,10 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>Name of the resourcepool in datacenter in which to place deployed VM.</div>
+                        <div>Name of the resource pool in datacenter in which to place deployed VM.</div>
+                        <div>Required if <em>cluster</em> is not specified.</div>
+                        <div>For default or non-unique resource pool names, specify <em>host</em> and <em>cluster</em>.</div>
+                        <div><code>Resources</code> is the default name of resource pool.</div>
                 </td>
             </tr>
             <tr>
@@ -333,7 +357,7 @@ Notes
 Examples
 --------
 
-.. code-block:: yaml
+.. code-block:: yaml+jinja
 
     - name: Deploy Virtual Machine from template in content library
       community.vmware.vmware_content_deploy_template:

--- a/docs/community.vmware.vmware_drs_group_manager_module.rst
+++ b/docs/community.vmware.vmware_drs_group_manager_module.rst
@@ -5,7 +5,7 @@
 community.vmware.vmware_drs_group_manager
 *****************************************
 
-**Manage VMs/Hosts group in the DRS group.**
+**Manage VMs and Hosts in DRS group.**
 
 
 Version added: 1.7.0
@@ -17,7 +17,7 @@ Version added: 1.7.0
 
 Synopsis
 --------
-- The module can be used to add / remove VMs/Hosts groups in a given cluster.
+- The module can be used to add VMs / Hosts to or remove them from a DRS group.
 
 
 

--- a/plugins/modules/vmware_guest_cross_vc_clone.py
+++ b/plugins/modules/vmware_guest_cross_vc_clone.py
@@ -312,46 +312,6 @@ class CrossVCCloneManager(PyVmomi):
         self.clone_spec.powerOn = True if self.params['state'].lower() == 'poweredon' else False
         self.clone_spec.location = self.relocate_spec
 
-    def get_recommended_datastore(self, datastore_cluster_obj=None):
-        """
-        Function to return Storage DRS recommended datastore from datastore cluster
-        Args:
-            datastore_cluster_obj: datastore cluster managed object
-        Returns: Name of recommended datastore from the given datastore cluster
-        """
-        if datastore_cluster_obj is None:
-            return None
-        # Check if Datastore Cluster provided by user is SDRS ready
-        sdrs_status = datastore_cluster_obj.podStorageDrsEntry.storageDrsConfig.podConfig.enabled
-        if sdrs_status:
-            # We can get storage recommendation only if SDRS is enabled on given datastorage cluster
-            pod_sel_spec = vim.storageDrs.PodSelectionSpec()
-            pod_sel_spec.storagePod = datastore_cluster_obj
-            storage_spec = vim.storageDrs.StoragePlacementSpec()
-            storage_spec.podSelectionSpec = pod_sel_spec
-            storage_spec.type = 'create'
-
-            try:
-                rec = self.content.storageResourceManager.RecommendDatastores(storageSpec=storage_spec)
-                rec_action = rec.recommendations[0].action[0]
-                return rec_action.destination.name
-            except Exception:
-                # There is some error so we fall back to general workflow
-                pass
-        datastore = None
-        datastore_freespace = 0
-        for ds in datastore_cluster_obj.childEntity:
-            if isinstance(ds, vim.Datastore) and ds.summary.freeSpace > datastore_freespace:
-                # If datastore field is provided, filter destination datastores
-                if not self.is_datastore_valid(datastore_obj=ds):
-                    continue
-
-                datastore = ds
-                datastore_freespace = ds.summary.freeSpace
-        if datastore:
-            return datastore.name
-        return None
-
 
 def main():
     """


### PR DESCRIPTION
##### SUMMARY

* Marked Datastore, Hostname, Resource pool name, and cluster name as optional
* Added appropriate check, doc changes, and a warning message
* User should either has to specify cluster name or hostname with the resource pool name
* Added Datastore Cluster parameter

Fixes: #397 #550

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/397_vmware_content.yml
docs/community.vmware.vmware_content_deploy_template_module.rst
plugins/modules/vmware_content_deploy_template.py
plugins/module_utils/vmware.py
plugins/modules/vmware_guest.py
plugins/modules/vmware_guest_cross_vc_clone.py