### PR TITLE
vmware_host_scsidisk_info: new module

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Name | Description
 [community.vmware.vmware_host_powermgmt_policy](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_powermgmt_policy_module.rst)|Manages the Power Management Policy of an ESXI host system
 [community.vmware.vmware_host_powerstate](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_powerstate_module.rst)|Manages power states of host systems in vCenter
 [community.vmware.vmware_host_scanhba](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_scanhba_module.rst)|Rescan host HBA's and optionally refresh the storage system
+[community.vmware.vmware_host_scsidisk_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_scsidisk_info_module.rst)|Gather information about SCSI disk attached to the given ESXi
 [community.vmware.vmware_host_service_facts](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_service_facts_module.rst)|Gathers facts about an ESXi host's services
 [community.vmware.vmware_host_service_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_service_info_module.rst)|Gathers info about an ESXi host's services
 [community.vmware.vmware_host_service_manager](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_service_manager_module.rst)|Manage services on a given ESXi host

--- a/docs/community.vmware.vmware_host_scsidisk_info_module.rst
+++ b/docs/community.vmware.vmware_host_scsidisk_info_module.rst
@@ -1,0 +1,272 @@
+.. _community.vmware.vmware_host_scsidisk_info_module:
+
+
+******************************************
+community.vmware.vmware_host_scsidisk_info
+******************************************
+
+**Gather information about SCSI disk attached to the given ESXi**
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- This module can be used to gather information about SCSI disk attached to the given ESXi.
+
+
+
+Requirements
+------------
+The below requirements are needed on the host that executes this module.
+
+- Python >= 2.7
+- PyVmomi
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+            <th width="100%">Comments</th>
+        </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>cluster_name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Name of the cluster from which all host systems will be used.</div>
+                        <div>SCSI disk information about each ESXi server will be returned for the given cluster.</div>
+                        <div>This parameter is required if <em>esxi_hostname</em> is not specified.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>esxi_hostname</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Name of the host system to work with.</div>
+                        <div>SCSI disk information about this ESXi server will be returned.</div>
+                        <div>This parameter is required if <em>cluster_name</em> is not specified.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>hostname</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The hostname or IP address of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_HOST</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The password of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PASSWORD</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: pass, pwd</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">443</div>
+                </td>
+                <td>
+                        <div>The port number of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PORT</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>proxy_host</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Address of a proxy that will receive all HTTPS requests and relay them.</div>
+                        <div>The format is a hostname or a IP.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PROXY_HOST</code> will be used instead.</div>
+                        <div>This feature depends on a version of pyvmomi greater than v6.7.1.2018.12</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>proxy_port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Port of the HTTP proxy that will receive all HTTPS requests and relay them.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PROXY_PORT</code> will be used instead.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>username</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The username of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_USER</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: admin, user</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>validate_certs</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>no</li>
+                                    <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Allows connection when SSL certificates are not valid. Set to <code>false</code> when certificates are not trusted.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_VALIDATE_CERTS</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                        <div>If set to <code>yes</code>, please make sure Python &gt;= 2.7.9 is installed on the given machine.</div>
+                </td>
+            </tr>
+    </table>
+    <br/>
+
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    - name: Gather information SCSI disk attached to the given ESXi
+      community.vmware.vmware_host_scsidisk_info:
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        esxi_hostname: '{{ esxi_hostname }}'
+      delegate_to: localhost
+
+    - name: Gather information of all host systems from the given cluster
+      community.vmware.vmware_host_scsidisk_info:
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        cluster_name: '{{ cluster_name }}'
+      delegate_to: localhost
+
+
+
+Return Values
+-------------
+Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>hosts_scsidisk_info</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">dictionary</span>
+                    </div>
+                </td>
+                <td>always</td>
+                <td>
+                            <div>metadata about host system SCSI disk information</div>
+                    <br/>
+                        <div style="font-size: smaller"><b>Sample:</b></div>
+                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{&#x27;10.65.201.106&#x27;: [{&#x27;block&#x27;: 41943040, &#x27;block_size&#x27;: 512, &#x27;canonical_name&#x27;: &#x27;t10.ATA_QEMU_HARDDISK_QM00001_&#x27;, &#x27;device_name&#x27;: &#x27;/vmfs/devices/disks/t10.ATA_QEMU_HARDDISK_QM00001_&#x27;, &#x27;device_path&#x27;: &#x27;/vmfs/devices/disks/t10.ATA_QEMU_HARDDISK_QM00001_&#x27;, &#x27;device_type&#x27;: &#x27;disk&#x27;, &#x27;display_name&#x27;: &#x27;Local ATA Disk (t10.ATA_QEMU_HARDDISK_QM00001_)&#x27;, &#x27;key&#x27;: &#x27;key-vim.host.ScsiDisk-0100000000514d30303030312020202020202020202020202051454d552048&#x27;, &#x27;local_disk&#x27;: True, &#x27;lun_type&#x27;: &#x27;disk&#x27;, &#x27;model&#x27;: &#x27;QEMU HARDDISK   &#x27;, &#x27;perenniallyReserved&#x27;: None, &#x27;protocol_endpoint&#x27;: False, &#x27;revision&#x27;: &#x27;1.5.&#x27;, &#x27;scsi_disk_type&#x27;: &#x27;native512&#x27;, &#x27;scsi_level&#x27;: 5, &#x27;serial_number&#x27;: &#x27;unavailable&#x27;, &#x27;ssd&#x27;: False, &#x27;uuid&#x27;: &#x27;0100000000514d30303030312020202020202020202020202051454d552048&#x27;, &#x27;vStorageSupport&#x27;: &#x27;vStorageUnsupported&#x27;, &#x27;vendor&#x27;: &#x27;ATA     &#x27;}]}</div>
+                </td>
+            </tr>
+    </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Abhijeet Kasurde (@Akasurde)

--- a/plugins/modules/vmware_host_scsidisk_info.py
+++ b/plugins/modules/vmware_host_scsidisk_info.py
@@ -1,0 +1,174 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2018, Ansible Project
+# Copyright: (c) 2020, Abhijeet Kasurde <akasurde@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = r'''
+---
+module: vmware_host_scsidisk_info
+short_description: Gather information about SCSI disk attached to the given ESXi
+description:
+- This module can be used to gather information about SCSI disk attached to the given ESXi.
+author:
+- Abhijeet Kasurde (@Akasurde)
+requirements:
+- Python >= 2.7
+- PyVmomi
+options:
+  esxi_hostname:
+    description:
+    - Name of the host system to work with.
+    - SCSI disk information about this ESXi server will be returned.
+    - This parameter is required if I(cluster_name) is not specified.
+    type: str
+  cluster_name:
+    description:
+    - Name of the cluster from which all host systems will be used.
+    - SCSI disk information about each ESXi server will be returned for the given cluster.
+    - This parameter is required if I(esxi_hostname) is not specified.
+    type: str
+extends_documentation_fragment:
+- community.vmware.vmware.documentation
+'''
+
+EXAMPLES = r'''
+- name: Gather information SCSI disk attached to the given ESXi
+  community.vmware.vmware_host_scsidisk_info:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    esxi_hostname: '{{ esxi_hostname }}'
+  delegate_to: localhost
+
+- name: Gather information of all host systems from the given cluster
+  community.vmware.vmware_host_scsidisk_info:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    cluster_name: '{{ cluster_name }}'
+  delegate_to: localhost
+'''
+
+RETURN = r'''
+hosts_scsidisk_info:
+    description: metadata about host system SCSI disk information
+    returned: always
+    type: dict
+    sample: {
+        "10.65.201.106": [
+            {
+                "block": 41943040,
+                "block_size": 512,
+                "canonical_name": "t10.ATA_QEMU_HARDDISK_QM00001_",
+                "device_name": "/vmfs/devices/disks/t10.ATA_QEMU_HARDDISK_QM00001_",
+                "device_path": "/vmfs/devices/disks/t10.ATA_QEMU_HARDDISK_QM00001_",
+                "device_type": "disk",
+                "display_name": "Local ATA Disk (t10.ATA_QEMU_HARDDISK_QM00001_)",
+                "key": "key-vim.host.ScsiDisk-0100000000514d30303030312020202020202020202020202051454d552048",
+                "local_disk": true,
+                "lun_type": "disk",
+                "model": "QEMU HARDDISK   ",
+                "perenniallyReserved": null,
+                "protocol_endpoint": false,
+                "revision": "1.5.",
+                "scsi_disk_type": "native512",
+                "scsi_level": 5,
+                "serial_number": "unavailable",
+                "ssd": false,
+                "uuid": "0100000000514d30303030312020202020202020202020202051454d552048",
+                "vStorageSupport": "vStorageUnsupported",
+                "vendor": "ATA     "
+            }
+        ]
+    }
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, vmware_argument_spec
+
+
+class VmwareHostDiskManager(PyVmomi):
+    def __init__(self, module):
+        super(VmwareHostDiskManager, self).__init__(module)
+        cluster_name = self.params.get('cluster_name')
+        esxi_host_name = self.params.get('esxi_hostname')
+        self.hosts = self.get_all_host_objs(cluster_name=cluster_name, esxi_host_name=esxi_host_name)
+        if not self.hosts:
+            self.module.fail_json(msg="Failed to find host system with given configuration.")
+
+    def gather_disk_info(self):
+        """
+        Gather information about SCSI disks
+
+        """
+        results = dict(changed=False, hosts_scsidisk_info=dict())
+        for host in self.hosts:
+            disk_info = []
+            storage_system = host.configManager.storageSystem
+            for disk in storage_system.storageDeviceInfo.scsiLun:
+                temp_disk_info = {
+                    'device_name': disk.deviceName,
+                    'device_type': disk.deviceType,
+                    'key': disk.key,
+                    'uuid': disk.uuid,
+                    'canonical_name': disk.canonicalName,
+                    'display_name': disk.displayName,
+                    'lun_type': disk.lunType,
+                    'vendor': disk.vendor,
+                    'model': disk.model,
+                    'revision': disk.revision,
+                    'scsi_level': disk.scsiLevel,
+                    'serial_number': disk.serialNumber,
+                    'vStorageSupport': disk.vStorageSupport,
+                    'protocol_endpoint': disk.protocolEndpoint,
+                    'perenniallyReserved': disk.perenniallyReserved,
+                    'block_size': None,
+                    'block': None,
+                    'device_path': '',
+                    'ssd': False,
+                    'local_disk': False,
+                    'scsi_disk_type': None,
+                }
+                if hasattr(disk, 'capacity'):
+                    temp_disk_info['block_size'] = disk.capacity.blockSize
+                    temp_disk_info['block'] = disk.capacity.block
+                if hasattr(disk, 'devicePath'):
+                    temp_disk_info['device_path'] = disk.devicePath
+                if hasattr(disk, 'ssd'):
+                    temp_disk_info['ssd'] = disk.ssd
+                if hasattr(disk, 'localDisk'):
+                    temp_disk_info['local_disk'] = disk.localDisk
+                if hasattr(disk, 'scsiDiskType'):
+                    temp_disk_info['scsi_disk_type'] = disk.scsiDiskType
+
+                disk_info.append(temp_disk_info)
+            results['hosts_scsidisk_info'][host.name] = disk_info
+        self.module.exit_json(**results)
+
+
+def main():
+    argument_spec = vmware_argument_spec()
+    argument_spec.update(
+        esxi_hostname=dict(type='str', required=False),
+        cluster_name=dict(type='str', required=False),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        required_one_of=[
+            ['cluster_name', 'esxi_hostname'],
+        ]
+    )
+
+    host_scsidisk_manager = VmwareHostDiskManager(module)
+    host_scsidisk_manager.gather_disk_info()
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/vmware_host_scsidisk_info/aliases
+++ b/tests/integration/targets/vmware_host_scsidisk_info/aliases
@@ -1,0 +1,5 @@
+cloud/vcenter
+
+needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_1esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_host_scsidisk_info/tasks/main.yml
+++ b/tests/integration/targets/vmware_host_scsidisk_info/tasks/main.yml
@@ -1,0 +1,71 @@
+---
+# Test code for the vmware_host_scsidisk_info module.
+# Copyright: (c) 2020, Abhijeet Kasurde <akasurde@redhat.com>
+# GNU General Public License v3.0+
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_attach_host: true
+
+- name: Gather SCSI disks info about all hosts in given cluster
+  vmware_host_scsidisk_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    cluster_name: "{{ ccr1 }}"
+    validate_certs: false
+  register: all_hosts_disk_result
+
+- name: Ensure SCSI disks info are gathered for all hosts in given cluster
+  assert:
+    that:
+      - all_hosts_disk_result.hosts_scsidisk_info
+      - not all_hosts_disk_result.changed
+
+- name: Gather SCSI disks info about host system
+  vmware_host_scsidisk_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    esxi_hostname: '{{ esxi1 }}'
+    validate_certs: false
+  register: all_hosts_disk_result
+
+- name: Ensure SCSI disks info are gathered about host system
+  assert:
+    that:
+      - all_hosts_disk_result.hosts_scsidisk_info
+      - not all_hosts_disk_result.changed
+
+- name: Gather SCSI disks info about all hosts in given cluster in check mode
+  vmware_host_scsidisk_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    cluster_name: "{{ ccr1 }}"
+    validate_certs: false
+  register: all_hosts_disk_result_check_mode
+  check_mode: true
+
+- name: Ensure SCSI disks info are gathered for all hosts in given cluster
+  assert:
+    that:
+      - all_hosts_disk_result_check_mode.hosts_scsidisk_info
+      - not all_hosts_disk_result_check_mode.changed
+
+- name: Ensure SCSI disks info about host system in check mode
+  vmware_host_scsidisk_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    esxi_hostname: '{{ esxi1 }}'
+    validate_certs: false
+  register: all_hosts_disk_result_check_mode
+  check_mode: true
+
+- name: Ensure SCSI disks info are gathered about host system
+  assert:
+    that:
+      - all_hosts_disk_result_check_mode.hosts_scsidisk_info
+      - not all_hosts_disk_result_check_mode.changed


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/703

##### SUMMARY

Module to gather information about SCSI disks attached to
ESXi

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
README.md
docs/community.vmware.vmware_host_scsidisk_info_module.rst
plugins/modules/vmware_host_scsidisk_info.py
tests/integration/targets/vmware_host_scsidisk_info/aliases
tests/integration/targets/vmware_host_scsidisk_info/tasks/main.yml
