### PR TITLE
vmware_resource_pool: fix a bug that always updates the resource pool config

### DIFF
--- a/changelogs/fragments/482_vmware_resource_pool.yml
+++ b/changelogs/fragments/482_vmware_resource_pool.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_resource_pool - fixed that always updates occur bug on vCenter Server even when not changing resource pool config (https://github.com/ansible-collections/community.vmware/pull/482).

--- a/plugins/modules/vmware_resource_pool.py
+++ b/plugins/modules/vmware_resource_pool.py
@@ -371,7 +371,8 @@ class VMwareResourcePool(PyVmomi):
         if self.module.check_mode:
             self.module.exit_json(changed=changed)
 
-        self.resource_pool_obj.UpdateConfig(self.resource_pool, rp_spec)
+        if changed:
+            self.resource_pool_obj.UpdateConfig(self.resource_pool, rp_spec)
 
         resource_pool_config = self.generate_rp_config_return_value(True)
         self.module.exit_json(changed=changed, resource_pool_config=resource_pool_config)


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/703
##### SUMMARY

The vmware_resource_pool module has a bug that always updates the resource pool config.  
The result of the module is to display not changed when using the same resource pool config, but change event occurs on vCenter.  
This PR is to fix the above bug.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

plugins/modules/vmware_resource_pool.py

##### ADDITIONAL INFORMATION

tested on vCenter 7.0