### PR TITLE
vmware_guest_network: fix for VMs in a Isolated Private VLAN portgroup

### DIFF
--- a/changelogs/fragments/pvlan_support.yml
+++ b/changelogs/fragments/pvlan_support.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- vmware_guest_network - add support for private vlan id (https://github.com/ansible-collections/community.vmware/pull/511).

--- a/plugins/modules/vmware_guest_network.py
+++ b/plugins/modules/vmware_guest_network.py
@@ -351,7 +351,7 @@ class PyVmomiHelper(PyVmomi):
         '''
         return network object matching given parameters
         :param vm_obj: vm object
-        :param network_params: dict containing parameters from deprectaed networks list method
+        :param network_params: dict containing parameters from deprecated networks list method
         :return: network object
         :rtype: object
         '''
@@ -380,7 +380,11 @@ class PyVmomiHelper(PyVmomi):
                     if (switch_name and dvs.config.name == switch_name) or not switch_name:
                         if network.config.name == network_name:
                             return network
-                        if network.config.defaultPortConfig.vlan.vlanId == vlan_id:
+                        if hasattr(network.config.defaultPortConfig.vlan, 'vlanId') and \
+                           network.config.defaultPortConfig.vlan.vlanId == vlan_id:
+                            return network
+                        if hasattr(network.config.defaultPortConfig.vlan, 'pvlanId') and \
+                           network.config.defaultPortConfig.vlan.pvlanId == vlan_id:
                             return network
                 elif isinstance(network, vim.Network):
                     if network_name and network_name == network.name:


### PR DESCRIPTION
##### SUMMARY
If a VM is in a Isolated Private VLAN, the _get_network_object() function fails because pvlanId property is used by VmwareDistributedVirtualSwitchPvlanSpec, rather than vlanId.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_guest_network

##### ADDITIONAL INFORMATION
Step-by-step: Create a Private VLAN isolated port group. Put a VM in that port group. Attempt to modify the networks of that VM using the vmware_guest_network module. The following error will occur:

```
The full traceback is:
Traceback (most recent call last):
  File "<stdin>", line 102, in <module>
  File "<stdin>", line 94, in _ansiballz_main
  File "<stdin>", line 40, in invoke_module
  File "/usr/lib/python3.9/runpy.py", line 210, in run_module
    return _run_module_code(code, init_globals, run_name, mod_spec)
  File "/usr/lib/python3.9/runpy.py", line 97, in _run_module_code
    _run_code(code, mod_globals, init_globals,
  File "/usr/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/tmp/ansible_community.vmware.vmware_guest_network_payload_2zitmcfg/ansible_community.vmware.vmware_guest_network_payload.zip/ansible_collections/community/vmware/plugins/modules/vmware_guest_network.py", line 886, in <module>
  File "/tmp/ansible_community.vmware.vmware_guest_network_payload_2zitmcfg/ansible_community.vmware.vmware_guest_network_payload.zip/ansible_collections/community/vmware/plugins/modules/vmware_guest_network.py", line 875, in main
  File "/tmp/ansible_community.vmware.vmware_guest_network_payload_2zitmcfg/ansible_community.vmware.vmware_guest_network_payload.zip/ansible_collections/community/vmware/plugins/modules/vmware_guest_network.py", line 706, in _nic_present
  File "/tmp/ansible_community.vmware.vmware_guest_network_payload_2zitmcfg/ansible_community.vmware.vmware_guest_network_payload.zip/ansible_collections/community/vmware/plugins/modules/vmware_guest_network.py", line 383, in _get_network_object
AttributeError: 'vim.dvs.VmwareDistributedVirtualSwitch.PvlanSpec' object has no attribute 'vlanId'
fatal: [vm]: FAILED! => changed=false
  module_stderr: |-
    Traceback (most recent call last):
      File "<stdin>", line 102, in <module>
      File "<stdin>", line 94, in _ansiballz_main
      File "<stdin>", line 40, in invoke_module
      File "/usr/lib/python3.9/runpy.py", line 210, in run_module
        return _run_module_code(code, init_globals, run_name, mod_spec)
      File "/usr/lib/python3.9/runpy.py", line 97, in _run_module_code
        _run_code(code, mod_globals, init_globals,
      File "/usr/lib/python3.9/runpy.py", line 87, in _run_code
        exec(code, run_globals)
      File "/tmp/ansible_community.vmware.vmware_guest_network_payload_2zitmcfg/ansible_community.vmware.vmware_guest_network_payload.zip/ansible_collections/community/vmware/plugins/modules/vmware_guest_network.py", line 886, in <module>
      File "/tmp/ansible_community.vmware.vmware_guest_network_payload_2zitmcfg/ansible_community.vmware.vmware_guest_network_payload.zip/ansible_collections/community/vmware/plugins/modules/vmware_guest_network.py", line 875, in main
      File "/tmp/ansible_community.vmware.vmware_guest_network_payload_2zitmcfg/ansible_community.vmware.vmware_guest_network_payload.zip/ansible_collections/community/vmware/plugins/modules/vmware_guest_network.py", line 706, in _nic_present
      File "/tmp/ansible_community.vmware.vmware_guest_network_payload_2zitmcfg/ansible_community.vmware.vmware_guest_network_payload.zip/ansible_collections/community/vmware/plugins/modules/vmware_guest_network.py", line 383, in _get_network_object
    AttributeError: 'vim.dvs.VmwareDistributedVirtualSwitch.PvlanSpec' object has no attribute 'vlanId'
  module_stdout: ''
  msg: |-
    MODULE FAILURE
    See stdout/stderr for the exact error
  rc: 1
```
