### PR TITLE
WIP: Improve vmware_dvs_portgroup module

### DIFF
--- a/changelogs/fragments/500-vmware_dvs_portgroup.yml
+++ b/changelogs/fragments/500-vmware_dvs_portgroup.yml
@@ -1,0 +1,3 @@
+deprecated_features:
+- vmware_dvs_portgroup - the ``portgroup_type`` option will be replaced by ``port_binding`` option. It is now deprecated, and will be removed in 2.0.0 (https://github.com/ansible-collections/community.vmware/pull/531).
+- vmware_dvs_portgroup - the ``vlan_trunk`` option is obsolete because the trunk range is specified with the ``vlan_trunk_range`` option. It is now deprecated, and will be removed in 2.0.0 (https://github.com/ansible-collections/community.vmware/pull/531).

--- a/plugins/modules/vmware_dvs_portgroup.py
+++ b/plugins/modules/vmware_dvs_portgroup.py
@@ -1381,5 +1381,6 @@ def main():
     vmware_dvs_portgroup = VMwareDvsPortgroup(module)
     vmware_dvs_portgroup.process_state()
 
+
 if __name__ == '__main__':
     main()

--- a/plugins/modules/vmware_dvs_portgroup.py
+++ b/plugins/modules/vmware_dvs_portgroup.py
@@ -3,6 +3,7 @@
 
 # Copyright: (c) 2015, Joseph Callen <jcallen () csc.com>
 # Copyright: (c) 2017, Ansible Project
+# Copyright: (c) 2018, Christian Kotte (@ckotte)
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -17,75 +18,110 @@ description:
     - Create or remove a Distributed vSwitch portgroup.
 author:
     - Joseph Callen (@jcpowermac)
-    - Philippe Dellaert (@pdellaert) <philippe@dellaert.org>
+    - Philippe Dellaert (@pdellaert)
+    - Christian Kotte (@ckotte)
 notes:
     - Tested on vSphere 5.5, 6.5
 requirements:
     - "python >= 2.6"
     - PyVmomi
 options:
-    portgroup_name:
+    portgroup:
         description:
             - The name of the portgroup that is to be created or deleted.
         required: True
         type: str
-    switch_name:
+        aliases: ['portgroup_name']
+    switch:
         description:
             - The name of the distributed vSwitch the port group should be created on.
         required: True
         type: str
-    vlan_id:
+        aliases: ['switch_name']
+    description:
         description:
-            - The VLAN ID that should be configured with the portgroup, use 0 for no VLAN.
-            - 'If C(vlan_trunk) is configured to be I(true), this can be a combination of multiple ranges and numbers, example: 1-200, 205, 400-4094.'
-            - The valid C(vlan_id) range is from 0 to 4094. Overlapping ranges are allowed.
-            - 'If C(vlan_private) is configured to be I(true), the corresponding private VLAN should already be configured in the distributed vSwitch.'
-        required: True
+            - The description of the portgroup.
         type: str
+        aliases: ['portgroup_description']
     num_ports:
         description:
             - The number of ports the portgroup should contain.
-        required: True
+            - The number of ports for a new portgroup will be 0 if not specified.
+            - The vSphere Client uses 8 by default.
+            - This option will be ignored if I(port_binding) is set to C(ephemeral).
+        aliases: ['ports']
         type: int
     portgroup_type:
         description:
             - See VMware KB 1022312 regarding portgroup types.
-        required: True
-        choices:
-            - 'earlyBinding'
-            - 'lateBinding'
-            - 'ephemeral'
+            - Deprecated. Will be removed in collection 2.0.0.
+        choices: ['earlyBinding', 'lateBinding', 'ephemeral']
+        type: str
+    port_binding:
+        description:
+            - The type of port binding determines when ports in a port group are assigned to virtual machines.
+            - Valid attributes are C(static), C(dynamic), or C(ephemeral).
+            - See VMware KB 1022312 U(https://kb.vmware.com/s/article/1022312) for more details.
+        choices: ['static', 'dynamic', 'ephemeral']
+        default: 'static'
+        type: str
+        version_added: '1.7.0'
+    port_allocation:
+        description:
+            - Elastic port groups automatically increase or decrease the number of ports as needed.
+            - Only valid if I(port_binding) is set to C(static).
+            - Will be C(elastic) if not specified and I(port_binding) is set to C(static).
+        choices: ['fixed', 'elastic']
+        type: str
+        version_added: '1.7.0'
+    network_resource_pool:
+        description:
+            - The Network Resource Pool the portgroup should be assigned to.
+        default: 'default'
+        version_added: '1.7.0'
         type: str
     state:
         description:
             - Determines if the portgroup should be present or not.
-        required: True
         type: str
-        choices:
-            - 'present'
-            - 'absent'
+        choices: ['present', 'absent']
+        default: 'present'
+    vlan_id:
+        description:
+            - The VLAN ID that should be configured with the portgroup, use 0 for no VLAN.
+        type: int
+        default: 0
+        required: False
+    private_vlan_id:
+        description:
+            - The secondary private VLAN ID.
+            - The secondary private VLAN ID need to be configured on the dvSwitch first.
+        type: int
+        version_added: '1.7.0'
+    vlan_trunk_range:
+        description:
+            - The VLAN trunk range that should be configured with the portgroup.
+            - "This can be a combination of multiple ranges and numbers, example: [ 1-200, 205, 400-4094 ]."
+            - "The default VLAN trunk range in the vSphere Client is [ 0-4094 ]."
+        type: list
+        elements: str
+        version_added: '1.7.0'
     vlan_trunk:
         description:
             - Indicates whether this is a VLAN trunk or not.
-            - Mutually exclusive with C(vlan_private) parameter.
+            - Deprecated. Will be removed in collection 2.0.0.
         required: False
         default: False
         type: bool
-    vlan_private:
-        description:
-            - Indicates whether this is for a private VLAN or not.
-            - Mutually exclusive with C(vlan_trunk) parameter.
-        required: False
-        default: False
-        type: bool
-    network_policy:
+    security:
         description:
             - Dictionary which configures the different security values for portgroup.
         suboptions:
-            promiscuous:
+            promiscuous_mode:
                 type: bool
                 description: Indicates whether promiscuous mode is allowed.
                 default: False
+                aliases: ['promiscuous']
             forged_transmits:
                 type: bool
                 description: Indicates whether forged transmits are allowed.
@@ -96,126 +132,129 @@ options:
                 default: False
         required: False
         default: {
-            promiscuous: False,
+            promiscuous_mode: False,
             forged_transmits: False,
             mac_changes: False,
         }
         type: dict
-    teaming_policy:
+        aliases: ['network_policy', 'security_policy']
+    teaming:
         description:
             - Dictionary which configures the different teaming values for portgroup.
         suboptions:
-            load_balance_policy:
-                description:
-                - Network adapter teaming policy.
-                - C(loadbalance_loadbased) is available from version 2.6 and onwards.
-                default: 'loadbalance_srcid'
+            load_balancing:
                 type: str
-                choices:
-                - loadbalance_ip
-                - loadbalance_srcmac
-                - loadbalance_srcid
-                - loadbalance_loadbased
-                - failover_explicit
+                description: Network adapter teaming policy.
+                choices: ['loadbalance_ip', 'loadbalance_srcmac', 'loadbalance_srcid', 'loadbalance_loadbased', 'failover_explicit']
+                default: loadbalance_srcid
+                aliases: ['load_balancing_policy']
+            network_failure_detection:
+                type: str
+                description: Network failure detection.
+                choices: ['link_status_only', 'beacon_probing']
+                default: link_status_only
             notify_switches:
-                description:
-                - Indicate whether or not to notify the physical switch if a link fails.
+                type: bool
+                description: Indicate whether or not to notify the physical switch if a link fails.
                 default: True
+            failback:
                 type: bool
-            inbound_policy:
+                description: Indicate whether or not to use a failback when restoring links.
+                aliases: ['rolling_order']
+                default: True
+            active_uplinks:
+                type: list
+                elements: str
+                description: List of active uplinks used for load balancing.
+            standby_uplinks:
+                type: list
+                elements: str
                 description:
-                - Indicate whether or not the teaming policy is applied to inbound frames as well.
-                type: bool
-                default: False
-            rolling_order:
-                description:
-                - Indicate whether or not to use a rolling policy when restoring links.
-                default: False
-                type: bool
-        default: {
-            'notify_switches': True,
-            'load_balance_policy': 'loadbalance_srcid',
-            'inbound_policy': False,
-            'rolling_order': False
-        }
+                - List of standby uplinks used for failover.
+                - All uplinks are used as active uplinks if C(active_uplinks) and C(standby_uplinks) are not defined.
+        required: False
         type: dict
-    port_policy:
+        default: {
+            'load_balancing': 'loadbalance_srcid',
+            'network_failure_detection': 'link_status_only',
+            'notify_switches': True,
+            'failback': True,
+        }
+        aliases: ['teaming_policy']
+    advanced:
         description:
-        - Dictionary which configures the advanced policy settings for the portgroup.
+            - Dictionary which configures the advanced policy settings for the portgroup.
         suboptions:
             block_override:
-                description:
-                - Indicates if the block policy can be changed per port.
+                type: bool
+                description: Indicates if the block policy can be changed per port.
                 default: True
+            netflow_override:
                 type: bool
-            port_config_reset_at_disconnect:
-                description:
-                - Indicates if the configuration of a port is reset automatically after disconnect.
-                default: True
-                type: bool
-                required: False
-            ipfix_override:
-                description:
-                - Indicates if the ipfix policy can be changed per port.
+                description: Indicates if the NetFlow policy can be changed per port.
                 default: False
-                type: bool
-            live_port_move:
-                description:
-                - Indicates if a live port can be moved in or out of the portgroup.
-                default: False
-                type: bool
+                aliases: ['ipfix_override']
             network_rp_override:
-                description:
-                - Indicates if the network resource pool can be changed per port.
-                default: False
                 type: bool
+                description: Indicates if the network resource pool can be changed per port.
+                default: false
+            port_config_reset_at_disconnect:
+                type: bool
+                description: Indicates if the configuration of a port is reset automatically after disconnect.
+                default: True
             security_override:
-                description:
-                - Indicates if the security policy can be changed per port.
-                default: False
                 type: bool
+                description: Indicates if the security policy can be changed per port.
+                default: False
             shaping_override:
-                description:
-                - Indicates if the shaping policy can be changed per port.
-                default: False
                 type: bool
+                description: Indicates if the shaping policy can be changed per port.
+                default: False
             traffic_filter_override:
-                description:
-                - Indicates if the traffic filter can be changed per port.
-                default: False
                 type: bool
+                description: Indicates if the traffic filter can be changed per port.
+                default: False
             uplink_teaming_override:
-                description:
-                - Indicates if the uplink teaming policy can be changed per port.
+                type: bool
+                description: Indicates if the uplink teaming policy can be changed per port.
                 default: False
-                type: bool
             vendor_config_override:
-                description:
-                - Indicates if the vendor config can be changed per port.
                 type: bool
+                description: Indicates if the vendor config can be changed per port.
                 default: False
             vlan_override:
-                description:
-                - Indicates if the vlan can be changed per port.
                 type: bool
+                description: Indicates if the vlan can be changed per port.
                 default: False
-        default: {
-            'traffic_filter_override': False,
-            'network_rp_override': False,
-            'live_port_move': False,
-            'security_override': False,
-            'vendor_config_override': False,
-            'port_config_reset_at_disconnect': True,
-            'uplink_teaming_override': False,
-            'block_override': True,
-            'shaping_override': False,
-            'vlan_override': False,
-            'ipfix_override': False
-        }
         type: dict
+        required: False
+        default: {
+            'block_override': True,
+            'netflow_override': False,
+            'network_rp_override': False,
+            'port_config_reset_at_disconnect': True,
+            'security_override': False,
+            'shaping_override': False,
+            'traffic_filter_override': False,
+            'uplink_teaming_override': False,
+            'vendor_config_override': False,
+            'vlan_override': False
+        }
+        aliases: ['port_policy']
+    netflow_enabled:
+        description:
+            - Indicates if NetFlow is enabled on the uplink portgroup.
+        type: bool
+        default: False
+        version_added: '1.7.0'
+    block_all_ports:
+        description:
+            - Indicates if all ports are blocked on the uplink portgroup.
+        type: bool
+        default: False
+        version_added: '1.7.0'
 extends_documentation_fragment:
 - community.vmware.vmware.documentation
-
 '''
 
 EXAMPLES = r'''
@@ -224,11 +263,10 @@ EXAMPLES = r'''
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
-    portgroup_name: vlan-123-portrgoup
-    switch_name: dvSwitch
+    portgroup: vlan-123-portrgoup
+    switch: dvSwitch
     vlan_id: 123
     num_ports: 120
-    portgroup_type: earlyBinding
     state: present
   delegate_to: localhost
 
@@ -237,71 +275,126 @@ EXAMPLES = r'''
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
-    portgroup_name: vlan-trunk-portrgoup
-    switch_name: dvSwitch
-    vlan_id: 1-1000, 1005, 1100-1200
-    vlan_trunk: True
+    portgroup: vlan-trunk-portgroup
+    switch: dvSwitch
+    vlan_trunk_range:
+      - 1-1000
+      - 1005
+      - 1100-1200
     num_ports: 120
-    portgroup_type: earlyBinding
     state: present
   delegate_to: localhost
 
-- name: Create private vlan portgroup
-  vmware_dvs_portgroup:
-    hostname: '{{ vcenter_hostname }}'
-    username: '{{ vcenter_username }}'
-    password: '{{ vcenter_password }}'
-    portgroup_name: private-vlan-portrgoup
-    switch_name: dvSwitch
-    vlan_id: 1001
-    vlan_private: True
-    num_ports: 120
-    portgroup_type: earlyBinding
-    state: present
-  delegate_to: localhost
-
-- name: Create no-vlan portgroup
+- name: Create pvlan portgroup
   community.vmware.vmware_dvs_portgroup:
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
-    portgroup_name: no-vlan-portrgoup
-    switch_name: dvSwitch
-    vlan_id: 0
+    portgroup: vlan-123-portgroup
+    switch: dvSwitch
+    private_vlan_id: 123
     num_ports: 120
-    portgroup_type: earlyBinding
     state: present
   delegate_to: localhost
 
-- name: Create vlan portgroup with all security and port policies
+- name: Create no-vlan portgroup with no uplinks
   community.vmware.vmware_dvs_portgroup:
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
-    portgroup_name: vlan-123-portrgoup
-    switch_name: dvSwitch
+    portgroup: no-vlan-portgroup
+    switch: dvSwitch
+    num_ports: 120
+    teaming:
+      active_uplinks: []
+      standby_uplinks: []
+    state: present
+  delegate_to: localhost
+
+- name: Create vlan portgroup with all settings
+  community.vmware.vmware_dvs_portgroup:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    portgroup: vlan-123-portgroup
+    switch: dvSwitch
     vlan_id: 123
     num_ports: 120
-    portgroup_type: earlyBinding
-    state: present
-    network_policy:
-      promiscuous: true
-      forged_transmits: true
-      mac_changes: true
-    port_policy:
-      block_override: true
-      ipfix_override: true
-      live_port_move: true
-      network_rp_override: true
+    port_binding: static
+    port_allocation: elastic
+    security:
+      promiscuous_mode: no
+      mac_changes: no
+      forged_transmits: no
+    teaming:
+      load_balancing: loadbalance_srcid
+      network_failure_detection: link_status_only
+      notify_switches: True
+      failback: True
+      active_uplinks: [ 'Uplink 1' ]
+      standby_uplinks: [ 'Uplink 2' ]
+    advanced:
       port_config_reset_at_disconnect: true
+      block_override: true
+      netflow_override: true
+      network_rp_override: true
       security_override: true
       shaping_override: true
       traffic_filter_override: true
       uplink_teaming_override: true
       vendor_config_override: true
       vlan_override: true
+    state: present
   delegate_to: localhost
 '''
+
+RETURN = """
+dvs_portroup:
+    description: information about performed operation
+    returned: always
+    type: dict
+    sample: {
+        "adv_block_ports": true,
+        "adv_netflow": false,
+        "adv_network_rp": false,
+        "adv_reset_at_disconnect": true,
+        "adv_security": false,
+        "adv_traffic_filtering": false,
+        "adv_traffic_shaping": false,
+        "adv_uplink_teaming": false,
+        "adv_vendor_conf": false,
+        "adv_vlan": false,
+        "block_all_ports": false,
+        "changed": false,
+        "description": null,
+        "dvswitch": "dvSwitch",
+        "failback": true,
+        "failover_active": [
+            "Uplink 1"
+        ],
+        "failover_standby": [
+            "Uplink 2"
+        ],
+        "failure_detection": "link_status_only",
+        "load_balancing": "loadbalance_srcid",
+        "netflow_enabled": false,
+        "network_rp": "default",
+        "notify": true,
+        "num_ports": null,
+        "port_allocation": "elastic",
+        "port_binding": "static",
+        "portgroup": "Test",
+        "result": "Portgroup already configured properly",
+        "sec_forged_transmits": false,
+        "sec_mac_changes": false,
+        "sec_promiscuous_mode": false,
+        "vlan_trunk_range": [
+            "1-1000",
+            1005,
+            "1100-1200"
+        ]
+    }
+"""
 
 try:
     from pyVmomi import vim, vmodl
@@ -309,8 +402,10 @@ except ImportError:
     pass
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
 from ansible_collections.community.vmware.plugins.module_utils.vmware import (
     PyVmomi,
+    TaskError,
     find_dvs_by_name,
     find_dvspg_by_name,
     vmware_argument_spec,
@@ -318,291 +413,922 @@ from ansible_collections.community.vmware.plugins.module_utils.vmware import (
 
 
 class VMwareDvsPortgroup(PyVmomi):
+    """Class to manage a DVS portgroup"""
+
     def __init__(self, module):
         super(VMwareDvsPortgroup, self).__init__(module)
         self.dvs_portgroup = None
         self.dv_switch = None
 
-    def create_vlan_list(self):
-        vlan_id_list = []
-        for vlan_id_splitted in self.module.params['vlan_id'].split(','):
-            vlans = vlan_id_splitted.split('-')
-            if len(vlans) > 2:
-                self.module.fail_json(msg="Invalid VLAN range %s." % vlan_id_splitted)
-            if len(vlans) == 2:
-                vlan_id_start = vlans[0].strip()
-                vlan_id_end = vlans[1].strip()
-                if not vlan_id_start.isdigit():
-                    self.module.fail_json(msg="Invalid VLAN %s." % vlan_id_start)
-                if not vlan_id_end.isdigit():
-                    self.module.fail_json(msg="Invalid VLAN %s." % vlan_id_end)
-                vlan_id_start = int(vlan_id_start)
-                vlan_id_end = int(vlan_id_end)
-                if vlan_id_start not in range(0, 4095) or vlan_id_end not in range(0, 4095):
-                    self.module.fail_json(msg="vlan_id range %s specified is incorrect. The valid vlan_id range is from 0 to 4094." % vlan_id_splitted)
-                vlan_id_list.append((vlan_id_start, vlan_id_end))
-            else:
-                vlan_id = vlans[0].strip()
-                if not vlan_id.isdigit():
-                    self.module.fail_json(msg="Invalid VLAN %s." % vlan_id)
-                vlan_id = int(vlan_id)
-                vlan_id_list.append((vlan_id, vlan_id))
+        self.switch_name = self.module.params['switch']
+        self.portgroup_name = self.module.params['portgroup']
+        self.description = self.module.params['description']
+        self.num_ports = self.module.params['num_ports']
+        self.network_resource_pool = self.module.params['network_resource_pool']
+        self.port_binding = self.module.params['port_binding']
+        self.port_allocation = self.module.params['port_allocation']
+        # Port binding sanity checks
+        if self.port_binding == 'ephemeral' and self.num_ports:
+            self.module.fail_json(
+                msg="The number of ports cannot be configured when port binding is set to 'ephemeral'."
+            )
+        if self.port_binding != 'static' and self.port_allocation == 'elastic':
+            self.module.fail_json(
+                msg="Port allocation of type 'elastic' cannot be configured when port binding isn't set to 'static'."
+            )
+        self.pp_reset = self.module.params['advanced']['port_config_reset_at_disconnect']
+        self.pp_block_ports = self.module.params['advanced']['block_override']
+        self.pp_shaping = self.module.params['advanced']['shaping_override']
+        self.pp_vendor_conf = self.module.params['advanced']['vendor_config_override']
+        self.pp_vlan = self.module.params['advanced']['vlan_override']
+        self.pp_uplink_teaming = self.module.params['advanced']['uplink_teaming_override']
+        self.pp_network_rp = self.module.params['advanced']['network_rp_override']
+        self.pp_security = self.module.params['advanced']['security_override']
+        self.pp_netflow = self.module.params['advanced']['netflow_override']
+        self.pp_traffic_filter = self.module.params['advanced']['traffic_filter_override']
+        self.sec_promiscuous_mode = self.params['security'].get('promiscuous_mode')
+        self.sec_forged_transmits = self.params['security'].get('forged_transmits')
+        self.sec_mac_changes = self.params['security'].get('mac_changes')
+        self.vlan_id = self.module.params['vlan_id']
+        self.vlan_trunk_range = self.module.params['vlan_trunk_range']
+        # VLAN trunk range sanity checks
+        if self.vlan_trunk_range:
+            for vlan_id_trunk_range in self.vlan_trunk_range:
+                if isinstance(vlan_id_trunk_range, int):
+                    if vlan_id_trunk_range not in range(0, 4095):
+                        self.module.fail_json(msg="vlan_trunk_range %s specified is incorrect. The valid vlan_trunk_range is from 0 to 4094." %
+                                              vlan_id_trunk_range)
+                else:
+                    vlans = vlan_id_trunk_range.split('-')
+                    if len(vlans) == 2:
+                        vlan_id_start = vlans[0].strip()
+                        vlan_id_end = vlans[1].strip()
+                        if not vlan_id_start.isdigit():
+                            self.module.fail_json(msg="Invalid VLAN %s." % vlan_id_start)
+                        if not vlan_id_end.isdigit():
+                            self.module.fail_json(msg="Invalid VLAN %s." % vlan_id_end)
+                        vlan_id_start = int(vlan_id_start)
+                        vlan_id_end = int(vlan_id_end)
+                        if vlan_id_start not in range(0, 4095) or vlan_id_end not in range(0, 4095):
+                            self.module.fail_json(msg="vlan_trunk_range %s specified is incorrect. The valid vlan_trunk_range is from 0 to 4094." %
+                                                  vlan_id_trunk_range)
+                    else:
+                        self.module.fail_json(msg="Invalid VLAN range %s." % vlan_id_trunk_range)
+        self.private_vlan_id = self.module.params['private_vlan_id']
+        self.teaming_load_balancing = self.params['teaming'].get('load_balancing')
+        self.teaming_failure_detection = self.params['teaming'].get('network_failure_detection')
+        self.teaming_notify_switches = self.params['teaming'].get('notify_switches')
+        self.teaming_failback = self.params['teaming'].get('failback')
+        self.teaming_failover_order_active = self.params['teaming'].get('active_uplinks')
+        self.teaming_failover_order_standby = self.params['teaming'].get('standby_uplinks')
+        # set other uplinks list to an empty array instead of 'None' if only one list is defined
+        # this avoids update issues since the API changes accepts 'None', but it changes it to '[]'
+        if self.teaming_failover_order_active or self.teaming_failover_order_standby:
+            if self.teaming_failover_order_active is None:
+                self.teaming_failover_order_active = []
+            if self.teaming_failover_order_standby is None:
+                self.teaming_failover_order_standby = []
+        self.netflow_enabled = self.module.params['netflow_enabled']
+        self.block_all_ports = self.module.params['block_all_ports']
 
-        vlan_id_list.sort()
-
-        return vlan_id_list
-
-    def build_config(self):
-        config = vim.dvs.DistributedVirtualPortgroup.ConfigSpec()
-
-        # Basic config
-        config.name = self.module.params['portgroup_name']
-        config.numPorts = self.module.params['num_ports']
-
-        # Default port config
-        config.defaultPortConfig = vim.dvs.VmwareDistributedVirtualSwitch.VmwarePortConfigPolicy()
-        if self.module.params['vlan_trunk']:
-            config.defaultPortConfig.vlan = vim.dvs.VmwareDistributedVirtualSwitch.TrunkVlanSpec()
-            config.defaultPortConfig.vlan.vlanId = list(map(lambda x: vim.NumericRange(start=x[0], end=x[1]), self.create_vlan_list()))
-        elif self.module.params['vlan_private']:
-            # Check that private VLAN exists in dvs
-            if self.module.params['vlan_private']:
-                pvlan_exists = self.check_dvs_pvlan()
-                if not pvlan_exists:
-                    self.module.fail_json(msg="No private vlan with id %s in distributed vSwitch %s"
-                                          % (self.module.params['vlan_id'], self.module.params['switch_name']))
-
-            config.defaultPortConfig.vlan = vim.dvs.VmwareDistributedVirtualSwitch.PvlanSpec()
-            config.defaultPortConfig.vlan.pvlanId = int(self.module.params['vlan_id'])
-        else:
-            config.defaultPortConfig.vlan = vim.dvs.VmwareDistributedVirtualSwitch.VlanIdSpec()
-            config.defaultPortConfig.vlan.vlanId = int(self.module.params['vlan_id'])
-        config.defaultPortConfig.vlan.inherited = False
-        config.defaultPortConfig.securityPolicy = vim.dvs.VmwareDistributedVirtualSwitch.SecurityPolicy()
-        config.defaultPortConfig.securityPolicy.allowPromiscuous = vim.BoolPolicy(value=self.module.params['network_policy']['promiscuous'])
-        config.defaultPortConfig.securityPolicy.forgedTransmits = vim.BoolPolicy(value=self.module.params['network_policy']['forged_transmits'])
-        config.defaultPortConfig.securityPolicy.macChanges = vim.BoolPolicy(value=self.module.params['network_policy']['mac_changes'])
-
-        # Teaming Policy
-        teamingPolicy = vim.dvs.VmwareDistributedVirtualSwitch.UplinkPortTeamingPolicy()
-        teamingPolicy.policy = vim.StringPolicy(value=self.module.params['teaming_policy']['load_balance_policy'])
-        teamingPolicy.reversePolicy = vim.BoolPolicy(value=self.module.params['teaming_policy']['inbound_policy'])
-        teamingPolicy.notifySwitches = vim.BoolPolicy(value=self.module.params['teaming_policy']['notify_switches'])
-        teamingPolicy.rollingOrder = vim.BoolPolicy(value=self.module.params['teaming_policy']['rolling_order'])
-        config.defaultPortConfig.uplinkTeamingPolicy = teamingPolicy
-
-        # PG policy (advanced_policy)
-        config.policy = vim.dvs.VmwareDistributedVirtualSwitch.VMwarePortgroupPolicy()
-        config.policy.blockOverrideAllowed = self.module.params['port_policy']['block_override']
-        config.policy.ipfixOverrideAllowed = self.module.params['port_policy']['ipfix_override']
-        config.policy.livePortMovingAllowed = self.module.params['port_policy']['live_port_move']
-        config.policy.networkResourcePoolOverrideAllowed = self.module.params['port_policy']['network_rp_override']
-        config.policy.portConfigResetAtDisconnect = self.module.params['port_policy']['port_config_reset_at_disconnect']
-        config.policy.securityPolicyOverrideAllowed = self.module.params['port_policy']['security_override']
-        config.policy.shapingOverrideAllowed = self.module.params['port_policy']['shaping_override']
-        config.policy.trafficFilterOverrideAllowed = self.module.params['port_policy']['traffic_filter_override']
-        config.policy.uplinkTeamingOverrideAllowed = self.module.params['port_policy']['uplink_teaming_override']
-        config.policy.vendorConfigOverrideAllowed = self.module.params['port_policy']['vendor_config_override']
-        config.policy.vlanOverrideAllowed = self.module.params['port_policy']['vlan_override']
-
-        # PG Type
-        config.type = self.module.params['portgroup_type']
-
-        return config
+        # NOTE: Deprecated options. Will be removed in collection 2.0.0
+        self.portgroup_type = self.module.params['portgroup_type']
+        self.vlan_trunk = self.module.params['vlan_trunk']
 
     def process_state(self):
+        """Process the current state of the portgroup"""
         dvspg_states = {
             'absent': {
-                'present': self.state_destroy_dvspg,
-                'absent': self.state_exit_unchanged,
+                'present': self.destroy_port_group,
+                'absent': self.exit_unchanged,
             },
             'present': {
-                'update': self.state_update_dvspg,
-                'present': self.state_exit_unchanged,
-                'absent': self.state_create_dvspg,
+                'present': self.update_port_group,
+                'absent': self.create_port_group,
             }
         }
         try:
-            dvspg_states[self.module.params['state']][self.check_dvspg_state()]()
+            dvspg_states[self.module.params['state']][self.check_port_group_state()]()
         except vmodl.RuntimeFault as runtime_fault:
             self.module.fail_json(msg=runtime_fault.msg)
         except vmodl.MethodFault as method_fault:
             self.module.fail_json(msg=method_fault.msg)
-        except Exception as e:
-            self.module.fail_json(msg=str(e))
+        except Exception as exception:
+            self.module.fail_json(msg=str(exception))
 
-    def update_port_group(self):
-        config = self.build_config()
-        config.configVersion = self.dvs_portgroup.config.configVersion
-        task = self.dvs_portgroup.ReconfigureDVPortgroup_Task(config)
-        changed, result = wait_for_task(task)
-        return changed, result
+    def check_port_group_state(self):
+        """Check if DVS portgroup exists"""
+        self.dv_switch = find_dvs_by_name(self.content, self.switch_name)
+
+        if self.dv_switch is None:
+            self.module.fail_json(
+                msg="A distributed virtual switch with name %s does not exist" % self.switch_name
+            )
+        self.dvs_portgroup = find_dvspg_by_name(self.dv_switch, self.portgroup_name)
+        if self.dvs_portgroup:
+            return 'present'
+        return 'absent'
 
     def create_port_group(self):
-        config = self.build_config()
-        task = self.dv_switch.AddDVPortgroup_Task([config])
-        changed, result = wait_for_task(task)
-        return changed, result
-
-    def state_destroy_dvspg(self):
+        """Create DVS portgroup"""
         changed = True
-        result = None
+        results = dict(changed=changed)
 
-        if not self.module.check_mode:
-            task = self.dvs_portgroup.Destroy_Task()
-            changed, result = wait_for_task(task)
-        self.module.exit_json(changed=changed, result=str(result))
+        pg_spec = vim.dvs.DistributedVirtualPortgroup.ConfigSpec()
 
-    def state_exit_unchanged(self):
-        self.module.exit_json(changed=False)
+        # Name
+        results['portgroup'] = self.portgroup_name
+        pg_spec.name = self.portgroup_name
+        # Description
+        results['description'] = self.description
+        pg_spec.description = self.description
+        # Number of ports
+        results['num_ports'] = self.num_ports
+        pg_spec.numPorts = self.num_ports
+        # Port binding
+        # NOTE: 'self.portgroup_type' is deprecated. Will be removed in collection 2.0.0
+        if self.portgroup_type:
+            results['portgroup_type'] = self.portgroup_type
+            pg_spec.type = self.portgroup_type
+        else:
+            results['port_binding'] = self.port_binding
+            pg_spec.type = self.get_api_port_binding_mode(self.port_binding)
+        # Port allocation
+        if not self.port_allocation:
+            if self.port_binding == 'dynamic' or self.port_binding == 'ephemeral':
+                results['port_allocation'] = 'n/a'
+            else:
+                results['port_allocation'] = 'elastic'
+                pg_spec.autoExpand = True
+        else:
+            results['port_allocation'] = self.port_allocation
+            if self.port_allocation == 'elastic':
+                pg_spec.autoExpand = True
+            elif self.port_allocation == 'fixed':
+                pg_spec.autoExpand = False
 
-    def state_update_dvspg(self):
-        changed = True
-        result = None
+        # Advanced / Port policies
+        results['adv_reset_at_disconnect'] = self.pp_reset
+        results['adv_block_ports'] = self.pp_block_ports
+        results['adv_traffic_shaping'] = self.pp_shaping
+        results['adv_vendor_conf'] = self.pp_vendor_conf
+        results['adv_vlan'] = self.pp_vlan
+        results['adv_uplink_teaming'] = self.pp_uplink_teaming
+        results['adv_network_rp'] = self.pp_network_rp
+        results['adv_security'] = self.pp_security
+        results['adv_netflow'] = self.pp_netflow
+        results['adv_traffic_filtering'] = self.pp_traffic_filter
+        result = self.check_port_policy_config(pg_config=None)
+        pg_spec.policy = result[0]
 
-        if not self.module.check_mode:
-            changed, result = self.update_port_group()
-        self.module.exit_json(changed=changed, result=str(result))
+        pg_spec.defaultPortConfig = vim.dvs.VmwareDistributedVirtualSwitch.VmwarePortConfigPolicy()
 
-    def state_create_dvspg(self):
-        changed = True
-        result = None
+        # Network resource pool
+        results['network_rp'] = self.network_resource_pool
+        if self.network_resource_pool == 'default':
+            pg_spec.defaultPortConfig.networkResourcePoolKey = vim.StringPolicy(inherited=False, value='-1')
+        else:
+            network_resource_pool = self.find_network_rp_by_name(self.network_resource_pool)
+            if network_resource_pool is None:
+                self.module.fail_json(msg="Network resource pool '%s' was not found" % self.network_resource_pool)
+            pg_spec.defaultPortConfig.networkResourcePoolKey = vim.StringPolicy(
+                inherited=False, value=network_resource_pool.key
+            )
 
-        if not self.module.check_mode:
-            changed, result = self.create_port_group()
-        self.module.exit_json(changed=changed, result=str(result))
+        # Security
+        results['sec_promiscuous_mode'] = self.sec_promiscuous_mode
+        results['sec_mac_changes'] = self.sec_mac_changes
+        results['sec_forged_transmits'] = self.sec_forged_transmits
+        result = self.check_security_config(pg_config=None)
+        pg_spec.defaultPortConfig.securityPolicy = result[0]
 
-    def check_dvs_pvlan(self):
+        # TODO: Traffic shaping
+
+        # NOTE: 'vlan_trunk' option is deprecated. Will be removed in collection 2.0.0
+        if self.vlan_trunk or self.vlan_trunk_range:
+            results['vlan_trunk_range'] = self.vlan_trunk_range
+            result = self.check_trunk_vlan_config(pg_config=None)
+            pg_spec.defaultPortConfig.vlan = result[0]
+        elif self.private_vlan_id:
+            if self.dv_switch.config.pvlanConfig:
+                pvlan_exists = self.check_pvlan_config()
+                if not pvlan_exists:
+                    self.module.fail_json(msg="No private vlan with id %s configured for this distributed switch." %
+                                          self.private_vlan_id)
+                results['private_vlan_id'] = self.private_vlan_id
+                pg_spec.defaultPortConfig.vlan = vim.dvs.VmwareDistributedVirtualSwitch.PvlanSpec()
+                pg_spec.defaultPortConfig.vlan.pvlanId = int(self.private_vlan_id)
+            else:
+                self.module.fail_json(msg="Private VLANs are not configured for this distributed switch.")
+        elif self.vlan_id or self.vlan_id == 0:
+            results['vlan_id'] = self.vlan_id
+            pg_spec.defaultPortConfig.vlan = vim.dvs.VmwareDistributedVirtualSwitch.VlanIdSpec()
+            pg_spec.defaultPortConfig.vlan.vlanId = int(self.vlan_id)
+        pg_spec.defaultPortConfig.vlan.inherited = False
+
+        # Teaming and failover
+        teaming_policy = vim.dvs.VmwareDistributedVirtualSwitch.UplinkPortTeamingPolicy()
+        results['load_balancing'] = self.teaming_load_balancing
+        teaming_policy.policy = vim.StringPolicy(inherited=False, value=self.teaming_load_balancing)
+        teaming_policy.failureCriteria = vim.dvs.VmwareDistributedVirtualSwitch.FailureCriteria()
+        results['failure_detection'] = self.teaming_failure_detection
+        if self.teaming_failure_detection == "link_status_only":
+            teaming_policy.failureCriteria.checkBeacon = vim.BoolPolicy(inherited=False, value=False)
+        elif self.teaming_failure_detection == "beacon_probing":
+            teaming_policy.failureCriteria.checkBeacon = vim.BoolPolicy(inherited=False, value=True)
+        # Deprecated since VI API 5.1. The system default (true) will be used
+        teaming_policy.reversePolicy = vim.BoolPolicy(inherited=False, value=True)
+        results['notify'] = self.teaming_notify_switches
+        teaming_policy.notifySwitches = vim.BoolPolicy(inherited=False, value=self.teaming_notify_switches)
+        # this option is called 'failback' in the vSphere Client
+        # rollingOrder also uses the opposite value displayed in the client
+        results['failback'] = self.teaming_failback
+        teaming_policy.rollingOrder = vim.BoolPolicy(inherited=False, value=not self.teaming_failback)
+        if self.teaming_failover_order_active or self.teaming_failover_order_standby:
+            teaming_policy.uplinkPortOrder = vim.dvs.VmwareDistributedVirtualSwitch.UplinkPortOrderPolicy()
+            teaming_policy.uplinkPortOrder.activeUplinkPort = self.teaming_failover_order_active
+            teaming_policy.uplinkPortOrder.standbyUplinkPort = self.teaming_failover_order_standby
+            results['failover_active'] = self.teaming_failover_order_active
+            results['failover_standby'] = self.teaming_failover_order_standby
+        pg_spec.defaultPortConfig.uplinkTeamingPolicy = teaming_policy
+
+        # Monitoring - NetFlow
+        results['netflow_enabled'] = self.netflow_enabled
+        result = self.check_netflow_policy_config(pg_config=None)
+        pg_spec.defaultPortConfig.ipfixEnabled = result[0]
+
+        # TODO: Traffic filtering and marking
+
+        # Misc. - Block all ports
+        results['block_all_ports'] = self.block_all_ports
+        result = self.check_blocked_policy_config(pg_config=None)
+        pg_spec.defaultPortConfig.blocked = result[0]
+
+        if self.module.check_mode:
+            results['result'] = "Portgroup would be created"
+        else:
+            task = self.dv_switch.AddDVPortgroup_Task([pg_spec])
+            try:
+                wait_for_task(task)
+            except TaskError as invalid_argument:
+                self.module.fail_json(
+                    msg="Failed to create portgroup : %s" % to_native(invalid_argument)
+                )
+            results['result'] = "Portgroup created"
+
+        self.module.exit_json(**results)
+
+    @staticmethod
+    def get_api_port_binding_mode(mode):
+        """Get port binding mode"""
+        port_binding_mode = None
+        if mode == 'earlyBinding':
+            port_binding_mode = 'static'
+        elif mode == 'lateBinding':
+            port_binding_mode = 'dynamic'
+        elif mode == 'static':
+            port_binding_mode = 'earlyBinding'
+        elif mode == 'dynamic':
+            port_binding_mode = 'lateBinding'
+        # ephemeral stays the same
+        elif mode == 'ephemeral':
+            port_binding_mode = 'ephemeral'
+        return port_binding_mode
+
+    def check_port_policy_config(self, pg_config):
+        """Check port policies config"""
+        changed = reset_at_disconnect = block_override = shaping_override = vendor_config_override = \
+            vlan_override = uplink_teaming_override = network_rp_override = security_override = \
+            netflow_override = traffic_filter_override = False
+        pg_policy_spec = vim.dvs.VmwareDistributedVirtualSwitch.VMwarePortgroupPolicy()
+        pg_policy_spec.portConfigResetAtDisconnect = self.pp_reset
+        pg_policy_spec.blockOverrideAllowed = self.pp_block_ports
+        pg_policy_spec.shapingOverrideAllowed = self.pp_shaping
+        pg_policy_spec.vendorConfigOverrideAllowed = self.pp_vendor_conf
+        pg_policy_spec.vlanOverrideAllowed = self.pp_vlan
+        pg_policy_spec.uplinkTeamingOverrideAllowed = self.pp_uplink_teaming
+        pg_policy_spec.networkResourcePoolOverrideAllowed = self.pp_network_rp
+        pg_policy_spec.securityPolicyOverrideAllowed = self.pp_security
+        pg_policy_spec.ipfixOverrideAllowed = self.pp_netflow
+        pg_policy_spec.trafficFilterOverrideAllowed = self.pp_traffic_filter
+        # There's no information available if this option is deprecated, but it isn't visible in the vSphere Client
+        pg_policy_spec.livePortMovingAllowed = False
+        # Check policies
+        if pg_config:
+            if pg_config.policy.portConfigResetAtDisconnect != self.pp_reset:
+                changed = reset_at_disconnect = True
+            if pg_config.policy.blockOverrideAllowed != self.pp_block_ports:
+                changed = block_override = True
+            if pg_config.policy.shapingOverrideAllowed != self.pp_shaping:
+                changed = shaping_override = True
+            if pg_config.policy.vendorConfigOverrideAllowed != self.pp_vendor_conf:
+                changed = vendor_config_override = True
+            if pg_config.policy.vlanOverrideAllowed != self.pp_vlan:
+                changed = vlan_override = True
+            if pg_config.policy.uplinkTeamingOverrideAllowed != self.pp_uplink_teaming:
+                changed = uplink_teaming_override = True
+            if pg_config.policy.networkResourcePoolOverrideAllowed != self.pp_network_rp:
+                changed = network_rp_override = True
+            if pg_config.policy.securityPolicyOverrideAllowed != self.pp_security:
+                changed = security_override = True
+            if pg_config.policy.ipfixOverrideAllowed != self.pp_netflow:
+                changed = netflow_override = True
+            if pg_config.policy.trafficFilterOverrideAllowed != self.pp_traffic_filter:
+                changed = traffic_filter_override = True
+        return (pg_policy_spec, changed, reset_at_disconnect, block_override, shaping_override,
+                vendor_config_override, vlan_override, uplink_teaming_override, network_rp_override,
+                security_override, netflow_override, traffic_filter_override)
+
+    def find_network_rp_by_name(self, resource_name):
+        """Find network resource pool by name"""
+        config = None
+        if self.dv_switch.config.networkResourceControlVersion == "version3":
+            config = self.dv_switch.config.infrastructureTrafficResourceConfig
+        elif self.dv_switch.config.networkResourceControlVersion == "version2":
+            config = self.dv_switch.networkResourcePool
+        for obj in config:
+            if obj.name == resource_name:
+                return obj
+        return None
+
+    def find_network_rp_by_key(self, resource_key):
+        """Find network resource pool by key"""
+        config = None
+        if self.dv_switch.config.networkResourceControlVersion == "version3":
+            config = self.dv_switch.config.infrastructureTrafficResourceConfig
+        elif self.dv_switch.config.networkResourceControlVersion == "version2":
+            config = self.dv_switch.networkResourcePool
+        for obj in config:
+            if obj.key == resource_key:
+                return obj
+        return None
+
+    def check_security_config(self, pg_config):
+        """Check security config"""
+        changed = False
+        promiscuous_mode_previous = mac_changes_previous = forged_transmits_previous = None
+        sec_spec = vim.dvs.VmwareDistributedVirtualSwitch.SecurityPolicy()
+        sec_spec.allowPromiscuous = vim.BoolPolicy(inherited=False, value=self.sec_promiscuous_mode)
+        sec_spec.macChanges = vim.BoolPolicy(inherited=False, value=self.sec_mac_changes)
+        sec_spec.forgedTransmits = vim.BoolPolicy(inherited=False, value=self.sec_forged_transmits)
+        if pg_config:
+            promiscuous_mode_previous = pg_config.defaultPortConfig.securityPolicy.allowPromiscuous.value
+            mac_changes_previous = pg_config.defaultPortConfig.securityPolicy.macChanges.value
+            forged_transmits_previous = pg_config.defaultPortConfig.securityPolicy.forgedTransmits.value
+            if promiscuous_mode_previous != self.sec_promiscuous_mode:
+                changed = True
+            if mac_changes_previous != self.sec_mac_changes:
+                changed = True
+            if forged_transmits_previous != self.sec_forged_transmits:
+                changed = True
+        return sec_spec, changed, promiscuous_mode_previous, mac_changes_previous, forged_transmits_previous
+
+    def check_pvlan_config(self):
+        """Check Private VLAN config"""
         for pvlan in self.dv_switch.config.pvlanConfig:
-            if pvlan.primaryVlanId == int(self.module.params['vlan_id']):
+            if pvlan.primaryVlanId == self.private_vlan_id:
                 return True
-            if pvlan.secondaryVlanId == int(self.module.params['vlan_id']):
+            if pvlan.secondaryVlanId == self.private_vlan_id:
                 return True
         return False
 
-    def check_dvspg_state(self):
-        self.dv_switch = find_dvs_by_name(self.content, self.module.params['switch_name'])
-
-        if self.dv_switch is None:
-            self.module.fail_json(msg="A distributed virtual switch with name %s does not exist" % self.module.params['switch_name'])
-        self.dvs_portgroup = find_dvspg_by_name(self.dv_switch, self.module.params['portgroup_name'])
-
-        if self.dvs_portgroup is None:
-            return 'absent'
-
-        # Check config
-        # Basic config
-        if self.dvs_portgroup.config.numPorts != self.module.params['num_ports']:
-            return 'update'
-
-        # Default port config
-        defaultPortConfig = self.dvs_portgroup.config.defaultPortConfig
-        if self.module.params['vlan_trunk']:
-            if not isinstance(defaultPortConfig.vlan, vim.dvs.VmwareDistributedVirtualSwitch.TrunkVlanSpec):
-                return 'update'
-            if list(map(lambda x: (x.start, x.end), defaultPortConfig.vlan.vlanId)) != self.create_vlan_list():
-                return 'update'
-        elif self.module.params['vlan_private']:
-            if not isinstance(defaultPortConfig.vlan, vim.dvs.VmwareDistributedVirtualSwitch.PvlanSpec):
-                return 'update'
-            if defaultPortConfig.vlan.pvlanId != int(self.module.params['vlan_id']):
-                return 'update'
+    def check_trunk_vlan_config(self, pg_config):
+        """Check trunk VLAN config"""
+        changed_vlan_trunk_range = False
+        # NOTE: the following code is for backward compatibility only. Will be removed in collection 2.0.0
+        if self.vlan_trunk:
+            trunk_vlan_spec = vim.dvs.VmwareDistributedVirtualSwitch.TrunkVlanSpec()
+            vlan_id_start, vlan_id_end = self.vlan_id.split('-')
+            trunk_vlan_spec.vlanId = [vim.NumericRange(start=int(vlan_id_start.strip()), end=int(vlan_id_end.strip()))]
+            # Do not check if range is already configured; just classify it as changed
+            changed_vlan_trunk_range = True
         else:
-            if not isinstance(defaultPortConfig.vlan, vim.dvs.VmwareDistributedVirtualSwitch.VlanIdSpec):
-                return 'update'
-            if defaultPortConfig.vlan.vlanId != int(self.module.params['vlan_id']):
-                return 'update'
+            vlan_id_ranges = self.vlan_trunk_range
+            trunk_vlan_spec = vim.dvs.VmwareDistributedVirtualSwitch.TrunkVlanSpec()
+            vlan_id_list = []
+            for vlan_id_range in vlan_id_ranges:
+                vlan_id_range_found = False
+                vlan_id_start, vlan_id_end = self.get_vlan_ids_from_range(vlan_id_range)
+                if pg_config:
+                    # Check if range is already configured
+                    for current_vlan_id_range in pg_config.defaultPortConfig.vlan.vlanId:
+                        if (current_vlan_id_range.start == int(vlan_id_start)
+                                and current_vlan_id_range.end == int(vlan_id_end)):
+                            vlan_id_range_found = True
+                            break
+                    if vlan_id_range_found is False:
+                        changed_vlan_trunk_range = True
+                vlan_id_list.append(vim.NumericRange(start=int(vlan_id_start), end=int(vlan_id_end)))
+            if pg_config:
+                # Check if range needs to be removed
+                for current_vlan_id_range in pg_config.defaultPortConfig.vlan.vlanId:
+                    vlan_id_range_found = False
+                    for vlan_id_range in vlan_id_ranges:
+                        vlan_id_start, vlan_id_end = self.get_vlan_ids_from_range(vlan_id_range)
+                        if (current_vlan_id_range.start == int(vlan_id_start)
+                                and current_vlan_id_range.end == int(vlan_id_end)):
+                            vlan_id_range_found = True
+                            break
+                    if vlan_id_range_found is False:
+                        changed_vlan_trunk_range = True
+            trunk_vlan_spec.vlanId = vlan_id_list
+        return trunk_vlan_spec, changed_vlan_trunk_range
 
-        if defaultPortConfig.securityPolicy.allowPromiscuous.value != self.module.params['network_policy']['promiscuous'] or \
-                defaultPortConfig.securityPolicy.forgedTransmits.value != self.module.params['network_policy']['forged_transmits'] or \
-                defaultPortConfig.securityPolicy.macChanges.value != self.module.params['network_policy']['mac_changes']:
-            return 'update'
+    @staticmethod
+    def get_vlan_ids_from_range(vlan_id_range):
+        """Get start and end VLAN ID from VLAN ID range"""
+        try:
+            vlan_id_start, vlan_id_end = vlan_id_range.split('-')
+        except (AttributeError, TypeError):
+            vlan_id_start = vlan_id_end = vlan_id_range
+        except ValueError:
+            vlan_id_start = vlan_id_end = vlan_id_range.strip()
+        return vlan_id_start, vlan_id_end
 
-        # Teaming Policy
-        teamingPolicy = self.dvs_portgroup.config.defaultPortConfig.uplinkTeamingPolicy
-        if teamingPolicy.policy.value != self.module.params['teaming_policy']['load_balance_policy'] or \
-                teamingPolicy.reversePolicy.value != self.module.params['teaming_policy']['inbound_policy'] or \
-                teamingPolicy.notifySwitches.value != self.module.params['teaming_policy']['notify_switches'] or \
-                teamingPolicy.rollingOrder.value != self.module.params['teaming_policy']['rolling_order']:
-            return 'update'
+    @staticmethod
+    def get_current_trunk_vlan_range(pg_config):
+        """Get current VLAN trunk range as string"""
+        current_vlan_id_list = []
+        for current_vlan_id_range in pg_config.defaultPortConfig.vlan.vlanId:
+            if current_vlan_id_range.start == current_vlan_id_range.end:
+                current_vlan_id_range_string = current_vlan_id_range.start
+            else:
+                current_vlan_id_range_string = '-'.join(
+                    [str(current_vlan_id_range.start), str(current_vlan_id_range.end)]
+                )
+            current_vlan_id_list.append(current_vlan_id_range_string)
+        return current_vlan_id_list
 
-        # PG policy (advanced_policy)
-        policy = self.dvs_portgroup.config.policy
-        if policy.blockOverrideAllowed != self.module.params['port_policy']['block_override'] or \
-                policy.ipfixOverrideAllowed != self.module.params['port_policy']['ipfix_override'] or \
-                policy.livePortMovingAllowed != self.module.params['port_policy']['live_port_move'] or \
-                policy.networkResourcePoolOverrideAllowed != self.module.params['port_policy']['network_rp_override'] or \
-                policy.portConfigResetAtDisconnect != self.module.params['port_policy']['port_config_reset_at_disconnect'] or \
-                policy.securityPolicyOverrideAllowed != self.module.params['port_policy']['security_override'] or \
-                policy.shapingOverrideAllowed != self.module.params['port_policy']['shaping_override'] or \
-                policy.trafficFilterOverrideAllowed != self.module.params['port_policy']['traffic_filter_override'] or \
-                policy.uplinkTeamingOverrideAllowed != self.module.params['port_policy']['uplink_teaming_override'] or \
-                policy.vendorConfigOverrideAllowed != self.module.params['port_policy']['vendor_config_override'] or \
-                policy.vlanOverrideAllowed != self.module.params['port_policy']['vlan_override']:
-            return 'update'
+    def check_netflow_policy_config(self, pg_config):
+        """Check NetFlow policy config"""
+        changed = False
+        netflow_enabled_previous = None
+        netflow_enabled_spec = vim.BoolPolicy()
+        netflow_enabled_spec.inherited = False
+        netflow_enabled_spec.value = self.netflow_enabled
+        if pg_config and pg_config.defaultPortConfig.ipfixEnabled.value != self.netflow_enabled:
+            changed = True
+            netflow_enabled_previous = pg_config.defaultPortConfig.ipfixEnabled.value
+        return netflow_enabled_spec, changed, netflow_enabled_previous
 
-        # PG Type
-        if self.dvs_portgroup.config.type != self.module.params['portgroup_type']:
-            return 'update'
+    def check_blocked_policy_config(self, pg_config):
+        """Check block all ports policy config"""
+        changed = False
+        block_all_ports_previous = None
+        block_all_ports_spec = vim.BoolPolicy()
+        block_all_ports_spec.inherited = False
+        block_all_ports_spec.value = self.block_all_ports
+        if pg_config and pg_config.defaultPortConfig.blocked.value != self.block_all_ports:
+            changed = True
+            block_all_ports_previous = pg_config.defaultPortConfig.blocked.value
+        return block_all_ports_spec, changed, block_all_ports_previous
 
-        return 'present'
+    def destroy_port_group(self):
+        """Delete a DVS portgroup"""
+        changed = True
+        results = dict(changed=changed)
+        results['dvswitch'] = self.switch_name
+        results['portgroup'] = self.portgroup_name
+        if self.module.check_mode:
+            results['result'] = "Portgroup would be deleted"
+        else:
+            try:
+                task = self.dvs_portgroup.Destroy_Task()
+            except vim.fault.VimFault as vim_fault:
+                self.module.fail_json(msg="Failed to deleted portgroup : %s" % to_native(vim_fault))
+            wait_for_task(task)
+            results['result'] = "Portgroup deleted"
+        self.module.exit_json(**results)
+
+    def exit_unchanged(self):
+        """Exit with status message"""
+        changed = False
+        results = dict(changed=changed)
+        results['dvswitch'] = self.switch_name
+        results['portgroup'] = self.portgroup_name
+        results['result'] = "Portgroup not present"
+        self.module.exit_json(**results)
+
+    def update_port_group(self):
+        """Check and update DVS portgroup"""
+        changed = changed_policy = changed_vlan = changed_vlan_trunk_range = \
+            changed_security = changed_teaming = changed_failover_order = False
+        results = dict(changed=changed)
+        results['dvswitch'] = self.switch_name
+        results['portgroup'] = self.portgroup_name
+        changed_list = []
+
+        pg_spec = vim.dvs.DistributedVirtualPortgroup.ConfigSpec()
+        # Use the same version in the new spec; The version will be increased by one by the API automatically
+        pg_spec.configVersion = self.dvs_portgroup.config.configVersion
+        pg_config = self.dvs_portgroup.config
+
+        # Check number of ports (only if option is specified)
+        # NOTE: 'self.portgroup_type' is deprecated. Will be removed in collection 2.0.0
+        if self.port_binding == 'ephemeral' or self.portgroup_type == 'ephemeral':
+            results['num_ports'] = 'n/a'
+        else:
+            results['num_ports'] = self.num_ports
+            if self.num_ports and pg_config.numPorts != self.num_ports:
+                changed = True
+                changed_list.append("num ports")
+                results['num_ports_previous'] = pg_config.description
+                pg_spec.numPorts = self.num_ports
+
+        # Check port binding
+        # NOTE: 'self.portgroup_type' is deprecated. Will be removed in collection 2.0.0
+        if self.portgroup_type:
+            results['portgroup_type'] = self.portgroup_type
+            if pg_config.type != self.portgroup_type:
+                changed = True
+                changed_list.append("portgroup type")
+                results['portgroup_type_previous'] = self.portgroup_type
+                pg_spec.type = self.portgroup_type
+        else:
+            results['port_binding'] = self.port_binding
+            if pg_config.type != self.get_api_port_binding_mode(self.port_binding):
+                changed = True
+                changed_list.append("port binding")
+                results['port_binding_previous'] = self.get_api_port_binding_mode(pg_config.type)
+                pg_spec.type = self.get_api_port_binding_mode(self.port_binding)
+
+        # Check port allocation
+        if not self.port_allocation:
+            if self.port_binding == 'dynamic' or self.port_binding == 'ephemeral':
+                results['port_allocation'] = 'n/a'
+            elif self.port_binding == 'static':
+                if pg_config.autoExpand:
+                    results['port_allocation'] = 'elastic'
+                else:
+                    results['port_allocation'] = 'fixed'
+        else:
+            results['port_allocation'] = self.port_allocation
+        if self.port_binding == 'static':
+            if self.port_allocation is None or self.port_allocation == 'elastic':
+                auto_expand = True
+            elif self.port_allocation == 'fixed':
+                auto_expand = False
+            if pg_config.autoExpand != auto_expand:
+                changed = True
+                changed_list.append("port allocation")
+                if pg_config.autoExpand:
+                    results['port_allocation_previous'] = 'elastic'
+                else:
+                    results['port_allocation_previous'] = 'fixed'
+                pg_spec.autoExpand = auto_expand
+
+        # Check description
+        results['description'] = self.description
+        if pg_config.description != self.description:
+            changed = True
+            changed_list.append("description")
+            results['description_previous'] = pg_config.description
+            if self.description is None:
+                # need to use empty string; will be set to None by API
+                pg_spec.description = ''
+            else:
+                pg_spec.description = self.description
+
+        # Check port policies
+        results['adv_reset_at_disconnect'] = self.pp_reset
+        results['adv_block_ports'] = self.pp_block_ports
+        results['adv_traffic_shaping'] = self.pp_shaping
+        results['adv_vendor_conf'] = self.pp_vendor_conf
+        results['adv_vlan'] = self.pp_vlan
+        results['adv_uplink_teaming'] = self.pp_uplink_teaming
+        results['adv_network_rp'] = self.pp_network_rp
+        results['adv_security'] = self.pp_security
+        results['adv_netflow'] = self.pp_netflow
+        results['adv_traffic_filtering'] = self.pp_traffic_filter
+        (pg_policy_spec, changed_policy, reset_at_disconnect, block_override, shaping_override,
+         vendor_config_override, vlan_override, uplink_teaming_override, network_rp_override,
+         security_override, netflow_override, traffic_filter_override) = self.check_port_policy_config(pg_config)
+        if changed_policy:
+            changed = True
+            changed_list.append("port policies")
+            if reset_at_disconnect:
+                results['adv_reset_at_disconnect_previous'] = pg_config.policy.portConfigResetAtDisconnect
+            if block_override:
+                results['adv_block_ports_previous'] = pg_config.policy.blockOverrideAllowed
+            if shaping_override:
+                results['adv_traffic_shaping_previous'] = pg_config.policy.shapingOverrideAllowed
+            if vendor_config_override:
+                results['adv_vendor_conf_previous'] = pg_config.policy.vendorConfigOverrideAllowed
+            if vlan_override:
+                results['adv_vlan_previous'] = pg_config.policy.vlanOverrideAllowed
+            if uplink_teaming_override:
+                results['adv_uplink_teaming_previous'] = pg_config.policy.uplinkTeamingOverrideAllowed
+            if network_rp_override:
+                results['adv_network_rp_previous'] = pg_config.policy.networkResourcePoolOverrideAllowed
+            if security_override:
+                results['adv_security_previous'] = pg_config.policy.securityPolicyOverrideAllowed
+            if netflow_override:
+                results['adv_netflow_previous'] = pg_config.policy.ipfixOverrideAllowed
+            if traffic_filter_override:
+                results['adv_traffic_filtering_previous'] = pg_config.policy.trafficFilterOverrideAllowed
+            pg_spec.policy = pg_policy_spec
+
+        pg_spec.defaultPortConfig = vim.dvs.VmwareDistributedVirtualSwitch.VmwarePortConfigPolicy()
+
+        # TODO: Check Traffic shaping
+
+        # NOTE: 'vlan_trunk' option is deprecated. Will be removed in collection 2.0.0
+        if self.vlan_trunk or self.vlan_trunk_range:
+            results['vlan_trunk_range'] = self.vlan_trunk_range
+            if isinstance(pg_config.defaultPortConfig.vlan, vim.dvs.VmwareDistributedVirtualSwitch.VlanIdSpec):
+                changed_vlan = True
+                results['vlan_id_previous'] = pg_config.defaultPortConfig.vlan.vlanId
+            elif isinstance(pg_config.defaultPortConfig.vlan, vim.dvs.VmwareDistributedVirtualSwitch.TrunkVlanSpec):
+                trunk_vlan_spec, changed_vlan_trunk_range = self.check_trunk_vlan_config(pg_config)
+                if changed_vlan_trunk_range:
+                    results['vlan_trunk_range_previous'] = self.get_current_trunk_vlan_range(pg_config)
+                    pg_spec.defaultPortConfig.vlan = trunk_vlan_spec
+            elif isinstance(pg_config.defaultPortConfig.vlan, vim.dvs.VmwareDistributedVirtualSwitch.PvlanSpec):
+                changed_vlan = True
+                results['private_vlan_id_previous'] = pg_config.defaultPortConfig.vlan.pvlanId
+            if changed_vlan or changed_vlan_trunk_range:
+                changed = True
+                changed_list.append("vlan")
+                if not changed_vlan_trunk_range:
+                    result = self.check_trunk_vlan_config(pg_config=None)
+                    pg_spec.defaultPortConfig.vlan = result[0]
+        elif self.private_vlan_id:
+            if self.dv_switch.config.pvlanConfig:
+                pvlan_exists = self.check_pvlan_config()
+                if not pvlan_exists:
+                    self.module.fail_json(msg="No private vlan with id %s configured for this distributed switch." %
+                                          self.private_vlan_id)
+                results['private_vlan_id'] = self.private_vlan_id
+                if isinstance(pg_config.defaultPortConfig.vlan, vim.dvs.VmwareDistributedVirtualSwitch.VlanIdSpec):
+                    changed_vlan = True
+                    results['vlan_id_previous'] = pg_config.defaultPortConfig.vlan.vlanId
+                elif isinstance(pg_config.defaultPortConfig.vlan, vim.dvs.VmwareDistributedVirtualSwitch.TrunkVlanSpec):
+                    changed_vlan = True
+                    results['vlan_trunk_range_previous'] = self.get_current_trunk_vlan_range(pg_config)
+                elif isinstance(pg_config.defaultPortConfig.vlan, vim.dvs.VmwareDistributedVirtualSwitch.PvlanSpec):
+                    if pg_config.defaultPortConfig.vlan.pvlanId != int(self.private_vlan_id):
+                        changed_vlan = True
+                        results['private_vlan_id_previous'] = pg_config.defaultPortConfig.vlan.pvlanId
+                if changed_vlan:
+                    changed = True
+                    changed_list.append("vlan")
+                    pg_spec.defaultPortConfig.vlan = vim.dvs.VmwareDistributedVirtualSwitch.PvlanSpec()
+                    pg_spec.defaultPortConfig.vlan.pvlanId = int(self.private_vlan_id)
+            else:
+                self.module.fail_json(msg="Private VLANs are not configured for this distributed switch.")
+        elif self.vlan_id or self.vlan_id == 0:
+            results['vlan_id'] = self.vlan_id
+            if isinstance(pg_config.defaultPortConfig.vlan, vim.dvs.VmwareDistributedVirtualSwitch.VlanIdSpec):
+                if pg_config.defaultPortConfig.vlan.vlanId != int(self.vlan_id):
+                    changed_vlan = True
+                    results['vlan_id_previous'] = pg_config.defaultPortConfig.vlan.vlanId
+            elif isinstance(pg_config.defaultPortConfig.vlan, vim.dvs.VmwareDistributedVirtualSwitch.TrunkVlanSpec):
+                changed_vlan = True
+                results['vlan_trunk_range_previous'] = self.get_current_trunk_vlan_range(pg_config)
+            elif isinstance(pg_config.defaultPortConfig.vlan, vim.dvs.VmwareDistributedVirtualSwitch.PvlanSpec):
+                changed_vlan = True
+                results['private_vlan_id_previous'] = pg_config.defaultPortConfig.vlan.pvlanId
+            if changed_vlan:
+                changed = True
+                changed_list.append("vlan")
+                pg_spec.defaultPortConfig.vlan = vim.dvs.VmwareDistributedVirtualSwitch.VlanIdSpec()
+                pg_spec.defaultPortConfig.vlan.vlanId = int(self.vlan_id)
+        if changed_vlan:
+            pg_spec.defaultPortConfig.vlan.inherited = False
+
+        # Check security
+        results['sec_promiscuous_mode'] = self.sec_promiscuous_mode
+        results['sec_mac_changes'] = self.sec_mac_changes
+        results['sec_forged_transmits'] = self.sec_forged_transmits
+        sec_spec, changed_security, promiscuous_mode_previous, mac_changes_previous, forged_transmits_previous = \
+            self.check_security_config(pg_config=pg_config)
+        pg_spec.defaultPortConfig.securityPolicy = sec_spec
+        if changed_security:
+            changed = True
+            changed_list.append("security")
+            results['sec_promiscuous_mode_previous'] = promiscuous_mode_previous
+            results['sec_mac_changes_previous'] = mac_changes_previous
+            results['sec_forged_transmits_previous'] = forged_transmits_previous
+
+        # Check network resource pool
+        results['network_rp'] = self.network_resource_pool
+        current_network_rp_key = pg_config.defaultPortConfig.networkResourcePoolKey.value
+        if self.network_resource_pool == 'default':
+            if current_network_rp_key != '-1':
+                changed = True
+                changed_list.append("network resource pool")
+                if current_network_rp_key == '-1':
+                    results['network_rp_previous'] = 'default'
+                else:
+                    results['network_rp_previous'] = self.find_network_rp_by_key(current_network_rp_key).name
+                pg_spec.defaultPortConfig.networkResourcePoolKey = vim.StringPolicy(inherited=False, value='-1')
+        else:
+            network_resource_pool = self.find_network_rp_by_name(self.network_resource_pool)
+            if network_resource_pool is None:
+                self.module.fail_json(msg="Network resource pool '%s' was not found" % self.network_resource_pool)
+            if current_network_rp_key != network_resource_pool.key:
+                changed = True
+                changed_list.append("network resource pool")
+                if current_network_rp_key == '-1':
+                    results['network_rp_previous'] = 'default'
+                else:
+                    results['network_rp_previous'] = self.find_network_rp_by_key(current_network_rp_key).name
+                pg_spec.defaultPortConfig.networkResourcePoolKey = vim.StringPolicy(
+                    inherited=False, value=network_resource_pool.key
+                )
+
+        # Check teaming policy
+        results['load_balancing'] = self.teaming_load_balancing
+        if pg_config.defaultPortConfig.uplinkTeamingPolicy.policy.value != self.teaming_load_balancing:
+            changed_teaming = True
+            changed_list.append("load balancing")
+            results['load_balancing_previous'] = pg_config.defaultPortConfig.uplinkTeamingPolicy.policy.value
+        # Check teaming notify switches
+        results['notify'] = self.teaming_notify_switches
+        if pg_config.defaultPortConfig.uplinkTeamingPolicy.notifySwitches.value != self.teaming_notify_switches:
+            changed_teaming = True
+            changed_list.append("notify switches")
+            results['notify_previous'] = pg_config.defaultPortConfig.uplinkTeamingPolicy.notifySwitches.value
+        # Check failback
+        results['failback'] = self.teaming_failback
+        # this option is called 'failback' in the vSphere Client
+        # rollingOrder also uses the opposite value displayed in the client
+        if pg_config.defaultPortConfig.uplinkTeamingPolicy.rollingOrder.value is self.teaming_failback:
+            changed_teaming = True
+            changed_list.append("failback")
+            results['failback_previous'] = not pg_config.defaultPortConfig.uplinkTeamingPolicy.rollingOrder.value
+        # Check teaming failover order
+        active_uplinks = pg_config.defaultPortConfig.uplinkTeamingPolicy.uplinkPortOrder.activeUplinkPort
+        standby_uplinks = pg_config.defaultPortConfig.uplinkTeamingPolicy.uplinkPortOrder.standbyUplinkPort
+        if self.teaming_failover_order_active is None and self.teaming_failover_order_standby is None:
+            # Set failover order to default
+            self.teaming_failover_order_active = \
+                self.dv_switch.config.defaultPortConfig.uplinkTeamingPolicy.uplinkPortOrder.activeUplinkPort
+            self.teaming_failover_order_standby = \
+                self.dv_switch.config.defaultPortConfig.uplinkTeamingPolicy.uplinkPortOrder.standbyUplinkPort
+        # active uplinks
+        results['failover_active'] = self.teaming_failover_order_active
+        if active_uplinks != self.teaming_failover_order_active:
+            changed_teaming = changed_failover_order = True
+            changed_list.append("failover order active")
+            results['failover_active_previous'] = active_uplinks
+        # standby uplinks
+        results['failover_standby'] = self.teaming_failover_order_standby
+        if standby_uplinks != self.teaming_failover_order_standby:
+            changed_teaming = changed_failover_order = True
+            changed_list.append("failover order standby")
+            results['failover_standby_previous'] = standby_uplinks
+        # Check teaming failure detection
+        results['failure_detection'] = self.teaming_failure_detection
+        if self.teaming_failure_detection == "link_status_only":
+            if pg_config.defaultPortConfig.uplinkTeamingPolicy.failureCriteria.checkBeacon.value is True:
+                changed_teaming = True
+                changed_list.append("network failure detection")
+                results['failure_detection_previous'] = "beacon_probing"
+        elif self.teaming_failure_detection == "beacon_probing":
+            if pg_config.defaultPortConfig.uplinkTeamingPolicy.failureCriteria.checkBeacon.value is False:
+                changed_teaming = True
+                changed_list.append("network failure detection")
+                results['failure_detection_previous'] = "link_status_only"
+
+        if changed_teaming:
+            changed = True
+            teaming_policy = vim.dvs.VmwareDistributedVirtualSwitch.UplinkPortTeamingPolicy()
+            teaming_policy.policy = vim.StringPolicy(inherited=False, value=self.teaming_load_balancing)
+            teaming_policy.failureCriteria = vim.dvs.VmwareDistributedVirtualSwitch.FailureCriteria()
+            if self.teaming_failure_detection == "link_status_only":
+                teaming_policy.failureCriteria.checkBeacon = vim.BoolPolicy(inherited=False, value=False)
+            elif self.teaming_failure_detection == "beacon_probing":
+                teaming_policy.failureCriteria.checkBeacon = vim.BoolPolicy(inherited=False, value=True)
+            # Deprecated since VI API 5.1. The system default (true) will be used
+            teaming_policy.reversePolicy = vim.BoolPolicy(inherited=False, value=True)
+            teaming_policy.notifySwitches = vim.BoolPolicy(inherited=False, value=self.teaming_notify_switches)
+            # this option is called 'failback' in the vSphere Client
+            # rollingOrder also uses the opposite value displayed in the client
+            teaming_policy.rollingOrder = vim.BoolPolicy(inherited=False, value=not self.teaming_failback)
+            teaming_policy.uplinkPortOrder = vim.dvs.VmwareDistributedVirtualSwitch.UplinkPortOrderPolicy()
+            if changed_failover_order:
+                teaming_policy.uplinkPortOrder.activeUplinkPort = self.teaming_failover_order_active
+                teaming_policy.uplinkPortOrder.standbyUplinkPort = self.teaming_failover_order_standby
+            else:
+                teaming_policy.uplinkPortOrder.activeUplinkPort = active_uplinks
+                teaming_policy.uplinkPortOrder.standbyUplinkPort = standby_uplinks
+            pg_spec.defaultPortConfig.uplinkTeamingPolicy = teaming_policy
+
+        # Check Monitoring - NetFlow
+        results['netflow_enabled'] = self.netflow_enabled
+        netflow_spec, changed_netflow, netflow_previous = self.check_netflow_policy_config(pg_config)
+        if changed_netflow:
+            changed = True
+            changed_list.append("netflow")
+            results['netflow_enabled_previous'] = netflow_previous
+            pg_spec.defaultPortConfig.ipfixEnabled = netflow_spec
+
+        # TODO: Check Traffic filtering and marking
+
+        # Check Misc. - Block all ports
+        results['block_all_ports'] = self.block_all_ports
+        blocked_spec, changed_blocked, blocked_previous = self.check_blocked_policy_config(pg_config)
+        if changed_blocked:
+            changed = True
+            changed_list.append("block all ports")
+            results['block_all_ports_previous'] = blocked_previous
+            pg_spec.defaultPortConfig.blocked = blocked_spec
+
+        if changed:
+            if self.module.check_mode:
+                changed_suffix = ' would be changed'
+            else:
+                changed_suffix = ' changed'
+            if len(changed_list) > 2:
+                message = ', '.join(changed_list[:-1]) + ', and ' + str(changed_list[-1])
+            elif len(changed_list) == 2:
+                message = ' and '.join(changed_list)
+            elif len(changed_list) == 1:
+                message = changed_list[0]
+            message += changed_suffix
+            if not self.module.check_mode:
+                try:
+                    task = self.dvs_portgroup.ReconfigureDVPortgroup_Task(pg_spec)
+                    wait_for_task(task)
+                except TaskError as invalid_argument:
+                    self.module.fail_json(msg="Failed to update portgroup : %s" % to_native(invalid_argument))
+        else:
+            message = "Portgroup already configured properly"
+        results['changed'] = changed
+        results['result'] = message
+
+        self.module.exit_json(**results)
 
 
 def main():
+    """Main"""
     argument_spec = vmware_argument_spec()
     argument_spec.update(
         dict(
-            portgroup_name=dict(required=True, type='str'),
-            switch_name=dict(required=True, type='str'),
-            vlan_id=dict(required=True, type='str'),
-            num_ports=dict(required=True, type='int'),
-            portgroup_type=dict(required=True, choices=['earlyBinding', 'lateBinding', 'ephemeral'], type='str'),
-            state=dict(required=True, choices=['present', 'absent'], type='str'),
-            vlan_trunk=dict(type='bool', default=False),
-            vlan_private=dict(type='bool', default=False),
-            network_policy=dict(
+            switch=dict(type='str', required=True, aliases=['switch_name']),
+            portgroup=dict(type='str', required=True, aliases=['portgroup_name']),
+            description=dict(type='str', aliases=['portgroup_description']),
+            vlan_id=dict(type='int', default=0),
+            vlan_trunk_range=dict(type='list', elements='str'),
+            private_vlan_id=dict(type='int'),
+            num_ports=dict(type='int', aliases=['ports']),
+            network_resource_pool=dict(type='str', default='default'),
+            port_binding=dict(type='str', default='static', choices=['static', 'dynamic', 'ephemeral']),
+            port_allocation=dict(type='str', choices=['fixed', 'elastic']),
+            state=dict(type='str', default='present', choices=['present', 'absent']),
+            security=dict(
                 type='dict',
                 options=dict(
-                    promiscuous=dict(type='bool', default=False),
+                    promiscuous_mode=dict(type='bool', default=False, aliases=['promiscuous']),
                     forged_transmits=dict(type='bool', default=False),
                     mac_changes=dict(type='bool', default=False)
                 ),
                 default=dict(
-                    promiscuous=False,
+                    promiscuous_mode=False,
                     forged_transmits=False,
                     mac_changes=False
-                )
+                ),
+                aliases=['network_policy', 'security_policy']
             ),
-            teaming_policy=dict(
+            teaming=dict(
                 type='dict',
                 options=dict(
-                    inbound_policy=dict(type='bool', default=False),
+                    load_balancing=dict(
+                        type='str',
+                        default='loadbalance_srcid',
+                        choices=[
+                            'loadbalance_ip',
+                            'loadbalance_srcmac',
+                            'loadbalance_srcid',
+                            'loadbalance_loadbased',
+                            'failover_explicit',
+                        ],
+                        aliases=['load_balancing_policy'],
+                    ),
+                    network_failure_detection=dict(
+                        type='str',
+                        choices=['link_status_only', 'beacon_probing'],
+                        default='link_status_only',
+                    ),
                     notify_switches=dict(type='bool', default=True),
-                    rolling_order=dict(type='bool', default=False),
-                    load_balance_policy=dict(type='str',
-                                             default='loadbalance_srcid',
-                                             choices=[
-                                                 'loadbalance_ip',
-                                                 'loadbalance_srcmac',
-                                                 'loadbalance_srcid',
-                                                 'loadbalance_loadbased',
-                                                 'failover_explicit',
-                                             ],
-                                             )
+                    failback=dict(type='bool', default=True, aliases=['rolling_order']),
+                    active_uplinks=dict(type='list', elements='str'),
+                    standby_uplinks=dict(type='list', elements='str'),
                 ),
                 default=dict(
-                    inbound_policy=False,
+                    network_failure_detection='link_status_only',
                     notify_switches=True,
-                    rolling_order=False,
-                    load_balance_policy='loadbalance_srcid',
+                    failback=True,
+                    load_balancing='loadbalance_srcid',
                 ),
+                aliases=['teaming_policy']
             ),
-            port_policy=dict(
+            advanced=dict(
                 type='dict',
                 options=dict(
                     block_override=dict(type='bool', default=True),
-                    ipfix_override=dict(type='bool', default=False),
-                    live_port_move=dict(type='bool', default=False),
+                    netflow_override=dict(type='bool', default=False, aliases=['ipfix_override']),
                     network_rp_override=dict(type='bool', default=False),
                     port_config_reset_at_disconnect=dict(type='bool', default=True),
                     security_override=dict(type='bool', default=False),
@@ -614,8 +1340,7 @@ def main():
                 ),
                 default=dict(
                     block_override=True,
-                    ipfix_override=False,
-                    live_port_move=False,
+                    netflow_override=False,
                     network_rp_override=False,
                     port_config_reset_at_disconnect=True,
                     security_override=False,
@@ -624,20 +1349,37 @@ def main():
                     uplink_teaming_override=False,
                     vendor_config_override=False,
                     vlan_override=False
-                )
-            )
+                ),
+                aliases=['port_policy']
+            ),
+            netflow_enabled=dict(type='bool', default=False),
+            block_all_ports=dict(type='bool', default=False),
+            # TODO: traffic shaping
+            # TODO: traffic filtering and marking
+            # NOTE: The below parameters are deprecated starting from Ansible collection 2.0.0
+            vlan_trunk=dict(
+                type='bool',
+                default=False,
+                removed_in_version='2.0.0',
+                removed_from_collection='community.vmware',
+                ),
+            portgroup_type=dict(
+                type='str', choices=['earlyBinding', 'lateBinding', 'ephemeral'], removed_in_version='2.0.0',
+                removed_from_collection='community.vmware',
+            ),
         )
     )
 
-    module = AnsibleModule(argument_spec=argument_spec,
-                           mutually_exclusive=[
-                               ['vlan_trunk', 'vlan_private']
-                           ],
-                           supports_check_mode=True)
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        mutually_exclusive=[
+            ['vlan_id', 'vlan_trunk_range', 'private_vlan_id']
+        ],
+        supports_check_mode=True
+    )
 
     vmware_dvs_portgroup = VMwareDvsPortgroup(module)
     vmware_dvs_portgroup.process_state()
-
 
 if __name__ == '__main__':
     main()

--- a/plugins/modules/vmware_dvs_portgroup.py
+++ b/plugins/modules/vmware_dvs_portgroup.py
@@ -1362,7 +1362,7 @@ def main():
                 default=False,
                 removed_in_version='2.0.0',
                 removed_from_collection='community.vmware',
-                ),
+            ),
             portgroup_type=dict(
                 type='str', choices=['earlyBinding', 'lateBinding', 'ephemeral'], removed_in_version='2.0.0',
                 removed_from_collection='community.vmware',

--- a/tests/integration/targets/vmware_dvs_portgroup/tasks/main.yml
+++ b/tests/integration/targets/vmware_dvs_portgroup/tasks/main.yml
@@ -13,11 +13,11 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    switch_name: "{{ dvswitch1 }}"
-    portgroup_name: "basic"
+    switch: "{{ dvswitch1 }}"
+    portgroup: "basic"
     vlan_id: 0
     num_ports: 32
-    portgroup_type: earlyBinding
+    port_binding: static
     state: present
   register: dvs_pg_result_0001
 
@@ -35,11 +35,11 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    switch_name: "{{ dvswitch1 }}"
-    portgroup_name: "basic-vlan10"
+    switch: "{{ dvswitch1 }}"
+    portgroup: "basic-vlan10"
     vlan_id: 10
     num_ports: 32
-    portgroup_type: earlyBinding
+    port_binding: static
     state: present
   register: dvs_pg_result_0002
 
@@ -54,12 +54,11 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    switch_name: "{{ dvswitch1 }}"
-    portgroup_name: "basic-trunk"
-    vlan_id: 1-4094
-    vlan_trunk: true
+    switch: "{{ dvswitch1 }}"
+    portgroup: "basic-trunk"
+    vlan_trunk_range: [ 1-2000 ]
     num_ports: 32
-    portgroup_type: earlyBinding
+    port_binding: static
     state: present
   register: dvs_pg_result_0003
 
@@ -74,11 +73,11 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    switch_name: "{{ dvswitch1 }}"
-    portgroup_name: "basic"
+    switch: "{{ dvswitch1 }}"
+    portgroup: "basic"
     vlan_id: 0
     num_ports: 32
-    portgroup_type: earlyBinding
+    port_binding: static
     state: present
   register: dvs_pg_result_0004
 
@@ -93,20 +92,19 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    switch_name: "{{ dvswitch1 }}"
-    portgroup_name: "basic-all-enabled"
+    switch: "{{ dvswitch1 }}"
+    portgroup: "basic-all-enabled"
     vlan_id: 0
     num_ports: 32
-    portgroup_type: earlyBinding
+    port_binding: static
     state: present
-    network_policy:
-      promiscuous: true
+    security:
+      promiscuous_mode: true
       forged_transmits: true
       mac_changes: true
-    port_policy:
+    advanced:
       block_override: true
-      ipfix_override: true
-      live_port_move: true
+      netflow_override: true
       network_rp_override: true
       port_config_reset_at_disconnect: true
       security_override: true
@@ -128,17 +126,17 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    switch_name: "{{ dvswitch1 }}"
-    portgroup_name: "basic-some-enabled"
+    switch: "{{ dvswitch1 }}"
+    portgroup: "basic-some-enabled"
     vlan_id: 0
     num_ports: 32
-    portgroup_type: earlyBinding
+    port_binding: static
     state: present
-    network_policy:
-      promiscuous: true
+    security:
+      promiscuous_mode: true
       forged_transmits: true
       mac_changes: false
-    port_policy:
+    advanced:
       vlan_override: true
   register: dvs_pg_result_0006
 
@@ -153,17 +151,17 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    switch_name: "{{ dvswitch1 }}"
-    portgroup_name: "basic-some-enabled"
+    switch: "{{ dvswitch1 }}"
+    portgroup: "basic-some-enabled"
     vlan_id: 0
     num_ports: 32
-    portgroup_type: earlyBinding
+    port_binding: static
     state: present
-    network_policy:
-      promiscuous: true
+    security:
+      promiscuous_mode: true
       forged_transmits: false
       mac_changes: false
-    port_policy:
+    advanced:
       vlan_override: true
   register: dvs_pg_result_0007
 
@@ -178,17 +176,17 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    switch_name: "{{ dvswitch1 }}"
-    portgroup_name: "basic-some-enabled"
+    switch: "{{ dvswitch1 }}"
+    portgroup: "basic-some-enabled"
     vlan_id: 0
     num_ports: 32
-    portgroup_type: earlyBinding
+    port_binding: static
     state: present
-    network_policy:
-      promiscuous: true
+    security:
+      promiscuous_mode: true
       forged_transmits: false
       mac_changes: false
-    port_policy:
+    advanced:
       vlan_override: false
   register: dvs_pg_result_0008
 
@@ -203,21 +201,21 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    switch_name: "{{ dvswitch1 }}"
-    portgroup_name: "basic-some-enabled"
+    switch: "{{ dvswitch1 }}"
+    portgroup: "basic-some-enabled"
     vlan_id: 0
     num_ports: 16
-    portgroup_type: earlyBinding
+    port_binding: static
     state: present
-    network_policy:
-      promiscuous: true
+    security:
+      promiscuous_mode: true
       forged_transmits: false
       mac_changes: false
-    port_policy:
+    advanced:
       vlan_override: false
   register: dvs_pg_result_0009
 
-- name: ensure vlan_override is changed
+- name: ensure num_ports is changed
   assert:
     that:
         - dvs_pg_result_0009.changed
@@ -228,36 +226,35 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    switch_name: "{{ dvswitch1 }}"
-    portgroup_name: "basic-some-enabled"
+    switch: "{{ dvswitch1 }}"
+    portgroup: "basic-some-enabled"
     vlan_id: 0
     num_ports: 16
-    portgroup_type: ephemeral
+    port_binding: ephemeral
     state: present
-    network_policy:
-      promiscuous: true
+    security:
+      promiscuous_mode: true
       forged_transmits: false
       mac_changes: false
-    port_policy:
+    advanced:
       vlan_override: false
   register: dvs_pg_result_0010
 
-- name: ensure vlan_override is changed
+- name: ensure portgroup_type is changed
   assert:
     that:
         - dvs_pg_result_0010.changed
-
 - name: delete basic portgroup
   vmware_dvs_portgroup:
     validate_certs: false
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    switch_name: "{{ dvswitch1 }}"
-    portgroup_name: "basic"
+    switch: "{{ dvswitch1 }}"
+    portgroup: "basic"
     vlan_id: 0
     num_ports: 32
-    portgroup_type: earlyBinding
+    port_binding: static
     state: absent
   register: dvs_pg_result_0011
 
@@ -272,11 +269,11 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    switch_name: "{{ dvswitch1 }}"
-    portgroup_name: "basic"
+    switch: "{{ dvswitch1 }}"
+    portgroup: "basic"
     vlan_id: 0
     num_ports: 32
-    portgroup_type: earlyBinding
+    port_binding: static
     state: absent
   register: dvs_pg_result_0012
 
@@ -291,12 +288,11 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    switch_name: "{{ dvswitch1 }}"
-    portgroup_name: "basic_trunk_0001"
-    vlan_id: 1-4096
-    vlan_trunk: true
+    switch: "{{ dvswitch1 }}"
+    portgroup: "basic_trunk_0001"
+    vlan_trunk_range: [ 1-4096 ]
     num_ports: 32
-    portgroup_type: earlyBinding
+    port_binding: static
     state: present
   register: dvs_pg_result_0013
   ignore_errors: true
@@ -305,7 +301,7 @@
   assert:
     that:
         - not dvs_pg_result_0013.changed
-        - "'vlan_id range 1-4096 specified is incorrect. The valid vlan_id range is from 0 to 4094.' == '{{ dvs_pg_result_0013.msg }}'"
+        - "'vlan_trunk_range 1-4096 specified is incorrect. The valid vlan_trunk_range is from 0 to 4094.' == '{{ dvs_pg_result_0013.msg }}'"
 
 - name: Change VLAN on basic VLAN portgroup
   vmware_dvs_portgroup:
@@ -313,11 +309,11 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    switch_name: "{{ dvswitch1 }}"
-    portgroup_name: "basic-vlan10"
+    switch: "{{ dvswitch1 }}"
+    portgroup: "basic-vlan10"
     vlan_id: 20
     num_ports: 32
-    portgroup_type: earlyBinding
+    port_binding: static
     state: present
   register: dvs_pg_result_0014
 
@@ -332,12 +328,11 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    switch_name: "{{ dvswitch1 }}"
-    portgroup_name: "basic-trunk"
-    vlan_id: 1000-2000
-    vlan_trunk: true
+    switch: "{{ dvswitch1 }}"
+    portgroup: "basic-trunk"
+    vlan_trunk_range: [ 1000-2000 ]
     num_ports: 32
-    portgroup_type: earlyBinding
+    port_binding: static
     state: present
   register: dvs_pg_result_0015
 
@@ -352,12 +347,11 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    switch_name: "{{ dvswitch1 }}"
-    portgroup_name: "complex-trunk"
-    vlan_id: 1-1000, 1005, 1100-1200
-    vlan_trunk: true
+    switch: "{{ dvswitch1 }}"
+    portgroup: "complex-trunk"
+    vlan_trunk_range: [ 1-1000, 1005, 1100-1200 ]
     num_ports: 32
-    portgroup_type: earlyBinding
+    port_binding: static
     state: present
   register: dvs_pg_result_0016
 
@@ -372,12 +366,11 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    switch_name: "{{ dvswitch1 }}"
-    portgroup_name: "complex-trunk"
-    vlan_id: 1-1000, 1006, 1100-1200
-    vlan_trunk: true
+    switch: "{{ dvswitch1 }}"
+    portgroup: "complex-trunk"
+    vlan_trunk_range: [ 1-1000, 1006, 1100-1200 ]
     num_ports: 32
-    portgroup_type: earlyBinding
+    port_binding: static
     state: present
   register: dvs_pg_result_0017
 
@@ -391,12 +384,11 @@
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
-    portgroup_name: private-vlan-portgroup
-    switch_name: "{{ dvswitch1 }}"
-    vlan_id: 10
-    vlan_private: true
+    portgroup: private-vlan-portgroup
+    switch: "{{ dvswitch1 }}"
+    private_vlan_id: 10
     num_ports: 12
-    portgroup_type: earlyBinding
+    port_binding: static
     state: present
     validate_certs: false
   register: dvs_pg_result_0018
@@ -406,7 +398,7 @@
   assert:
     that:
         - not dvs_pg_result_0018.changed
-        - "'No private vlan with id 10 in distributed vSwitch {{ dvswitch1 }}' == '{{ dvs_pg_result_0018.msg }}'"
+        - "'Private VLANs are not configured for this distributed switch.' == '{{ dvs_pg_result_0018.msg }}'"
 
 - when: vcsim is not defined
   block:
@@ -418,7 +410,7 @@
         password: "{{ vcenter_password }}"
         datacenter_name: "{{ dc1 }}"
         state: present
-        switch_name: dvswitch_0001
+        switch: dvswitch_0001
         mtu: 9000
         uplink_quantity: 2
         discovery_proto: lldp
@@ -455,12 +447,11 @@
         hostname: '{{ vcenter_hostname }}'
         username: '{{ vcenter_username }}'
         password: '{{ vcenter_password }}'
-        portgroup_name: private-vlan-portgroup
-        switch_name: dvswitch_0001
-        vlan_id: 1
-        vlan_private: true
+        portgroup: private-vlan-portgroup
+        switch: dvswitch_0001
+        private_vlan_id: 1
         num_ports: 12
-        portgroup_type: earlyBinding
+        port_binding: static
         state: present
         validate_certs: false
       register: dvs_pg_result_0019
@@ -475,12 +466,11 @@
         hostname: '{{ vcenter_hostname }}'
         username: '{{ vcenter_username }}'
         password: '{{ vcenter_password }}'
-        portgroup_name: private-vlan-portgroup
-        switch_name: dvswitch_0001
-        vlan_id: 2
-        vlan_private: true
+        portgroup: private-vlan-portgroup
+        switch: dvswitch_0001
+        private_vlan_id: 2
         num_ports: 12
-        portgroup_type: earlyBinding
+        port_binding: static
         state: present
         validate_certs: false
       register: dvs_pg_result_0020
@@ -495,11 +485,11 @@
         hostname: '{{ vcenter_hostname }}'
         username: '{{ vcenter_username }}'
         password: '{{ vcenter_password }}'
-        portgroup_name: private-vlan-portgroup
-        switch_name: dvswitch_0001
+        portgroup: private-vlan-portgroup
+        switch: dvswitch_0001
         vlan_id: 5
         num_ports: 12
-        portgroup_type: earlyBinding
+        port_binding: static
         state: present
         validate_certs: false
       register: dvs_pg_result_0021
@@ -517,7 +507,7 @@
         password: "{{ vcenter_password }}"
         datacenter_name: "{{ dc1 }}"
         state: absent
-        switch_name: dvswitch_0001
+        switch: dvswitch_0001
       register: dvs_result_0001
 
     - name: Integration test a dvPortGroup name with special characters
@@ -546,11 +536,11 @@
             username: "{{ vcenter_username }}"
             password: "{{ vcenter_password }}"
             validate_certs: false
-            switch_name: 'dvSwitch\/%'
-            portgroup_name: 'dvportgroup\/%'
+            switch: 'dvSwitch\/%'
+            portgroup: 'dvportgroup\/%'
             vlan_id: 1
             num_ports: 8
-            portgroup_type: earlyBinding
+            port_binding: static
             state: present
           register: create_dvportgroup_with_special_characters_result
 
@@ -564,11 +554,11 @@
             username: "{{ vcenter_username }}"
             password: "{{ vcenter_password }}"
             validate_certs: false
-            switch_name: 'dvSwitch\/%'
-            portgroup_name: 'dvportgroup\/%'
+            switch: 'dvSwitch\/%'
+            portgroup: 'dvportgroup\/%'
             vlan_id: 1
             num_ports: 8
-            portgroup_type: earlyBinding
+            port_binding: static
             state: present
           register: create_dvportgroup_with_special_characters_idempotency_check_result
 
@@ -582,11 +572,11 @@
             username: "{{ vcenter_username }}"
             password: "{{ vcenter_password }}"
             validate_certs: false
-            switch_name: 'dvSwitch\/%'
-            portgroup_name: 'dvportgroup\/%'
+            switch: 'dvSwitch\/%'
+            portgroup: 'dvportgroup\/%'
             vlan_id: 1
             num_ports: 8
-            portgroup_type: earlyBinding
+            port_binding: static
             state: absent
           register: delete_dvportgroup_with_special_characters_result
 
@@ -600,11 +590,11 @@
             username: "{{ vcenter_username }}"
             password: "{{ vcenter_password }}"
             validate_certs: false
-            switch_name: 'dvSwitch\/%'
-            portgroup_name: 'dvportgroup\/%'
+            switch: 'dvSwitch\/%'
+            portgroup: 'dvportgroup\/%'
             vlan_id: 1
             num_ports: 8
-            portgroup_type: earlyBinding
+            port_binding: static
             state: absent
           register: delete_dvportgroup_with_special_characters_idempotency_check_result
 


### PR DESCRIPTION
##### SUMMARY

- Add ```port_allocation``` option
- Add ```port_binding``` option (replacement for ```portgroup_type``` option)
- Add ```network_resource_pool``` option
- Add ```vlan_trunk_range``` option (replacement for ```vlan_trunk``` option)
- Add ```private_vlan_id``` option
- Fix teaming policy: now it's possible to configure every option available in the vSphere Client
  - Use ```failback``` instead of ```rolling_order``` to match vSphere Client
  - Remove ```inbound_policy``` option (deprecated in API since v5.1)
  - Add ```network_failure_detection``` option
  - Add ```failover_order``` (```active_uplinks``` and ```standby_uplinks```) option
- Add ```netflow_enabled``` and ```block_all_ports``` options
- Remove ```live_port_move``` option from ```port_policies``` / ```advanced``` which isn't available in the vSphere Client
- Add update functionality for all options

Fixes https://github.com/ansible-collections/community.vmware/issues/161

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_dvs_portgroup

##### ADDITIONAL INFORMATION
Original PR: https://github.com/ansible/ansible/pull/48719

Makes commit e750c5a (Added private vlan configuration) in vmware_dvs_portgroup (#78) and parameter vlan_private obsolete
(Copied private VLAN sanity check from this commit)
