### PR TITLE
WIP Guest extra config - vmware_guest_info

### DIFF
--- a/plugins/modules/vmware_guest_info.py
+++ b/plugins/modules/vmware_guest_info.py
@@ -71,6 +71,12 @@ options:
      - Destination datacenter for the deploy operation
      required: True
      type: str
+   show_extra_config:
+     description:
+     - Show extra config for a VM. 
+     - In the UI, this is the information which appears under advanced VM settings.
+     default: false
+     type: bool
    tags:
      description:
      - Whether to show tags or not.
@@ -269,6 +275,7 @@ def main():
         moid=dict(type='str'),
         folder=dict(type='str'),
         datacenter=dict(type='str', required=True),
+        show_extra_config=dict(type='bool', default=False),
         tags=dict(type='bool', default=False),
         schema=dict(type='str', choices=['summary', 'vsphere'], default='summary'),
         properties=dict(type='list', elements='str'),
@@ -303,6 +310,11 @@ def main():
                 instance = pyv.gather_facts(vm)
             else:
                 instance = pyv.to_json(vm, module.params['properties'])
+            if module.params.get('show_extra_config'):
+              extra_config = {}
+              for item in vm.config.extraConfig:
+                extra_config[item.key] = item.value
+              instance.update(extra_config=extra_config)
             if module.params.get('tags'):
                 if not HAS_VSPHERE:
                     module.fail_json(msg="Unable to find 'vCloud Suite SDK' Python library which is required."


### PR DESCRIPTION
##### SUMMARY
Add the ability to collect the extra config key/values from vmware_guest_info.
When deploying Tanzu Kubernetes for vSphere Distributed Switching, this is needed to extract the haproxy self signed certificate.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_guest_info

##### ADDITIONAL INFORMATION
At time of writing I have not been able to write any tests, as the testing documentation does not explain how get ISOs to add to the ro datastore.
