### PR TITLE
vmware_guest: Document networks connected and start_connected sub-options

### DIFF
--- a/changelogs/fragments/507-vmware_guest_fix-documentation.yml
+++ b/changelogs/fragments/507-vmware_guest_fix-documentation.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- vmware_guest - add documentation for networks parameters connected and start_connected (https://github.com/ansible-collections/community.vmware/issues/507).


### PR DESCRIPTION
##### SUMMARY
The `networks` parameter is missing two sub parameters in the document section.

Fixes #507

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
vmware_guest
