### PR TITLE
vmware_host_facts: add ESXi host current time info in host facts

### DIFF
--- a/changelogs/fragments/527-vmware_host_facts.yml
+++ b/changelogs/fragments/527-vmware_host_facts.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_host_facts - Add ESXi host current time info in returned host facts(https://github.com/ansible-collections/community.vmware/issues/527)

--- a/plugins/module_utils/vmware.py
+++ b/plugins/module_utils/vmware.py
@@ -15,6 +15,7 @@ import re
 import ssl
 import time
 import traceback
+import datetime
 from collections import OrderedDict
 from distutils.version import StrictVersion
 from random import randint
@@ -428,6 +429,38 @@ def gather_vm_facts(content, vm):
 
     facts['vnc'] = get_vnc_extraconfig(vm)
     return facts
+
+
+def ansible_date_time_facts(timestamp):
+    # timestamp is a datetime.datetime object
+    date_time_facts = {}
+    if timestamp is None:
+        return date_time_facts
+
+    utctimestamp = timestamp.astimezone(datetime.timezone.utc)
+
+    date_time_facts['year'] = timestamp.strftime('%Y')
+    date_time_facts['month'] = timestamp.strftime('%m')
+    date_time_facts['weekday'] = timestamp.strftime('%A')
+    date_time_facts['weekday_number'] = timestamp.strftime('%w')
+    date_time_facts['weeknumber'] = timestamp.strftime('%W')
+    date_time_facts['day'] = timestamp.strftime('%d')
+    date_time_facts['hour'] = timestamp.strftime('%H')
+    date_time_facts['minute'] = timestamp.strftime('%M')
+    date_time_facts['second'] = timestamp.strftime('%S')
+    date_time_facts['epoch'] = timestamp.strftime('%s')
+    if date_time_facts['epoch'] == '' or date_time_facts['epoch'][0] == '%':
+        date_time_facts['epoch'] = str(int(epoch_ts))
+    date_time_facts['date'] = timestamp.strftime('%Y-%m-%d')
+    date_time_facts['time'] = timestamp.strftime('%H:%M:%S')
+    date_time_facts['iso8601_micro'] = utctimestamp.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    date_time_facts['iso8601'] = utctimestamp.strftime("%Y-%m-%dT%H:%M:%SZ")
+    date_time_facts['iso8601_basic'] = timestamp.strftime("%Y%m%dT%H%M%S%f")
+    date_time_facts['iso8601_basic_short'] = timestamp.strftime("%Y%m%dT%H%M%S")
+    date_time_facts['tz'] = timestamp.strftime("%Z")
+    date_time_facts['tz_offset'] = timestamp.strftime("%z")
+
+    return date_time_facts
 
 
 def deserialize_snapshot_obj(obj):

--- a/plugins/module_utils/vmware.py
+++ b/plugins/module_utils/vmware.py
@@ -449,8 +449,6 @@ def ansible_date_time_facts(timestamp):
     date_time_facts['minute'] = timestamp.strftime('%M')
     date_time_facts['second'] = timestamp.strftime('%S')
     date_time_facts['epoch'] = timestamp.strftime('%s')
-    if date_time_facts['epoch'] == '' or date_time_facts['epoch'][0] == '%':
-        date_time_facts['epoch'] = str(int(epoch_ts))
     date_time_facts['date'] = timestamp.strftime('%Y-%m-%d')
     date_time_facts['time'] = timestamp.strftime('%H:%M:%S')
     date_time_facts['iso8601_micro'] = utctimestamp.strftime("%Y-%m-%dT%H:%M:%S.%fZ")

--- a/plugins/modules/vmware_host_facts.py
+++ b/plugins/modules/vmware_host_facts.py
@@ -229,10 +229,16 @@ ansible_facts:
     }
 '''
 
+import datetime
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 from ansible.module_utils.common.text.formatters import bytes_to_human
-from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, vmware_argument_spec, find_obj
+from ansible_collections.community.vmware.plugins.module_utils.vmware import (
+    PyVmomi,
+    vmware_argument_spec,
+    find_obj,
+    ansible_date_time_facts
+)
 
 try:
     from pyVmomi import vim
@@ -270,7 +276,7 @@ class VMwareHostFactManager(PyVmomi):
         ansible_facts.update(self.get_system_facts())
         ansible_facts.update(self.get_vsan_facts())
         ansible_facts.update(self.get_cluster_facts())
-        ansible_facts.update({'host_current_time': self.esxi_time})
+        ansible_facts.update({'host_date_time': ansible_date_time_facts(self.esxi_time)})
         if self.params.get('show_tag'):
             vmware_client = VmwareRestClient(self.module)
             tag_info = {

--- a/plugins/modules/vmware_host_facts.py
+++ b/plugins/modules/vmware_host_facts.py
@@ -253,8 +253,10 @@ class VMwareHostFactManager(PyVmomi):
             if len(self.host) > 1:
                 self.module.fail_json(msg="esxi_hostname matched multiple hosts")
             self.host = self.host[0]
+            self.esxi_time = None
         else:
             self.host = find_obj(self.content, [vim.HostSystem], None)
+            self.esxi_time = self.si.CurrentTime()
 
         if self.host is None:
             self.module.fail_json(msg="Failed to find host system.")
@@ -268,6 +270,7 @@ class VMwareHostFactManager(PyVmomi):
         ansible_facts.update(self.get_system_facts())
         ansible_facts.update(self.get_vsan_facts())
         ansible_facts.update(self.get_cluster_facts())
+        ansible_facts.update({'host_current_time': self.esxi_time})
         if self.params.get('show_tag'):
             vmware_client = VmwareRestClient(self.module)
             tag_info = {

--- a/plugins/modules/vmware_host_facts.py
+++ b/plugins/modules/vmware_host_facts.py
@@ -229,7 +229,6 @@ ansible_facts:
     }
 '''
 
-import datetime
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 from ansible.module_utils.common.text.formatters import bytes_to_human

--- a/tests/integration/targets/vmware_host_facts/tasks/main.yml
+++ b/tests/integration/targets/vmware_host_facts/tasks/main.yml
@@ -91,3 +91,32 @@
           - "'numCpuCores' in facts['ansible_facts']['hardware']['cpuInfo']"
           - "'product' in facts['ansible_facts']['config']"
           - "'apiVersion' in facts['ansible_facts']['config']['product']"
+
+    - name: check host current time through a vcenter
+      vmware_host_facts:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        esxi_hostname: '{{ esxi1 }}'
+      register: facts
+    - debug: var=facts
+    - name: verify host_current_time
+      assert:
+        that:
+          - "'host_current_time' in facts['ansible_facts']"
+          - facts['ansible_facts']['host_current_time'] == None
+
+    - name: check host current time through a host
+      vmware_host_facts:
+        validate_certs: false
+        hostname: '{{ esxi1 }}'
+        username: '{{ esxi_user }}'
+        password: '{{ esxi_password }}'
+      register: facts
+    - debug: var=facts
+    - name: verify host_current_time
+      assert:
+        that:
+          - "'host_current_time' in facts['ansible_facts']"
+          - facts['ansible_facts']['host_current_time'] != None

--- a/tests/integration/targets/vmware_host_facts/tasks/main.yml
+++ b/tests/integration/targets/vmware_host_facts/tasks/main.yml
@@ -101,11 +101,11 @@
         esxi_hostname: '{{ esxi1 }}'
       register: facts
     - debug: var=facts
-    - name: verify host_current_time
+    - name: verify host_date_time
       assert:
         that:
-          - "'host_current_time' in facts['ansible_facts']"
-          - facts['ansible_facts']['host_current_time'] == None
+          - "'host_date_time' in facts['ansible_facts']"
+          - facts['ansible_facts']['host_date_time'] == {}
 
     - name: check host current time through a host
       vmware_host_facts:
@@ -115,8 +115,8 @@
         password: '{{ esxi_password }}'
       register: facts
     - debug: var=facts
-    - name: verify host_current_time
+    - name: verify host_date_time
       assert:
         that:
-          - "'host_current_time' in facts['ansible_facts']"
-          - facts['ansible_facts']['host_current_time'] != None
+          - "'host_date_time' in facts['ansible_facts']"
+          - facts['ansible_facts']['host_date_time'] != {}


### PR DESCRIPTION
Depends-On: #553

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #527 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_host_facts

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Added info "host_current_time": "2020-11-30T08:43:56.472599+00:00",
```paste below
TASK [debug] ***********************************************************************************************************************************
ok: [localhost] => {
    "esxi_host_results": {
        "ansible_facts": {
            "ansible_all_ipv4_addresses": [
                "192.168.104.7"
            ], 
            "ansible_bios_date": "2017-01-17T00:00:00+00:00", 
            "ansible_bios_version": "2.4.3", 
            "ansible_datastore": [
                {
                    "free": "928.01 GB", 
                    "name": "test-ds", 
                    "total": "3.00 TB"
                }, 
            ], 
            "ansible_distribution": "VMware ESXi", 
            "ansible_distribution_build": "14320388", 
            "ansible_distribution_version": "6.7.0", 
            "ansible_hostname": "test-esxi", 
            "ansible_in_maintenance_mode": false, 
            "ansible_interfaces": [
                "vmk0", 
                "vmk1"
            ], 
            "ansible_memfree_mb": 19378, 
            "ansible_memtotal_mb": 65442, 
            "ansible_os_type": "vmnix-x86", 
            "ansible_processor": "Intel(R) Xeon(R) CPU E5-2630 v4 @ 2.20GHz", 
            "ansible_processor_cores": 20, 
            "ansible_processor_count": 2, 
            "ansible_processor_vcpus": 40, 
            "ansible_product_name": "PowerEdge R630", 
            "ansible_product_serial": "GVVLNK2", 
            "ansible_system_vendor": "Dell Inc.", 
            "ansible_uptime": 4308832, 
            "ansible_uuid": "4c4c4544-0056-5610-804c-c7c04f4e4b32", 
            "ansible_vmk0": {
                "device": "vmk0", 
                "ipv4": {
                    "address": "xx.xx.xx.xx", 
                    "netmask": "255.255.255.0"
                }, 
                "macaddress": "80:18:44:e3:45:78", 
                "mtu": 1500
            }, 
            "ansible_vmk1": {
                "device": "vmk1", 
                "ipv4": {
                    "address": "192.168.104.7", 
                    "netmask": "255.255.254.0"
                }, 
                "macaddress": "00:50:56:65:d1:d2", 
                "mtu": 1500
            }, 
            "cluster": null, 
            "host_current_time": "2020-11-30T08:43:56.472599+00:00", 
            "vsan_cluster_uuid": null, 
            "vsan_health": "unknown", 
            "vsan_node_uuid": null
        }, 
        "changed": false, 
        "failed": false
    }
}
```
