### PR TITLE
vmware_migrate_vmk: Fix integration test

### DIFF
--- a/tests/integration/targets/vmware_migrate_vmk/aliases
+++ b/tests/integration/targets/vmware_migrate_vmk/aliases
@@ -1,4 +1,3 @@
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
-disabled

--- a/tests/integration/targets/vmware_migrate_vmk/tasks/main.yml
+++ b/tests/integration/targets/vmware_migrate_vmk/tasks/main.yml
@@ -95,9 +95,11 @@
             username: "{{ vcenter_username }}"
             password: "{{ vcenter_password }}"
             validate_certs: false
-            datacenter: "{{ dc1 }}"
-            switch: "{{ dvswitch1 }}"
-            uplink_quantity: 1
+            datacenter_name: "{{ dc1 }}"
+            switch_name: "{{ dvswitch1 }}"
+            switch_version: 6.5.0
+            uplink_quantity: 2
+            state: present
           register: create_new_dvswitch_result
 
         - assert:
@@ -112,6 +114,7 @@
             validate_certs: false
             esxi_hostname: "{{ esxi1 }}"
             switch_name: "{{ dvswitch1 }}"
+            state: present
           register: add_esxi_host_dvswitch_result
 
         - assert:

--- a/tests/integration/targets/vmware_migrate_vmk/tasks/main.yml
+++ b/tests/integration/targets/vmware_migrate_vmk/tasks/main.yml
@@ -72,26 +72,6 @@
         that:
           - create_new_vswitch_pg_result.changed is sameas true
 
-    - name: "Create a new vmkernel"
-      vmware_vmkernel:
-        hostname: "{{ vcenter_hostname }}"
-        username: "{{ vcenter_username }}"
-        password: "{{ vcenter_password }}"
-        validate_certs: false
-        esxi_hostname: "{{ esxi1 }}"
-        vswitch_name: "{{ switch1 }}"
-        portgroup_name: "{{ vswitch_pg_name_for_test }}"
-        device: "{{ device_name }}"
-        network:
-          type: 'static'
-          ip_address: 192.168.0.254
-          subnet_mask: 255.255.255.0
-      register: prepare_integration_tests_result
-
-    - assert:
-        that:
-          - prepare_integration_tests_result.changed is sameas true
-
     - name: "Gather dvSwitch info"
       vmware_dvswitch_info:
         hostname: "{{ vcenter_hostname }}"
@@ -138,7 +118,6 @@
             that:
               - add_esxi_host_dvswitch_result.changed is sameas true
 
-
     - name: "Create new a port group of dvSwitch"
       vmware_dvs_portgroup:
         hostname: "{{ vcenter_hostname }}"
@@ -156,6 +135,26 @@
     - assert:
         that:
           - create_new_dvswitch_pg_result.changed is sameas true
+
+    - name: "Create a new vmkernel"
+      vmware_vmkernel:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        esxi_hostname: "{{ esxi1 }}"
+        vswitch_name: "{{ switch1 }}"
+        portgroup_name: "{{ vswitch_pg_name_for_test }}"
+        device: "{{ device_name }}"
+        network:
+          type: 'static'
+          ip_address: 192.168.0.254
+          subnet_mask: 255.255.255.0
+      register: prepare_integration_tests_result
+
+    - assert:
+        that:
+          - prepare_integration_tests_result.changed is sameas true
 
 - name: "Migrate Management vmk from vSwitch to dvSwitch"
   vmware_migrate_vmk:
@@ -231,22 +230,6 @@
 
 - name: "Delete the used objects for integration test"
   block:
-    - name: "Delete the used dvSwitch for integration test"
-      vmware_dvswitch:
-        hostname: "{{ vcenter_hostname }}"
-        username: "{{ vcenter_username }}"
-        password: "{{ vcenter_password }}"
-        validate_certs: false
-        datacenter: "{{ dc1 }}"
-        switch: "{{ dvswitch1 }}"
-        uplink_quantity: 1
-        state: absent
-      register: delete_dvswitch_result
-
-    - assert:
-        that:
-          - delete_dvswitch_result.changed is sameas true
-
     - name: "Delete the used vmkernel for integration test"
       vmware_vmkernel:
         hostname: "{{ vcenter_hostname }}"
@@ -263,6 +246,22 @@
     - assert:
         that:
           - delete_vmk_result.changed is sameas true
+
+    - name: "Delete the used dvSwitch for integration test"
+      vmware_dvswitch:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        datacenter: "{{ dc1 }}"
+        switch: "{{ dvswitch1 }}"
+        uplink_quantity: 1
+        state: absent
+      register: delete_dvswitch_result
+
+    - assert:
+        that:
+          - delete_dvswitch_result.changed is sameas true
 
     - name: "Delete the used port group for integration test"
       vmware_portgroup:

--- a/tests/integration/targets/vmware_migrate_vmk/tasks/main.yml
+++ b/tests/integration/targets/vmware_migrate_vmk/tasks/main.yml
@@ -132,8 +132,6 @@
             validate_certs: false
             esxi_hostname: "{{ esxi1 }}"
             switch_name: "{{ dvswitch1 }}"
-            vmnics:
-              - vmnic1
           register: add_esxi_host_dvswitch_result
 
         - assert:


### PR DESCRIPTION
##### SUMMARY
`vmware_migrate_vmk` integration tests fail against vCenter 7

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_migrate_vmk

##### ADDITIONAL INFORMATION
~~The integration test tries to create a vmkernel interface with IP `192.168.0.254/24`. But `192.168.0.254` is usually the broadcast address in network `192.168.0.0/24` and it's possible that vCenter 7 doesn't like this.~~

_edit:_
As @laidbackware pointed out correctly, the broadcast address is .255, **not** .254.

_update_:
I don't think we have a problem with creating the vmkernel interface or the IP `192.168.0.254/24`. It looks like `Add ESXi host to dvSwitch` fails and the CI pipeline tries again, but _then_ creating a vmk interface with `192.168.0.254/24` fails because this would result in a duplicate IP address.