### PR TITLE
vmware_host_firewall_manager: prepare all_ip transition

### DIFF
--- a/changelogs/fragments/vmware_host_firewall_manager-prepare-all_ip-transition.yaml
+++ b/changelogs/fragments/vmware_host_firewall_manager-prepare-all_ip-transition.yaml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+- vmware_host_firewall_manager - Add a deprecation warning regarding the user of new rule with no ``allowed_hosts`` key. This will be enforced by the release 2.0.0.
+- vmware_host_firewall_manager - Add a deprecation warning regardng the user of new rule with no ``allowed_ip`` entry in the ``allowed_hosts`` dictionary.


### PR DESCRIPTION
Starting with 2.0.0, `allowed_hosts` will be a dictionary and
its `all_ip` subkey will have to be defined.

See: https://github.com/ansible-collections/community.vmware/issues/178