### PR TITLE
vmware_guest_file_operation: provide error message

### DIFF
--- a/changelogs/fragments/485_vmware_file_operation.yml
+++ b/changelogs/fragments/485_vmware_file_operation.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- vmware_guest_file_operation - provide useful error message when exception occurs (https://github.com/ansible-collections/community.vmware/issues/485).

--- a/plugins/modules/vmware_guest_file_operation.py
+++ b/plugins/modules/vmware_guest_file_operation.py
@@ -349,6 +349,8 @@ class VmwareGuestFileManager(PyVmomi):
             url = fileTransferInfo.url
             url = url.replace("*", hostname)
             resp, info = urls.fetch_url(self.module, url, method="GET")
+            if info.get('status') != 200 or not resp:
+                self.module.fail_json(msg="Failed to fetch file : %s" % info.get('msg', ''), body=info.get('body', ''))
             try:
                 with open(dest, "wb") as local_file:
                     local_file.write(resp.read())


### PR DESCRIPTION
##### SUMMARY

Return useful error message when exception occurs while file
operation.

Partially fixes: #485

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/485_vmware_file_operation.yml
plugins/modules/vmware_guest_file_operation.py
