### PR TITLE
vmware_guest_disk: Fix an issue with vSphere 7 when adding several HDDs

### DIFF
--- a/changelogs/fragments/373-vmware_guest_disk.yml
+++ b/changelogs/fragments/373-vmware_guest_disk.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- vmware_guest_disk - fix an issue with vSphere 7 when adding several virtual disks and (https://github.com/ansible-collections/community.vmware/issues/373)

--- a/plugins/modules/vmware_guest_disk.py
+++ b/plugins/modules/vmware_guest_disk.py
@@ -468,6 +468,7 @@ class PyVmomiHelper(PyVmomi):
         disk_spec = vim.vm.device.VirtualDeviceSpec()
         disk_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.add
         disk_spec.device = vim.vm.device.VirtualDisk()
+        disk_spec.device.key = -randint(20000, 24999)
         disk_spec.device.backing = vim.vm.device.VirtualDisk.FlatVer2BackingInfo()
         disk_spec.device.backing.diskMode = disk['disk_mode']
         disk_spec.device.backing.sharing = disk['sharing']


### PR DESCRIPTION
##### SUMMARY
The behavior of the vSphere API changed considerably with 7.0U1 (probably already with 7.0, but I didn't have closer look).

The difference is: Although the `key` property of a virtual device is ignored, vCenter now checks if it is unique and fails if it isn't. The problem is that all virtual disks are created with a default key of 0, so are not unique.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_guest_disk

##### ADDITIONAL INFORMATION
see issue #545 and PR #552 for more information