### PR TITLE
vmware_dvswitch: Fix idempotency prob with vSphere 7.0.1

### DIFF
--- a/changelogs/fragments/576-vmware_dvswitch.yml
+++ b/changelogs/fragments/576-vmware_dvswitch.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- vmware_dvswitch - fix an issue with vSphere 7 when no switch_version is defined (https://github.com/ansible-collections/community.vmware/issues/576)

--- a/plugins/modules/vmware_dvswitch.py
+++ b/plugins/modules/vmware_dvswitch.py
@@ -653,10 +653,8 @@ class VMwareDvSwitch(PyVmomi):
                 changed_version = True
                 spec_product = self.create_product_spec(self.switch_version)
         else:
-            results['version'] = self.vcenter_switch_version
-            if self.dvs.config.productInfo.version != self.vcenter_switch_version:
-                changed_version = True
-                spec_product = self.create_product_spec(self.vcenter_switch_version)
+            results['version'] = self.dvs.config.productInfo.version
+            changed_version = False
         if changed_version:
             changed = True
             changed_list.append("switch version")

--- a/plugins/modules/vmware_dvswitch.py
+++ b/plugins/modules/vmware_dvswitch.py
@@ -277,10 +277,6 @@ class VMwareDvSwitch(PyVmomi):
 
         self.switch_name = self.module.params['switch_name']
         self.switch_version = self.module.params['switch_version']
-        if self.content.about.version == '6.7.0':
-            self.vcenter_switch_version = '6.6.0'
-        else:
-            self.vcenter_switch_version = self.content.about.version
         folder = self.params['folder']
         if folder:
             self.folder_obj = self.content.searchIndex.FindByInventoryPath(folder)


### PR DESCRIPTION
##### SUMMARY
When no `switch_version` is given, the module tries to guess the correct version. As far as I understand the code, the module even might upgrade the dvSwitch version when no version is given if you've upgraded your vCenter. But that's not how other modules work: If people don't specify something, we just ignore this... we don't silently change things.

Fixes #576 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_dvswitch