### PR TITLE
vmware_host_firewall_manager: prepare all_ip transition

### DIFF
--- a/changelogs/fragments/vmware_host_firewall_manager-prepare-all_ip-transition.yaml
+++ b/changelogs/fragments/vmware_host_firewall_manager-prepare-all_ip-transition.yaml
@@ -1,0 +1,3 @@
+---
+deprecated_features:
+- vmware_host_firewall_manager - the creation of new rule with no ``allowed_ip`` entry in the ``allowed_hosts`` dictionary won't be allowed after 2.0.0 release.

--- a/plugins/modules/vmware_host_firewall_manager.py
+++ b/plugins/modules/vmware_host_firewall_manager.py
@@ -60,6 +60,8 @@ EXAMPLES = r'''
     rules:
         - name: vvold
           enabled: True
+          allowed_hosts:
+            all_ip: True
   delegate_to: localhost
 
 - name: Enable vvold rule set for an ESXi Host
@@ -71,6 +73,8 @@ EXAMPLES = r'''
     rules:
         - name: vvold
           enabled: True
+          allowed_hosts:
+            all_ip: True
   delegate_to: localhost
 
 - name: Manage multiple rule set for an ESXi Host
@@ -82,6 +86,8 @@ EXAMPLES = r'''
     rules:
         - name: vvold
           enabled: True
+          allowed_hosts:
+            all_ip: True
         - name: CIMHttpServer
           enabled: False
   delegate_to: localhost
@@ -391,6 +397,17 @@ def main():
                         version='3.0.0',
                         collection_name='community.vmware'
                     )
+        if not rule_option.get("enabled"):
+            continue
+        try:
+            isinstance(rule_option["allowed_hosts"]["all_ip"], bool)
+        except (KeyError, IndexError):
+            module.deprecate(
+                msg=('Please adjust your playbook to ensure the `allowed_hosts` '
+                     'entries come with an `all_ip` key (boolean).'),
+                version='2.0.0',
+                collection_name='community.vmware'
+            )
 
     vmware_firewall_manager = VmwareFirewallManager(module)
     vmware_firewall_manager.check_params()


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/community.vmware/pull/600

Starting with 2.0.0,  `all_ip` subkey of `allowed_hosts` will have to be defined.

See: https://github.com/ansible-collections/community.vmware/issues/178