### PR TITLE
vmware_host_logbundle - handle fetch_url status

### DIFF
--- a/changelogs/fragments/vmware_host_logbundle.yml
+++ b/changelogs/fragments/vmware_host_logbundle.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- vmware_host_logbundle - handle fetch_url status before attempting to read response.


### PR DESCRIPTION
##### SUMMARY

When url timeouts fetch_url API returns None. Check status
before proceeding and using response from fetch_url

Fixes error message like
"Failed to fetch logbundle from ...: 'NoneType' object has no attribute 'read'"

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/vmware_host_logbundle.yml
plugins/modules/vmware_host_logbundle.py
