### PR TITLE
vmware_object_role_permission: allow role names from web UI

### DIFF
--- a/changelogs/fragments/436_vmware_object_role_permission.yml
+++ b/changelogs/fragments/436_vmware_object_role_permission.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- vmware_object_role_permission - add support for role name presented in vSphere Web UI (https://github.com/ansible-collections/community.vmware/issues/436).


### PR DESCRIPTION
##### SUMMARY

User can now specify role names from the web UI while using
vmware_object_role_permission module.

Fixes: #436

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/436_vmware_object_role_permission.yml
plugins/modules/vmware_object_role_permission.py
