### PR TITLE
modify the changelog.yaml for 1.5.1 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ community.vmware Release Notes
 
 .. contents:: Topics
 
+
 v1.5.1
 ======
 
@@ -22,8 +23,8 @@ Minor Changes
 - vmware_drs_group - code refactor (https://github.com/ansible-collections/community.vmware/pull/475).
 - vmware_guest - add documentation for networks parameters connected and start_connected (https://github.com/ansible-collections/community.vmware/issues/507).
 - vmware_guest_controller - error handling in task exception.
-- vmware_vm_inventory - skip inaccessible vm configuration.
 - vmware_resource_pool - manage resource pools on ESXi hosts (https://github.com/ansible-collections/community.vmware/issues/492).
+- vmware_vm_inventory - skip inaccessible vm configuration.
 
 Bugfixes
 --------

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -437,8 +437,6 @@ releases:
     release_date: '2020-11-12'
   1.5.0:
     changes:
-      breaking_changes:
-      - vmware_resource_pool - manage resource pools on ESXi hosts (https://github.com/ansible-collections/community.vmware/issues/492).
       bugfixes:
       - vmware_cluster_ha - added APD and PDL configuration (https://github.com/ansible-collections/community.vmware/issues/451).
       - vmware_deploy_ovf - fixed an UnboundLocalError for variable 'name' in check
@@ -453,6 +451,7 @@ releases:
         (https://github.com/ansible-collections/community.vmware/issues/507).
       - vmware_guest_controller - error handling in task exception.
       - vmware_vm_inventory - skip inaccessible vm configuration.
+      - vmware_resource_pool - manage resource pools on ESXi hosts (https://github.com/ansible-collections/community.vmware/issues/492).
     fragments:
     - 436_vmware_object_role_permission.yml
     - 451_vmware_cluster_ha.yml
@@ -464,3 +463,8 @@ releases:
     - inventory_fix.yml
     - vmware_guest_ctrl.yml
     release_date: '2020-12-01'
+  1.5.1:
+    changes:
+      minor_changes:
+      - vmware_resource_pool - relabel the change introduced in 1.5.0 as Minor Changes (https://github.com/ansible-collections/community.vmware/issues/540).
+    release_date: '2020-12-02'


### PR DESCRIPTION
We actually need to modify the `changelogs/changelog.yaml` to
get the `CHANGELOG.rst` right.

I used `antsibull-changelog generate` to regenerate the final changelog
file.