### PR TITLE
vcenter_domain_user_group_info: add a new module

### DIFF
--- a/docs/community.vmware.vcenter_domain_user_group_info_module.rst
+++ b/docs/community.vmware.vcenter_domain_user_group_info_module.rst
@@ -298,7 +298,7 @@ Examples
 
 .. code-block:: yaml
 
-    - name: Gather all domain user avcenter_domain_user_group_infond group of vsphere.local
+    - name: Gather all domain user and group of vsphere.local
       community.vmware.vcenter_domain_user_group_info:
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"

--- a/docs/community.vmware.vcenter_domain_user_group_info_module.rst
+++ b/docs/community.vmware.vcenter_domain_user_group_info_module.rst
@@ -8,6 +8,7 @@ community.vmware.vcenter_domain_user_group_info
 **Gather user or group information of a domain**
 
 
+Version added: 1.6.0
 
 .. contents::
    :local:
@@ -328,6 +329,17 @@ Examples
         find_users: true
         find_groups: false
       register: gather_all_domain_user_result
+
+    - name: Gather administrator user by exact match condition
+      community.vmware.vcenter_domain_user_group_info:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        domain: vsphere.local
+        search_string: "vsphere.local\\administrator"
+        exact_match: true
+      register: gather_administrator_user_exact_match_result
 
 
 

--- a/docs/community.vmware.vcenter_domain_user_group_info_module.rst
+++ b/docs/community.vmware.vcenter_domain_user_group_info_module.rst
@@ -51,7 +51,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>If a group is existing, the returned contains only users or groups that directly belong to the specified group.</div>
+                        <div>If a group existing, returned contains only users or groups that directly belong to the specified group.</div>
                 </td>
             </tr>
             <tr>
@@ -66,7 +66,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>If a user is existing, the returned contains only groups that directly contain the specified user.</div>
+                        <div>If a user existing, returned contains only groups that directly contain the specified user.</div>
                 </td>
             </tr>
             <tr>
@@ -101,7 +101,7 @@ Parameters
                         </ul>
                 </td>
                 <td>
-                        <div>If <em>exact_match</em> is True, it indicates the <em>search_string</em> passed should match a user or group name exactly.</div>
+                        <div>If <em>exact_match</em> is <code>True</code>, it indicates the <em>search_string</em> passed should match a user or group name exactly.</div>
                 </td>
             </tr>
             <tr>
@@ -120,7 +120,7 @@ Parameters
                         </ul>
                 </td>
                 <td>
-                        <div>If <em>find_groups</em> is True, domain groups will be included in the result.</div>
+                        <div>If <em>find_groups</em> is <code>True</code>, domain groups will be included in the result.</div>
                 </td>
             </tr>
             <tr>
@@ -139,7 +139,7 @@ Parameters
                         </ul>
                 </td>
                 <td>
-                        <div>If <em>find_users</em> is True, domain users will be included in the result.</div>
+                        <div>If <em>find_users</em> is <code>True</code>, domain users will be included in the result.</div>
                 </td>
             </tr>
             <tr>
@@ -297,8 +297,8 @@ Examples
 
 .. code-block:: yaml
 
-    - name: Gather all domain user and group of vsphere.local
-      vcenter_domain_user_group_info:
+    - name: Gather all domain user avcenter_domain_user_group_infond group of vsphere.local
+      community.vmware.vcenter_domain_user_group_info:
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
@@ -308,7 +308,7 @@ Examples
       register: gather_all_domain_user_group_result
 
     - name: Gather all domain user and group included the administrator string
-      vcenter_domain_user_group_info:
+      community.vmware.vcenter_domain_user_group_info:
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
@@ -316,6 +316,18 @@ Examples
         domain: vsphere.local
         search_string: administrator
       register: gather_domain_user_group_result
+
+    - name: Gather all domain user of vsphere.local
+      community.vmware.vcenter_domain_user_group_info:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        domain: vsphere.local
+        search_string: ''
+        find_users: true
+        find_groups: false
+      register: gather_all_domain_user_result
 
 
 

--- a/docs/community.vmware.vcenter_domain_user_group_info_module.rst
+++ b/docs/community.vmware.vcenter_domain_user_group_info_module.rst
@@ -1,0 +1,368 @@
+.. _community.vmware.vcenter_domain_user_group_info_module:
+
+
+***********************************************
+community.vmware.vcenter_domain_user_group_info
+***********************************************
+
+**Gather user or group information of a domain**
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- This module can be used to gather information about user or group of a domain.
+
+
+
+Requirements
+------------
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.7
+- PyVmomi
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+            <th width="100%">Comments</th>
+        </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>belongs_to_group</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>If a group is existing, the returned contains only users or groups that directly belong to the specified group.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>belongs_to_user</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>If a user is existing, the returned contains only groups that directly contain the specified user.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>domain</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">"vsphere.local"</div>
+                </td>
+                <td>
+                        <div>The <em>domain</em> to be specified searching.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>exact_match</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                    <li>yes</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>If <em>exact_match</em> is True, it indicates the <em>search_string</em> passed should match a user or group name exactly.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>find_groups</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>no</li>
+                                    <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                        </ul>
+                </td>
+                <td>
+                        <div>If <em>find_groups</em> is True, domain groups will be included in the result.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>find_users</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>no</li>
+                                    <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                        </ul>
+                </td>
+                <td>
+                        <div>If <em>find_users</em> is True, domain users will be included in the result.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>hostname</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The hostname or IP address of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_HOST</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The password of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PASSWORD</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: pass, pwd</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">443</div>
+                </td>
+                <td>
+                        <div>The port number of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PORT</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>proxy_host</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Address of a proxy that will receive all HTTPS requests and relay them.</div>
+                        <div>The format is a hostname or a IP.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PROXY_HOST</code> will be used instead.</div>
+                        <div>This feature depends on a version of pyvmomi greater than v6.7.1.2018.12</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>proxy_port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Port of the HTTP proxy that will receive all HTTPS requests and relay them.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PROXY_PORT</code> will be used instead.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>search_string</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The <em>search_string</em> is a string to be specified searching.</div>
+                        <div>Specify the domain user or group name to be searched.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>username</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The username of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_USER</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: admin, user</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>validate_certs</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>no</li>
+                                    <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Allows connection when SSL certificates are not valid. Set to <code>false</code> when certificates are not trusted.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_VALIDATE_CERTS</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                        <div>If set to <code>true</code>, please make sure Python &gt;= 2.7.9 is installed on the given machine.</div>
+                </td>
+            </tr>
+    </table>
+    <br/>
+
+
+
+
+Examples
+--------
+
+.. code-block:: yaml
+
+    - name: Gather all domain user and group of vsphere.local
+      vcenter_domain_user_group_info:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        domain: vsphere.local
+        search_string: ''
+      register: gather_all_domain_user_group_result
+
+    - name: Gather all domain user and group included the administrator string
+      vcenter_domain_user_group_info:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        domain: vsphere.local
+        search_string: administrator
+      register: gather_domain_user_group_result
+
+
+
+Return Values
+-------------
+Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>domain_user_groups</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                    </div>
+                </td>
+                <td>success</td>
+                <td>
+                            <div>list of domain user and group information</div>
+                    <br/>
+                        <div style="font-size: smaller"><b>Sample:</b></div>
+                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[
+        {
+            &quot;fullName&quot;: &quot;Administrator vsphere.local&quot;,
+            &quot;group&quot;: false,
+            &quot;principal&quot;: &quot;Administrator&quot;
+        }
+    ]</div>
+                </td>
+            </tr>
+    </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- sky-joker (@sky-joker)

--- a/plugins/modules/vcenter_domain_user_group_info.py
+++ b/plugins/modules/vcenter_domain_user_group_info.py
@@ -1,0 +1,164 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2020, sky-joker
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+module: vcenter_domain_user_group_info
+short_description: Gather user or group information of a domain
+author:
+  - sky-joker (@sky-joker)
+description:
+  - This module can be used to gather information about user or group of a domain.
+requirements:
+  - python >= 2.7
+  - PyVmomi
+options:
+  domain:
+    description:
+      - The I(domain) to be specified searching.
+    type: str
+    default: vsphere.local
+  search_string:
+    description:
+      - The I(search_string) is a string to be specified searching.
+      - Specify the domain user or group name to be searched.
+    type: str
+    required: True
+  belongs_to_group:
+    description:
+      -  If a group is existing, the returned contains only users or groups that directly belong to the specified group.
+    type: str
+  belongs_to_user:
+    description:
+      - If a user is existing, the returned contains only groups that directly contain the specified user.
+    type: str
+  exact_match:
+    description:
+      - If I(exact_match) is True, it indicates the I(search_string) passed should match a user or group name exactly.
+    type: bool
+    default: False
+  find_users:
+    description:
+      - If I(find_users) is True, domain users will be included in the result.
+    type: bool
+    default: True
+  find_groups:
+    description:
+      - If I(find_groups) is True, domain groups will be included in the result.
+    type: bool
+    default: True
+extends_documentation_fragment:
+  - community.vmware.vmware.documentation
+'''
+
+EXAMPLES = r'''
+- name: Gather all domain user and group of vsphere.local
+  vcenter_domain_user_group_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    domain: vsphere.local
+    search_string: ''
+  register: gather_all_domain_user_group_result
+
+- name: Gather all domain user and group included the administrator string
+  vcenter_domain_user_group_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    domain: vsphere.local
+    search_string: administrator
+  register: gather_domain_user_group_result
+'''
+
+RETURN = r'''
+domain_user_groups:
+  description: list of domain user and group information
+  returned: success
+  type: list
+  sample: >-
+    [
+        {
+            "fullName": "Administrator vsphere.local",
+            "group": false,
+            "principal": "Administrator"
+        }
+    ]
+'''
+
+try:
+    from pyVmomi import vim
+except ImportError:
+    pass
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
+from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, vmware_argument_spec
+
+
+class VcenterDomainUserGroupInfo(PyVmomi):
+    def __init__(self, module):
+        super(VcenterDomainUserGroupInfo, self).__init__(module)
+        self.domain = self.params['domain']
+        self.search_string = self.params['search_string']
+        self.belongs_to_group = self.params['belongs_to_group']
+        self.belongs_to_user = self.params['belongs_to_user']
+        self.exact_match = self.params['exact_match']
+        self.find_users = self.params['find_users']
+        self.find_groups = self.params['find_groups']
+
+    def execute(self):
+        try:
+            user_search_result = self.content.userDirectory.RetrieveUserGroups(
+                domain=self.domain,
+                searchStr=self.search_string,
+                belongsToGroup=self.belongs_to_group,
+                belongsToUser=self.belongs_to_user,
+                exactMatch=self.exact_match,
+                findUsers=self.find_users,
+                findGroups=self.find_groups
+            )
+        except vim.fault.NotFound as e:
+            self.module.fail_json(msg="%s" % to_native(e.msg))
+        except Exception as e:
+            self.module.fail_json(msg="Couldn't gather domain user or group information: %s" % to_native(e))
+
+        user_search_result_normalization = []
+        if user_search_result:
+            for object in user_search_result:
+                user_search_result_normalization.append({
+                    'fullName': object.fullName,
+                    'principal': object.principal,
+                    'group': object.group
+                })
+
+        self.module.exit_json(changed=False, domain_user_groups=user_search_result_normalization)
+
+
+def main():
+    argument_spec = vmware_argument_spec()
+    argument_spec.update(
+        domain=dict(type='str', default='vsphere.local'),
+        search_string=dict(type='str', required=True),
+        belongs_to_group=dict(type='str', default=None),
+        belongs_to_user=dict(type='str', default=None),
+        exact_match=dict(type='bool', default=False),
+        find_users=dict(type='bool', default=True),
+        find_groups=dict(type='bool', default=True)
+    )
+
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+
+    vcenter_domain_user_info = VcenterDomainUserGroupInfo(module)
+    vcenter_domain_user_info.execute()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/vcenter_domain_user_group_info.py
+++ b/plugins/modules/vcenter_domain_user_group_info.py
@@ -58,7 +58,7 @@ extends_documentation_fragment:
 '''
 
 EXAMPLES = r'''
-- name: Gather all domain user avcenter_domain_user_group_infond group of vsphere.local
+- name: Gather all domain user and group of vsphere.local
   community.vmware.vcenter_domain_user_group_info:
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"

--- a/plugins/modules/vcenter_domain_user_group_info.py
+++ b/plugins/modules/vcenter_domain_user_group_info.py
@@ -52,6 +52,7 @@ options:
       - If I(find_groups) is C(True), domain groups will be included in the result.
     type: bool
     default: True
+version_added: '1.6.0'
 extends_documentation_fragment:
   - community.vmware.vmware.documentation
 '''

--- a/tests/integration/targets/vcenter_domain_user_group_info/aliases
+++ b/tests/integration/targets/vcenter_domain_user_group_info/aliases
@@ -1,0 +1,2 @@
+cloud/vcenter
+zuul/vmware/vcenter_only

--- a/tests/integration/targets/vcenter_domain_user_group_info/tasks/main.yml
+++ b/tests/integration/targets/vcenter_domain_user_group_info/tasks/main.yml
@@ -159,3 +159,19 @@
     that:
       - gather_license_service_group_administrator_result.domain_user_groups | length == 1
       - gather_license_service_group_administrator_result.domain_user_groups.0.principal == "LicenseService.Administrators"
+
+- name: Gather administrator user by exact match condition
+  vcenter_domain_user_group_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    domain: vsphere.local
+    search_string: "vsphere.local\\administrator"
+    exact_match: true
+  register: gather_administrator_user_exact_match_result
+
+- name: Make sure if administrator user is existing by exact match
+  assert:
+    that:
+      - gather_administrator_user_exact_match_result.domain_user_groups.0.principal == "VSPHERE.LOCAL\\Administrator"

--- a/tests/integration/targets/vcenter_domain_user_group_info/tasks/main.yml
+++ b/tests/integration/targets/vcenter_domain_user_group_info/tasks/main.yml
@@ -1,0 +1,161 @@
+# Test code for the vcenter_domain_user_group_info module.
+# Copyright: (c) 2020, sky-joker <sky.jokerxx@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- import_role:
+    name: prepare_vmware_tests
+
+- name: Gather all domain user and group of vsphere.local
+  vcenter_domain_user_group_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    domain: vsphere.local
+    search_string: ''
+  register: gather_all_domain_user_group_result
+
+- name: Make sure if domain_user_groups attribute is existing
+  assert:
+    that:
+      - gather_all_domain_user_group_result.domain_user_groups is defined
+      - gather_all_domain_user_group_result.domain_user_groups | length >= 1
+
+- name: Gather all domain user and group included the admin string
+  vcenter_domain_user_group_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    domain: vsphere.local
+    search_string: admin
+  register: gather_domain_user_group_result
+
+- name: Make sure if multiple users are existing and included the admin string
+  assert:
+    that:
+      - >-
+        gather_domain_user_group_result.domain_user_groups
+        | map(attribute='principal')
+        | map('upper')
+        | map('regex_search', 'ADMIN')
+        | select('none')
+        | list
+        | length == 0
+      - gather_domain_user_group_result.domain_user_groups | length >= 2
+
+- name: Gather all domain user of vsphere.local
+  vcenter_domain_user_group_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    domain: vsphere.local
+    search_string: ''
+    find_users: true
+    find_groups: false
+  register: gather_all_domain_user_result
+
+- name: Make sure if the result doesn't include domain groups
+  assert:
+    that:
+      - >-
+        gather_all_domain_user_result.domain_user_groups
+        | map(attribute='group')
+        | select('true')
+        | list
+        | length == 0
+
+- name: Gather all domain group of vsphere.local
+  vcenter_domain_user_group_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    domain: vsphere.local
+    search_string: ''
+    find_users: false
+    find_groups: true
+  register: gather_all_domain_group_result
+
+- name: Make sure if the result doesn't include domain users
+  assert:
+    that:
+      - >-
+        gather_all_domain_group_result.domain_user_groups
+        | map(attribute='group')
+        | select('false')
+        | list
+        | length == 0
+
+- name: Gather administrator user only of domain
+  vcenter_domain_user_group_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    domain: vsphere.local
+    search_string: administrator
+    find_users: true
+    find_groups: false
+  register: gather_administrator_user_only_result
+
+- name: Make sure if the administrator user only is existing in result
+  assert:
+    that:
+      - gather_administrator_user_only_result.domain_user_groups | length == 1
+      - gather_administrator_user_only_result.domain_user_groups.0.principal == "Administrator"
+      - gather_administrator_user_only_result.domain_user_groups.0.group is sameas false
+
+- name: Gather DCAdmins group only of domain
+  vcenter_domain_user_group_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    domain: vsphere.local
+    search_string: DCAdmins
+    find_users: false
+    find_groups: true
+  register: gather_dcadmins_group_only_result
+
+- name: Make sure if the DCAdmins group only is existing in result
+  assert:
+    that:
+      - gather_dcadmins_group_only_result.domain_user_groups | length == 1
+      - gather_dcadmins_group_only_result.domain_user_groups.0.principal == "DCAdmins"
+      - gather_dcadmins_group_only_result.domain_user_groups.0.group is sameas true
+
+- name: Gather administrators included to LicenseService.Administrators group
+  vcenter_domain_user_group_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    domain: vsphere.local
+    search_string: administrators
+    belongs_to_group: LicenseService.Administrators
+  register: gather_administrators_license_service_group_result
+
+- name: Make sure if the administrators a member of LicenseService.Administrtors group is existing
+  assert:
+    that:
+      - gather_administrators_license_service_group_result.domain_user_groups | length == 1
+      - gather_administrators_license_service_group_result.domain_user_groups.0.principal == "Administrators"
+
+- name: Gather LicenseService.Administrators group included to administrators user
+  vcenter_domain_user_group_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    domain: vsphere.local
+    search_string: LicenseService.Administrators
+    belongs_to_user: administrators
+  register: gather_license_service_group_administrator_result
+
+- name: Make sure if the administrators belonging to LicenseService.Administrtors group is existing
+  assert:
+    that:
+      - gather_license_service_group_administrator_result.domain_user_groups | length == 1
+      - gather_license_service_group_administrator_result.domain_user_groups.0.principal == "LicenseService.Administrators"


### PR DESCRIPTION
##### SUMMARY

This PR adds the new vcenter_domain_user_group_info module.  
By using the module, we can gather domain users or groups from the vCenter Server.

##### ISSUE TYPE

- New Module Pull Request

##### COMPONENT NAME

plugins/modules/vcenter_domain_user_group_info.py
tests/integration/targets/vcenter_domain_user_group_info/aliases
tests/integration/targets/vcenter_domain_user_group_info/tasks/main.yml
docs/community.vmware.vcenter_domain_user_group_info_module.rst

##### ADDITIONAL INFORMATION