### PR TITLE
vmware_vm_inventory: Skip inaccessible VM configuration

### DIFF
--- a/changelogs/fragments/inventory_fix.yml
+++ b/changelogs/fragments/inventory_fix.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- vmware_vm_inventory - skip inaccessible vm configuration.

--- a/plugins/inventory/vmware_vm_inventory.py
+++ b/plugins/inventory/vmware_vm_inventory.py
@@ -788,7 +788,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             for vm_obj_property in vm_obj.propSet:
                 properties[vm_obj_property.name] = vm_obj_property.val
 
-            if (properties.get('runtime.connectionState') or properties['runtime'].connectionState) == 'orphaned':
+            if (properties.get('runtime.connectionState') or properties['runtime'].connectionState) in ('orphaned', 'inaccessible'):
                 continue
 
             # Custom values


### PR DESCRIPTION
##### SUMMARY

Some VM configurations are in 'inaccessible' state, skip
over these kind of VMs.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/inventory_fix.yml
plugins/inventory/vmware_vm_inventory.py
