### PR TITLE
update teardown to support vsphere 7.0u1

### DIFF
--- a/changelogs/fragments/568_teardown_with_esxi.yaml
+++ b/changelogs/fragments/568_teardown_with_esxi.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+- For vSphere 7.0u1, add steps to tests to remove vCLS VMs before removing datastore
+- Fix vSwitch0 default port group removal to run against all hosts
+- Fix remove hosts from cluster to use cluster name variable

--- a/tests/integration/targets/prepare_vmware_tests/tasks/teardown_with_esxi.yml
+++ b/tests/integration/targets/prepare_vmware_tests/tasks/teardown_with_esxi.yml
@@ -98,7 +98,7 @@
   with_items: "{{ esxi_hosts }}"
   ignore_errors: true
 
-- name: Exit maintenance on hosts to allow deletion of vCSA VMs
+- name: Exit maintenance on hosts to allow deletion of vCLS VMs
   vmware_maintenancemode:
     hostname: "{{ item }}"
     username: "{{ esxi_user }}"

--- a/tests/integration/targets/prepare_vmware_tests/tasks/teardown_with_esxi.yml
+++ b/tests/integration/targets/prepare_vmware_tests/tasks/teardown_with_esxi.yml
@@ -87,6 +87,28 @@
   with_items: "{{ esxi_hosts }}"
   ignore_errors: true
 
+- name: Remove ESXi Hosts to vCenter
+  vmware_host:
+    datacenter_name: '{{ dc1 }}'
+    cluster_name: '{{ ccr1 }}'
+    esxi_hostname: '{{ item }}'
+    esxi_username: '{{ esxi_user }}'
+    esxi_password: '{{ esxi_password }}'
+    state: absent
+  with_items: "{{ esxi_hosts }}"
+  ignore_errors: true
+
+- name: Exit maintenance on hosts to allow deletion of vCSA VMs
+  vmware_maintenancemode:
+    hostname: "{{ item }}"
+    username: "{{ esxi_user }}"
+    password: "{{ esxi_password }}"
+    esxi_hostname: "{{ item }}"
+    timeout: 3600
+    state: absent
+  with_items: "{{ esxi_hosts }}"
+  delegate_to: localhost
+
 - name: Gather all remaining VMs on hosts
   vmware_vm_info:
     hostname: '{{ item }}'
@@ -109,17 +131,6 @@
     - "{{ vminfo.results }}"
     - virtual_machines
   when: "'vCLS' in item.1.guest_name"
-
-- name: Remove ESXi Hosts to vCenter
-  vmware_host:
-    datacenter_name: '{{ dc1 }}'
-    cluster_name: '{{ ccr1 }}'
-    esxi_hostname: '{{ item }}'
-    esxi_username: '{{ esxi_user }}'
-    esxi_password: '{{ esxi_password }}'
-    state: absent
-  with_items: "{{ esxi_hosts }}"
-  ignore_errors: true
 
 - name: Umount NFS datastores to ESXi (1/2)
   vmware_host_datastore:

--- a/tests/integration/targets/prepare_vmware_tests/tasks/teardown_with_esxi.yml
+++ b/tests/integration/targets/prepare_vmware_tests/tasks/teardown_with_esxi.yml
@@ -69,12 +69,13 @@
 
 - name: Remove any potential existing "VM Network" on vSwitch0
   vmware_portgroup:
-    esxi_hostname: '{{ esxi_hosts }}'
+    esxi_hostname: '{{ item }}'
     switch: vSwitch0
     portgroup: VM Network
     validate_certs: false
     state: absent
   ignore_errors: true
+  with_items: "{{ esxi_hosts }}"
 
 - name: Remove the vSwitches
   vmware_vswitch:
@@ -86,10 +87,33 @@
   with_items: "{{ esxi_hosts }}"
   ignore_errors: true
 
+- name: Gather all remaining VMs on hosts
+  vmware_vm_info:
+    hostname: '{{ item }}'
+    username: '{{ esxi_user }}'
+    password: '{{ esxi_password }}'
+  delegate_to: localhost
+  register: vminfo
+  with_items: "{{ esxi_hosts }}"
+
+- name: Remove remaining any vCLS VMs
+  vmware_guest:
+    hostname: "{{ item.0.item }}"
+    username: '{{ esxi_user }}'
+    password: '{{ esxi_password }}'
+    uuid: "{{ item.1.uuid }}"
+    force: true
+    state: absent
+  delegate_to: localhost
+  with_subelements:
+    - "{{ vminfo.results }}"
+    - virtual_machines
+  when: "'vCLS' in item.1.guest_name"
+
 - name: Remove ESXi Hosts to vCenter
   vmware_host:
     datacenter_name: '{{ dc1 }}'
-    cluster_name: ccr1
+    cluster_name: '{{ ccr1 }}'
     esxi_hostname: '{{ item }}'
     esxi_username: '{{ esxi_user }}'
     esxi_password: '{{ esxi_password }}'


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/community.vmware/pull/577

##### SUMMARY
In vCenter 7.0u1 and above when creating a vSphere cluster some vCenter managed VMs are created to help with DRS. When a shared a datastore is added to a cluster the VMs will be automatically moved there, which has broken the teardown_with_esxi play. After hosts are removed from the cluster the NFS datastore cannot be unmounted due to the existence of the vCLS VMs. This fix will forcefully remove the vCLS VMs before the hosts are removed from the cluster.

Also fixed the vSwitch0 removal to remove 'VM Network' port group from each host and fixed the remove hosts from cluster to use the parameterised cluster name.

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
teardown_with_esxi.yml 

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
