### PR TITLE
vmware_guest: Fix an issue with vSphere 7 when adding several HDDs / NICs

### DIFF
--- a/changelogs/fragments/545-vmware_guest.yml
+++ b/changelogs/fragments/545-vmware_guest.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- vmware_guest - fix an issue with vSphere 7 when adding several virtual disks and / or vNICs (https://github.com/ansible-collections/community.vmware/issues/545)

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -1174,6 +1174,7 @@ class PyVmomiDeviceHelper(object):
         diskspec = vim.vm.device.VirtualDeviceSpec()
         diskspec.operation = vim.vm.device.VirtualDeviceSpec.Operation.add
         diskspec.device = vim.vm.device.VirtualDisk()
+        diskspec.device.key = -randint(20000, 24999)
         diskspec.device.backing = vim.vm.device.VirtualDisk.FlatVer2BackingInfo()
         diskspec.device.controllerKey = disk_ctl.device.key
 
@@ -1224,6 +1225,7 @@ class PyVmomiDeviceHelper(object):
     def create_nic(self, device_type, device_label, device_infos):
         nic = vim.vm.device.VirtualDeviceSpec()
         nic.device = self.get_device(device_type, device_infos['name'])
+        nic.device.key = -randint(25000, 29999)
         nic.device.wakeOnLanEnabled = bool(device_infos.get('wake_on_lan', True))
         nic.device.deviceInfo = vim.Description()
         nic.device.deviceInfo.label = device_label


### PR DESCRIPTION
##### SUMMARY
The behavior of the vSphere API changed considerably with 7.0U1 (probably already with 7.0, but I didn't have closer look).

The difference is: Although the key property of a virtual device is ignored, vCenter now checks if it is unique and fails if it isn't. The problem is that all virtual disks and NICs are created with a default key of 0, so are not unique.

Fixes #545 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_guest

##### ADDITIONAL INFORMATION
`vmware_guest_disk` has the same problem: #373 