### PR TITLE
temporarily disable vmware_migrate_vmk test

### DIFF
--- a/tests/integration/targets/vmware_migrate_vmk/aliases
+++ b/tests/integration/targets/vmware_migrate_vmk/aliases
@@ -1,3 +1,4 @@
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+disabled


### PR DESCRIPTION
##### SUMMARY

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tests/integration/targets/vmware_migrate_vmk/aliases
