### PR TITLE
vmware_guest: use additional details to detect network

### DIFF
--- a/changelogs/fragments/502_vmware_guest.yml
+++ b/changelogs/fragments/502_vmware_guest.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- vmware_guest - use additional details for detecting network (https://github.com/ansible-collections/community.vmware/issues/502).

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -973,10 +973,7 @@ from ansible_collections.community.vmware.plugins.module_utils.vmware import (
     vmware_argument_spec,
     set_vm_power_state,
     PyVmomi,
-    find_dvs_by_name,
-    find_dvspg_by_name,
     wait_for_vm_ip,
-    quote_obj_name,
 )
 
 

--- a/tests/integration/targets/vmware_guest/tasks/network_negative_test.yml
+++ b/tests/integration/targets/vmware_guest/tasks/network_negative_test.yml
@@ -4,37 +4,6 @@
 
 - debug: var=f0
 
-- name: create new VMs with non-existent network
-  vmware_guest:
-    validate_certs: false
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    name: new_vm
-    guest_id: centos64Guest
-    datacenter: "{{ dc1 }}"
-    disk:
-      - size: 3mb
-        type: thin
-        datastore: "{{ rw_datastore }}"
-    networks:
-      - name: "Non existent VM"
-    hardware:
-        num_cpus: 1
-        memory_mb: 128
-    state: poweredoff
-    folder: "{{ f0 }}"
-  register: non_existent_network
-  ignore_errors: true
-
-- debug: var=non_existent_network
-
-- name: assert that no changes were not made
-  assert:
-    that:
-        - not (non_existent_network is changed)
-        - "'does not exist' in non_existent_network.msg"
-
 - name: create new VMs with network and with only IP
   vmware_guest:
     validate_certs: false


### PR DESCRIPTION
##### SUMMARY

Old logic used to get first found network by name. This
would fail in the scenario where user has same network name
in both DVSwitch and Standard Switch.

Fixes: #502

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/502_vmware_guest.yml
plugins/modules/vmware_guest.py
tests/integration/targets/vmware_guest/tasks/network_negative_test.yml
