### PR TITLE
vmware_resource_pool: add integration test for using esxi_hostname param

### DIFF
--- a/tests/integration/targets/prepare_vmware_tests/tasks/init_real_lab.yml
+++ b/tests/integration/targets/prepare_vmware_tests/tasks/init_real_lab.yml
@@ -9,6 +9,8 @@
     - include_tasks: setup_cluster.yml
     - include_tasks: setup_attach_hosts.yml
       when: setup_attach_host is defined
+    - include_tasks: move_host_out_of_cluster.yml
+      when: move_host_out_of_cluster is defined
     - include_tasks: setup_datastore.yml
       when: setup_datastore is defined
     - include_tasks: setup_virtualmachines.yml

--- a/tests/integration/targets/prepare_vmware_tests/tasks/move_host_out_of_cluster.yml
+++ b/tests/integration/targets/prepare_vmware_tests/tasks/move_host_out_of_cluster.yml
@@ -1,0 +1,44 @@
+---
+- name: Enter maintenance mode
+  vmware_maintenancemode:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi_hosts.1 }}"
+    state: present
+  register: enter_maintenance_mode_result
+
+- assert:
+    that:
+      - enter_maintenance_mode_result.changed is sameas true
+
+- name: Move ESXi out of Cluster
+  vmware_host:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    datacenter: "{{ dc1 }}"
+    folder: "{{ dc1 }}/host"
+    esxi_hostname: "{{ esxi_hosts.1 }}"
+    state: reconnect
+  register: move_esxi_out_of_cluster_result
+
+- assert:
+    that:
+      - move_esxi_out_of_cluster_result.changed is sameas true
+
+- name: Exit maintenance mode
+  vmware_maintenancemode:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi_hosts.1 }}"
+    state: absent
+  register: exit_maintenance_mode_result
+
+- assert:
+    that:
+      - exit_maintenance_mode_result.changed is sameas true

--- a/tests/integration/targets/vmware_resource_pool/aliases
+++ b/tests/integration/targets/vmware_resource_pool/aliases
@@ -1,3 +1,3 @@
 cloud/vcenter
 needs/target/prepare_vmware_tests
-zuul/vmware/vcenter_1esxi
+zuul/vmware/vcenter_2esxi

--- a/tests/integration/targets/vmware_resource_pool/tasks/main.yml
+++ b/tests/integration/targets/vmware_resource_pool/tasks/main.yml
@@ -224,7 +224,7 @@
       password: "{{ vcenter_password }}"
       validate_certs: false
       datacenter: "{{ dc1 }}"
-      esxi_hostname: "{{ esxi_hosts.0 }}"
+      esxi_hostname: "{{ esxi1 }}"
 
   block:
     - name: add resource pool to ESXi with check_mode

--- a/tests/integration/targets/vmware_resource_pool/tasks/main.yml
+++ b/tests/integration/targets/vmware_resource_pool/tasks/main.yml
@@ -7,6 +7,7 @@
   vars:
     setup_attach_host: true
     setup_datastore: true
+    move_host_out_of_cluster: true
 
 - name: set the vmware_resource_pool module default values
   module_defaults:
@@ -224,7 +225,7 @@
       password: "{{ vcenter_password }}"
       validate_certs: false
       datacenter: "{{ dc1 }}"
-      esxi_hostname: "{{ esxi1 }}"
+      esxi_hostname: "{{ esxi2 }}"
 
   block:
     - name: add resource pool to ESXi with check_mode

--- a/tests/integration/targets/vmware_resource_pool/tasks/main.yml
+++ b/tests/integration/targets/vmware_resource_pool/tasks/main.yml
@@ -215,3 +215,101 @@
         that:
           - resource_result_014.changed is sameas false
           - resource_result_014.resource_pool_config is defined
+
+- name: set the vmware_resource_pool module default values without cluster parameter
+  module_defaults:
+    vmware_resource_pool:
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      validate_certs: false
+      datacenter: "{{ dc1 }}"
+      esxi_hostname: "{{ esxi_hosts.0 }}"
+
+  block:
+    - name: add resource pool to ESXi with check_mode
+      vmware_resource_pool:
+        resource_pool: test_resource_015
+      check_mode: true
+      register: resource_result_015
+
+    - assert:
+        that:
+          - resource_result_015.changed is sameas true
+
+    - name: add resource pool to ESXi
+      vmware_resource_pool:
+        resource_pool: test_resource_015
+      register: resource_result_016
+
+    - assert:
+        that:
+          - resource_result_016.changed is sameas true
+
+    - name: add resource pool to ESXi(idempotency check)
+      vmware_resource_pool:
+        resource_pool: test_resource_015
+      register: resource_result_017
+
+    - assert:
+        that:
+          - resource_result_017.changed is sameas false
+
+    - name: change resource pool config with the custom default value and check_mode
+      vmware_resource_pool:
+        resource_pool: test_resource_015
+        mem_shares: custom
+        cpu_shares: custom
+      check_mode: true
+      register: resource_result_018
+
+    - assert:
+        that:
+          - resource_result_018.changed is sameas true
+
+    - name: change resource pool config with the custom default value
+      vmware_resource_pool:
+        resource_pool: test_resource_015
+        mem_shares: custom
+        cpu_shares: custom
+      register: resource_result_019
+
+    - assert:
+        that:
+          - resource_result_019.changed is sameas true
+          - resource_result_019.resource_pool_config is defined
+          - resource_result_019.resource_pool_config.cpuAllocation.shares.level == 'custom'
+          - resource_result_019.resource_pool_config.cpuAllocation.shares.shares == 4000
+          - resource_result_019.resource_pool_config.memoryAllocation.shares.level == 'custom'
+          - resource_result_019.resource_pool_config.memoryAllocation.shares.shares == 163840
+
+    - name: remove resource pool from ESXi with check_mode
+      vmware_resource_pool:
+        resource_pool: test_resource_015
+        state: absent
+      check_mode: true
+      register: resource_result_020
+
+    - assert:
+        that:
+          - resource_result_020.changed is sameas true
+
+    - name: remove resource pool from ESXi
+      vmware_resource_pool:
+        resource_pool: test_resource_015
+        state: absent
+      register: resource_result_021
+
+    - assert:
+        that:
+          - resource_result_021.changed is sameas true
+
+    - name: remove resource pool from ESXi(idempotency check)
+      vmware_resource_pool:
+        resource_pool: test_resource_015
+        state: absent
+      register: resource_result_023
+
+    - assert:
+        that:
+          - resource_result_023.changed is sameas false


### PR DESCRIPTION
##### SUMMARY

This PR adds tests for using the esxi_hostname parameter to the vmware_resource_pool integration test.  
Follow up: https://github.com/ansible-collections/community.vmware/pull/524

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

tests/integration/targets/vmware_resource_pool/tasks/main.yml

##### ADDITIONAL INFORMATION

The integration test file did not existing the tests for using the esxi_hostname parameter, so I add it.