### PR TITLE
vmware_host_disk_info: new module

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Name | Description
 [community.vmware.vmware_host_config_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_config_info_module.rst)|Gathers info about an ESXi host's advance configuration information
 [community.vmware.vmware_host_config_manager](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_config_manager_module.rst)|Manage advanced system settings of an ESXi host
 [community.vmware.vmware_host_datastore](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_datastore_module.rst)|Manage a datastore on ESXi host
+[community.vmware.vmware_host_disk_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_disk_info_module.rst)|Gathers information about disks attached to given ESXi host/s.
 [community.vmware.vmware_host_dns](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_dns_module.rst)|Manage DNS configuration of an ESXi host system
 [community.vmware.vmware_host_dns_facts](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_dns_facts_module.rst)|Gathers facts about an ESXi host's DNS configuration information
 [community.vmware.vmware_host_dns_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_dns_info_module.rst)|Gathers info about an ESXi host's DNS configuration information

--- a/docs/community.vmware.vmware_host_disk_info_module.rst
+++ b/docs/community.vmware.vmware_host_disk_info_module.rst
@@ -1,0 +1,302 @@
+.. _community.vmware.vmware_host_disk_info_module:
+
+
+**************************************
+community.vmware.vmware_host_disk_info
+**************************************
+
+**Gathers information about disks attached to given ESXi host/s.**
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- This module returns information about disks attached to given ESXi host/s
+- If *cluster_name* is provided, then disk information about all hosts from the given cluster will be returned.
+- If *esxi_hostname* is provided, then disk information about the given host system will be returned.
+
+
+
+Requirements
+------------
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- PyVmomi
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+            <th width="100%">Comments</th>
+        </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>cluster_name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Name of the cluster from which the ESXi host belong to.</div>
+                        <div>If <code>esxi_hostname</code> is not given, this parameter is required.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>esxi_hostname</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>ESXi hostname to gather information from.</div>
+                        <div>If <code>cluster_name</code> is not given, this parameter is required.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>hostname</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The hostname or IP address of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_HOST</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The password of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PASSWORD</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: pass, pwd</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">443</div>
+                </td>
+                <td>
+                        <div>The port number of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PORT</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>proxy_host</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Address of a proxy that will receive all HTTPS requests and relay them.</div>
+                        <div>The format is a hostname or a IP.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PROXY_HOST</code> will be used instead.</div>
+                        <div>This feature depends on a version of pyvmomi greater than v6.7.1.2018.12</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>proxy_port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Port of the HTTP proxy that will receive all HTTPS requests and relay them.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PROXY_PORT</code> will be used instead.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>username</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The username of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_USER</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: admin, user</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>validate_certs</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>no</li>
+                                    <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Allows connection when SSL certificates are not valid. Set to <code>false</code> when certificates are not trusted.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_VALIDATE_CERTS</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                        <div>If set to <code>true</code>, please make sure Python &gt;= 2.7.9 is installed on the given machine.</div>
+                </td>
+            </tr>
+    </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - Tested on vSphere 6.7 and 7.0
+
+
+
+Examples
+--------
+
+.. code-block:: yaml
+
+    - name: Gather info about vmhbas of all ESXi Host in the given Cluster
+      community.vmware.vmware_host_disk_info:
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        cluster_name: '{{ cluster_name }}'
+      delegate_to: localhost
+      register: cluster_host_vmhbas
+
+    - name: Gather info about vmhbas of an ESXi Host
+      community.vmware.vmware_host_disk_info:
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        esxi_hostname: '{{ esxi_hostname }}'
+      delegate_to: localhost
+      register: host_vmhbas
+
+
+
+Return Values
+-------------
+Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>hosts_disk_info</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                    </div>
+                </td>
+                <td>always</td>
+                <td>
+                            <div>list of information for all disks attached to each ESXi host</div>
+                    <br/>
+                        <div style="font-size: smaller"><b>Sample:</b></div>
+                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">&quot;192.168.0.182&quot;: [
+        {
+            &quot;canonical_name&quot;: &quot;naa.6000c296ed6217bd61df35622eb21a3a&quot;,
+            &quot;capacity_mb&quot;: 4096,
+            &quot;device_path&quot;: &quot;/vmfs/devices/disks/naa.6000c296ed6217bd61df35622eb21a3a&quot;,
+            &quot;device_type&quot;: &quot;disk&quot;,
+            &quot;device_ctd_list&quot;: [
+                &quot;vmhba0:C0:T1:L0&quot;
+            ],
+            &quot;disk_uid&quot;: &quot;key-vim.host.ScsiDisk-02000000006000c296ed6217bd61df35622eb21a3a566972747561&quot;,
+            &quot;display_name&quot;: &quot;Local VMware Disk (naa.6000c296ed6217bd61df35622eb21a3a)&quot;
+        },
+        {
+            &quot;canonical_name&quot;: &quot;naa.6000c2968ad7142d93faae527fe8822b&quot;,
+            &quot;capacity_mb&quot;: 204800,
+            &quot;device_path&quot;: &quot;/vmfs/devices/disks/naa.6000c2968ad7142d93faae527fe8822b&quot;,
+            &quot;device_type&quot;: &quot;disk&quot;,
+            &quot;device_ctd_list&quot;: [
+                &quot;vmhba0:C0:T3:L0&quot;
+            ],
+            &quot;disk_uid&quot;: &quot;key-vim.host.ScsiDisk-02000000006000c2968ad7142d93faae527fe8822b566972747561&quot;,
+            &quot;display_name&quot;: &quot;Local VMware Disk (naa.6000c2968ad7142d93faae527fe8822b)&quot;
+        },]</div>
+                </td>
+            </tr>
+    </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Matt Proud (@laidbackware)

--- a/plugins/modules/vmware_host_disk_info.py
+++ b/plugins/modules/vmware_host_disk_info.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type

--- a/plugins/modules/vmware_host_disk_info.py
+++ b/plugins/modules/vmware_host_disk_info.py
@@ -1,0 +1,163 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.0',
+    'author': 'Matt Proud'
+}
+
+DOCUMENTATION = '''
+---
+module: vmware_host_disk_info
+short_description: Gathers information about disks attached to given ESXi host/s
+description:
+- This module returns information about disks attached to given ESXi host/s
+- If cluster_name is provide, then disk information about all hosts from given cluster will be returned.
+- If esxi_hostname is provided, then disk information about given host system will be returned.
+authot:
+- Matt Proud
+notes:
+- Tested on vSphere 6.7 and 7.0
+requirements:
+- python >= 2.6
+- PyVmomi
+options:
+
+'''
+
+EXAMPLES = '''
+- name: Gather info about vmhbas of all ESXi Host in the given Cluster
+  vmware_host_disk_info:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    cluster_name: '{{ cluster_name }}'
+  delegate_to: localhost
+  register: cluster_host_vmhbas
+
+- name: Gather info about vmhbas of an ESXi Host
+  vmware_host_disk_info:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    esxi_hostname: '{{ esxi_hostname }}'
+  delegate_to: localhost
+  register: host_vmhbas
+'''
+
+RETURN = '''
+"hosts_disk_info": {
+    "192.168.0.182": [
+        {
+            "canonical_name": "naa.6000c296ed6217bd61df35622eb21a3a",
+            "capacity_mb": 4096,
+            "device_path": "/vmfs/devices/disks/naa.6000c296ed6217bd61df35622eb21a3a",
+            "device_type": "disk",
+            "device_ctd_list": [
+                "vmhba0:C0:T1:L0"
+            ],
+            "disk_uid": "key-vim.host.ScsiDisk-02000000006000c296ed6217bd61df35622eb21a3a566972747561",
+            "display_name": "Local VMware Disk (naa.6000c296ed6217bd61df35622eb21a3a)"
+        },
+        {
+            "canonical_name": "naa.6000c2968ad7142d93faae527fe8822b",
+            "capacity_mb": 204800,
+            "device_path": "/vmfs/devices/disks/naa.6000c2968ad7142d93faae527fe8822b",
+            "device_type": "disk",
+            "device_ctd_list": [
+                "vmhba0:C0:T3:L0"
+            ],
+            "disk_uid": "key-vim.host.ScsiDisk-02000000006000c2968ad7142d93faae527fe8822b566972747561",
+            "display_name": "Local VMware Disk (naa.6000c2968ad7142d93faae527fe8822b)"
+        },]
+    }
+'''
+
+try:
+    from pyVmomi import vim
+except ImportError:
+    pass
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.community.vmware.plugins.module_utils.vmware import vmware_argument_spec, PyVmomi, get_all_objs
+
+class HostDiskInfo(PyVmomi):
+    """Class to return host disk info"""
+
+    def __init__(self, module):
+        super(HostDiskInfo, self).__init__(module)
+        cluster_name = self.params.get('cluster_name', None)
+        esxi_host_name = self.params.get('esxi_hostname', None)
+        self.hosts = self.get_all_host_objs(cluster_name=cluster_name, esxi_host_name=esxi_host_name)
+        if not self.hosts:
+            self.module.fail_json(msg="Failed to find host system.")
+
+    def gather_host_disk_info(self):
+        hosts_disk_info = {}
+        for host in self.hosts:
+            host_disk_info = []
+            storage_system = host.configManager.storageSystem.storageDeviceInfo
+            # Collect target lookup for naa devices
+            lun_lookup = {}
+            for lun in storage_system.multipathInfo.lun:
+                key = lun.lun
+                paths = []
+                for path in lun.path:
+                    paths.append(path.name)
+                lun_lookup[key] = paths
+
+            for disk in storage_system.scsiLun:
+                canonical_name = disk.canonicalName
+                try:
+                    capacity = int(disk.capacity.block * disk.capacity.blockSize / 1048576)
+                except AttributeError:
+                    capacity = 0
+                try:
+                    device_path = disk.devicePath
+                except AttributeError:
+                    device_path = ""
+                device_type = disk.deviceType
+                display_name = disk.displayName
+                disk_uid = disk.key
+                device_ctd_list = lun_lookup[disk_uid]
+                
+                disk_dict = {"capacity_mb": capacity,
+                                        "device_path": device_path,
+                                            "device_type": device_type,
+                                            "display_name": display_name,
+                                            "disk_uid": disk_uid,
+                                            "device_ctd_list": device_ctd_list,
+                                            "canonical_name": canonical_name}
+                host_disk_info.append(disk_dict)
+
+            hosts_disk_info[host.name] = host_disk_info
+        
+        return hosts_disk_info
+
+
+
+def main():
+    """Main"""
+    argument_spec = vmware_argument_spec()
+    argument_spec.update(
+        cluster_name=dict(type='str', required=False),
+        esxi_hostname=dict(type='str', required=False),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        required_one_of=[
+            ['cluster_name', 'esxi_hostname'],
+        ],
+        supports_check_mode=True,
+    )
+
+    host_disk_mgr = HostDiskInfo(module)
+    module.exit_json(changed=False, hosts_disk_facts=host_disk_mgr.gather_host_disk_info())
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/vmware_host_disk_info.py
+++ b/plugins/modules/vmware_host_disk_info.py
@@ -163,7 +163,7 @@ def main():
     )
 
     host_disk_mgr = HostDiskInfo(module)
-    module.exit_json(changed=False, hosts_disk_facts=host_disk_mgr.gather_host_disk_info())
+    module.exit_json(changed=False, hosts_disk_info=host_disk_mgr.gather_host_disk_info())
 
 
 if __name__ == "__main__":

--- a/plugins/modules/vmware_host_disk_info.py
+++ b/plugins/modules/vmware_host_disk_info.py
@@ -88,11 +88,6 @@ hosts_disk_info:
         },]
 '''
 
-try:
-    from pyVmomi import vim
-except ImportError:
-    pass
-
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.vmware.plugins.module_utils.vmware import vmware_argument_spec, PyVmomi
 

--- a/plugins/modules/vmware_host_disk_info.py
+++ b/plugins/modules/vmware_host_disk_info.py
@@ -1,23 +1,20 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
+#
+# Copyright (c) 2020, Matt Proud 
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-ANSIBLE_METADATA = {
-    'metadata_version': '1.0',
-    'author': 'Matt Proud'
-}
-
 DOCUMENTATION = '''
 ---
 module: vmware_host_disk_info
-short_description: Gathers information about disks attached to given ESXi host/s
+short_description: Gathers information about disks attached to given ESXi host/s.
 description:
 - This module returns information about disks attached to given ESXi host/s
-- If cluster_name is provide, then disk information about all hosts from given cluster will be returned.
-- If esxi_hostname is provided, then disk information about given host system will be returned.
+- If I(cluster_name) is provided, then disk information about all hosts from the given cluster will be returned.
+- If I(esxi_hostname) is provided, then disk information about the given host system will be returned.
 authot:
 - Matt Proud
 notes:
@@ -26,12 +23,23 @@ requirements:
 - python >= 2.6
 - PyVmomi
 options:
-
+  cluster_name:
+    description:
+    - Name of the cluster from which the ESXi host belong to.
+    - If C(esxi_hostname) is not given, this parameter is required.
+    type: str
+  esxi_hostname:
+    description:
+    - ESXi hostname to gather information from.
+    - If C(cluster_name) is not given, this parameter is required.
+    type: str
+extends_documentation_fragment:
+- community.vmware.vmware.documentation
 '''
 
 EXAMPLES = '''
 - name: Gather info about vmhbas of all ESXi Host in the given Cluster
-  vmware_host_disk_info:
+  community.vmware.vmware_host_disk_info:
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
@@ -40,7 +48,7 @@ EXAMPLES = '''
   register: cluster_host_vmhbas
 
 - name: Gather info about vmhbas of an ESXi Host
-  vmware_host_disk_info:
+  community.vmware.vmware_host_disk_info:
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
@@ -83,7 +91,8 @@ except ImportError:
     pass
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.community.vmware.plugins.module_utils.vmware import vmware_argument_spec, PyVmomi, get_all_objs
+from ansible_collections.community.vmware.plugins.module_utils.vmware import vmware_argument_spec, PyVmomi
+
 
 class HostDiskInfo(PyVmomi):
     """Class to return host disk info"""
@@ -124,21 +133,19 @@ class HostDiskInfo(PyVmomi):
                 display_name = disk.displayName
                 disk_uid = disk.key
                 device_ctd_list = lun_lookup[disk_uid]
-                
+
                 disk_dict = {"capacity_mb": capacity,
-                                        "device_path": device_path,
-                                            "device_type": device_type,
-                                            "display_name": display_name,
-                                            "disk_uid": disk_uid,
-                                            "device_ctd_list": device_ctd_list,
-                                            "canonical_name": canonical_name}
+                            "device_path": device_path,
+                            "device_type": device_type,
+                            "display_name": display_name,
+                            "disk_uid": disk_uid,
+                            "device_ctd_list": device_ctd_list,
+                            "canonical_name": canonical_name}
                 host_disk_info.append(disk_dict)
 
             hosts_disk_info[host.name] = host_disk_info
-        
+
         return hosts_disk_info
-
-
 
 def main():
     """Main"""

--- a/plugins/modules/vmware_host_disk_info.py
+++ b/plugins/modules/vmware_host_disk_info.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2020, Matt Proud 
+# Copyright (c) 2020, Matt Proud
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -15,8 +15,8 @@ description:
 - This module returns information about disks attached to given ESXi host/s
 - If I(cluster_name) is provided, then disk information about all hosts from the given cluster will be returned.
 - If I(esxi_hostname) is provided, then disk information about the given host system will be returned.
-authot:
-- Matt Proud
+author:
+- Matt Proud (@laidbackware)
 notes:
 - Tested on vSphere 6.7 and 7.0
 requirements:
@@ -58,7 +58,11 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
-"hosts_disk_info": {
+hosts_disk_info:
+  description: list of information for all disks attached to each ESXi host
+  returned: always
+  type: list
+  sample: >-
     "192.168.0.182": [
         {
             "canonical_name": "naa.6000c296ed6217bd61df35622eb21a3a",
@@ -82,7 +86,6 @@ RETURN = '''
             "disk_uid": "key-vim.host.ScsiDisk-02000000006000c2968ad7142d93faae527fe8822b566972747561",
             "display_name": "Local VMware Disk (naa.6000c2968ad7142d93faae527fe8822b)"
         },]
-    }
 '''
 
 try:
@@ -135,17 +138,18 @@ class HostDiskInfo(PyVmomi):
                 device_ctd_list = lun_lookup[disk_uid]
 
                 disk_dict = {"capacity_mb": capacity,
-                            "device_path": device_path,
-                            "device_type": device_type,
-                            "display_name": display_name,
-                            "disk_uid": disk_uid,
-                            "device_ctd_list": device_ctd_list,
-                            "canonical_name": canonical_name}
+                             "device_path": device_path,
+                             "device_type": device_type,
+                             "display_name": display_name,
+                             "disk_uid": disk_uid,
+                             "device_ctd_list": device_ctd_list,
+                             "canonical_name": canonical_name}
                 host_disk_info.append(disk_dict)
 
             hosts_disk_info[host.name] = host_disk_info
 
         return hosts_disk_info
+
 
 def main():
     """Main"""

--- a/tests/integration/targets/vmware_host_disk_info/aliases
+++ b/tests/integration/targets/vmware_host_disk_info/aliases
@@ -1,0 +1,4 @@
+cloud/vcenter
+needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_1esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_host_disk_info/tasks/main.yml
+++ b/tests/integration/targets/vmware_host_disk_info/tasks/main.yml
@@ -1,0 +1,37 @@
+# Test code for the vmware_guest_info module.
+# Copyright: (c) 2017, Abhijeet Kasurde <akasurde@redhat.com>
+# Copyright: (c) 2018, James E. King III (@jeking3) <jking@apache.org>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_attach_host: true
+
+- when: vcsim is not defined
+  block:
+    # Testcase 0001: Get disk info for a host
+    - name: get list of disks from a single host
+      vmware_host_disk_info:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        esxi_hostname: "{{ esxi_hosts[0] }}"
+      register: host_disk_info
+
+    - debug:
+        var: host_disk_info
+
+    # Testcase 0002: Get disk info for all hosts in a cluster
+    - name: get list of disks from all hosts in a cluster
+      vmware_host_disk_info:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        cluster_name: "{{ ccr1 }}"
+      register: host_disk_info
+
+    - debug:
+        var: host_disk_info    


### PR DESCRIPTION
##### SUMMARY
Added module to extract information about disks attached to a host. This can be used to link the naa number to the CTD number, which can be required for datastore creation, especially in home labs.
Added tests for both host and cluster extraction. The sim does not seem to expose the necessary endpoint, hence the need to test against actual objects.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
vmware_host_disk_info.py

##### ADDITIONAL INFORMATION
Below is an example of how the output can be used to build a mapping table of the CTD number to the naa number. This assumes results were registered as cluster_host_disks. If the CTD number is known, then this output can be used to enable datastore creation without knowing the naa number. I have found this necessary in my nested lab build and cannot automate local datastores without this ability to find out the naa number.

```
- name: Build device lookup table
    set_fact: 
      host_disk_map: >-
        {
        {% for cluster in cluster_host_disks.results %}
        {% for host_name, disks in cluster.hosts_disk_facts.items() %}
        {% for disk in disks %}
        "{{host_name}}_{{disk.device_ctd_list[0]}}": 
          "{{disk.canonical_name}}",
        {% endfor %}
        {% endfor %}
        {% endfor %}
        }
```