### PR TITLE
vmware_deploy_ovf: Fix the issue that the name variable referenced error occurs

### DIFF
--- a/changelogs/fragments/499-vmware_deploy_ovf.yml
+++ b/changelogs/fragments/499-vmware_deploy_ovf.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_deploy_ovf - fixed the issue that the name variable referenced error occurs when the check mode (https://github.com/ansible-collections/community.vmware/pull/499).

--- a/changelogs/fragments/499-vmware_deploy_ovf.yml
+++ b/changelogs/fragments/499-vmware_deploy_ovf.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - vmware_deploy_ovf - fixed the issue that the name variable referenced error occurs when the check mode (https://github.com/ansible-collections/community.vmware/pull/499).
+  - vmware_deploy_ovf - fixed an UnboundLocalError for variable 'name' in check mode (https://github.com/ansible-collections/community.vmware/pull/499).

--- a/plugins/modules/vmware_deploy_ovf.py
+++ b/plugins/modules/vmware_deploy_ovf.py
@@ -436,6 +436,7 @@ class VMwareDeployOvf(PyVmomi):
         for warning in getattr(self.import_spec, 'warning', []):
             self.module.warn('Problem validating OVF import spec: %s' % to_native(warning.msg))
 
+        name = self.params.get('name')
         if not self.params['allow_duplicates']:
             name = self.import_spec.importSpec.configSpec.name
             match = find_vm_by_name(self.content, name, folder=folder)


### PR DESCRIPTION
##### SUMMARY

The vmware_deploy_ovf module occurs the name variable referenced error when the check mode.  
This PR is to fix the above issue.

fixes: https://github.com/ansible-collections/community.vmware/issues/497

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

plugins/modules/vmware_deploy_ovf.py

##### ADDITIONAL INFORMATION

tested on vCenter/ESXi 7.0