### PR TITLE
vmware_vm_inventory: Ensure self.port is integer

### DIFF
--- a/changelogs/fragments/489_vmware_vm_inventory_port_cast_integer.yaml
+++ b/changelogs/fragments/489_vmware_vm_inventory_port_cast_integer.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-- vmware_vm_inventory - ensure self.port is integer (https://github.com/ansible-collections/community.vmware/pull/489).
+- vmware_vm_inventory - ensure self.port is integer (https://github.com/ansible-collections/community.vmware/issues/488).

--- a/changelogs/fragments/489_vmware_vm_inventory_port_cast_integer.yaml
+++ b/changelogs/fragments/489_vmware_vm_inventory_port_cast_integer.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- vmware_vm_inventory - ensure self.port is integer (https://github.com/ansible-collections/community.vmware/pull/489).

--- a/plugins/inventory/vmware_vm_inventory.py
+++ b/plugins/inventory/vmware_vm_inventory.py
@@ -46,6 +46,7 @@ DOCUMENTATION = r'''
         port:
             description: Port number used to connect to vCenter or ESXi Server.
             default: 443
+            type: int
             env:
               - name: VMWARE_PORT
         validate_certs:


### PR DESCRIPTION
##### SUMMARY
This patch ensure the `VMWARE_PORT` environment variable is an integer to avoid traceback mentioned on issue #448 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes: #488

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_vm_inventory

##### ADDITIONAL INFORMATION

```diff
(awx) [root@rh-tower-latest inventory]# diff -ruN vmware_vm_inventory.py-latest-collection vmware_vm_inventory.py 
--- vmware_vm_inventory.py-latest-collection	2020-11-09 14:28:36.940432717 -0500
+++ vmware_vm_inventory.py	2020-11-09 16:46:32.978181736 -0500
@@ -343,7 +343,7 @@
         self.hostname = hostname
         self.username = username
         self.password = password
-        self.port = port
+        self.port = int(port)
         self.with_tags = with_tags
         self.validate_certs = validate_certs
         self.content = None
```

**Ansible Tower ENV**
```json
(ansible) [root@rh-tower-latest ~]# curl -u admin -k -L https://$(hostname)/api/v2/settings/jobs | jq | grep AWX_TASK_ENV -A2 
Enter host password for user 'admin':

  "AWX_TASK_ENV": {
    "VMWARE_PORT": "9091"
  },
```
**rpdb python debugging**
```python
(ansible) [root@rh-tower-latest ~]# telnet localhost 4444
Trying ::1...
telnet: connect to address ::1: Connection refused
Trying 127.0.0.1...
telnet: connect to address 127.0.0.1: Connection refused
(ansible) [root@rh-tower-latest ~]# telnet localhost 4444
Trying ::1...
telnet: connect to address ::1: Connection refused
Trying 127.0.0.1...
Connected to localhost.
Escape character is '^]'.
> /var/lib/awx/vendor/inventory_collections/ansible_collections/community/vmware/plugins/inventory/vmware_vm_inventory.py(409)_login()
-> service_instance = None
(Pdb) self.port
9091
(Pdb) self.hostname
u'192.168.221.10'
(Pdb) self.username
u'test'
(Pdb) self.password
u'test'
(Pdb) l
404  	        if not self.validate_certs and hasattr(ssl, 'SSLContext'):
405  	            ssl_context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
406  	            ssl_context.verify_mode = ssl.CERT_NONE
407  	
408  	        import rpdb; rpdb.set_trace()
409  ->	        service_instance = None
410  	        try:
411  	            service_instance = connect.SmartConnect(host=self.hostname, user=self.username,
412  	                                                    pwd=self.password, sslContext=ssl_context,
413  	                                                    port=self.port)
414  	
(Pdb) n
> /var/lib/awx/vendor/inventory_collections/ansible_collections/community/vmware/plugins/inventory/vmware_vm_inventory.py(410)_login()
-> try:
(Pdb) n
> /var/lib/awx/vendor/inventory_collections/ansible_collections/community/vmware/plugins/inventory/vmware_vm_inventory.py(411)_login()
-> service_instance = connect.SmartConnect(host=self.hostname, user=self.username,
(Pdb) n
> /var/lib/awx/vendor/inventory_collections/ansible_collections/community/vmware/plugins/inventory/vmware_vm_inventory.py(412)_login()
-> pwd=self.password, sslContext=ssl_context,
(Pdb) n
> /var/lib/awx/vendor/inventory_collections/ansible_collections/community/vmware/plugins/inventory/vmware_vm_inventory.py(413)_login()
-> port=self.port)
(Pdb) n
```

**tcpdump showing it worked**
```
(awx) [root@rh-tower-latest inventory]# tcpdump  -Nnn -i eth0 host 192.168.221.10
tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
listening on eth0, link-type EN10MB (Ethernet), capture size 262144 bytes
16:45:09.418267 IP 192.168.169.112.36704 > 192.168.221.10.9091: Flags [S], seq 3627740504, win 29200, options [mss 1460,sackOK,TS val 345022460 ecr 0,nop,wscale 7], length 0
16:45:10.420140 IP 192.168.169.112.36704 > 192.168.221.10.9091: Flags [S], seq 3627740504, win 29200, options [mss 1460,sackOK,TS val 345023462 ecr 0,nop,wscale 7], length 0
```