### PR TITLE
vmware_host_ntp: Fix issue with disconnected hosts

### DIFF
--- a/changelogs/fragments/539-vmware_host_ntp.yml
+++ b/changelogs/fragments/539-vmware_host_ntp.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- vmware_host_ntp - fix an issue with disconnected hosts (https://github.com/ansible-collections/community.vmware/issues/539)

--- a/plugins/modules/vmware_host_ntp.py
+++ b/plugins/modules/vmware_host_ntp.py
@@ -203,52 +203,56 @@ class VmwareNtpConfigManager(PyVmomi):
         changed = False
         for host in self.hosts:
             self.results[host.name] = dict()
-            ntp_servers_configured, ntp_servers_to_change = self.check_ntp_servers(host=host)
-            # add/remove NTP servers
-            if self.desired_state:
-                self.results[host.name]['state'] = self.desired_state
-                if ntp_servers_to_change:
-                    self.results[host.name]['ntp_servers_changed'] = ntp_servers_to_change
-                    operation = 'add' if self.desired_state == 'present' else 'delete'
-                    new_ntp_servers = self.update_ntp_servers(
-                        host=host,
-                        ntp_servers_configured=ntp_servers_configured,
-                        ntp_servers_to_change=ntp_servers_to_change,
-                        operation=operation
-                    )
-                    self.results[host.name]['ntp_servers_current'] = new_ntp_servers
-                    self.results[host.name]['changed'] = True
-                    change_list.append(True)
-                else:
-                    self.results[host.name]['ntp_servers_current'] = ntp_servers_configured
-                    if self.verbose:
-                        self.results[host.name]['msg'] = (
-                            "NTP servers already added" if self.desired_state == 'present'
-                            else "NTP servers already removed"
+            if host.runtime.connectionState == "connected":
+                ntp_servers_configured, ntp_servers_to_change = self.check_ntp_servers(host=host)
+                # add/remove NTP servers
+                if self.desired_state:
+                    self.results[host.name]['state'] = self.desired_state
+                    if ntp_servers_to_change:
+                        self.results[host.name]['ntp_servers_changed'] = ntp_servers_to_change
+                        operation = 'add' if self.desired_state == 'present' else 'delete'
+                        new_ntp_servers = self.update_ntp_servers(
+                            host=host,
+                            ntp_servers_configured=ntp_servers_configured,
+                            ntp_servers_to_change=ntp_servers_to_change,
+                            operation=operation
                         )
-                    self.results[host.name]['changed'] = False
-                    change_list.append(False)
-            # overwrite NTP servers
-            else:
-                self.results[host.name]['ntp_servers'] = self.ntp_servers
-                if ntp_servers_to_change:
-                    self.results[host.name]['ntp_servers_changed'] = self.get_differt_entries(
-                        ntp_servers_configured,
-                        ntp_servers_to_change
-                    )
-                    self.update_ntp_servers(
-                        host=host,
-                        ntp_servers_configured=ntp_servers_configured,
-                        ntp_servers_to_change=ntp_servers_to_change,
-                        operation='overwrite'
-                    )
-                    self.results[host.name]['changed'] = True
-                    change_list.append(True)
+                        self.results[host.name]['ntp_servers_current'] = new_ntp_servers
+                        self.results[host.name]['changed'] = True
+                        change_list.append(True)
+                    else:
+                        self.results[host.name]['ntp_servers_current'] = ntp_servers_configured
+                        if self.verbose:
+                            self.results[host.name]['msg'] = (
+                                "NTP servers already added" if self.desired_state == 'present'
+                                else "NTP servers already removed"
+                            )
+                        self.results[host.name]['changed'] = False
+                        change_list.append(False)
+                # overwrite NTP servers
                 else:
-                    if self.verbose:
-                        self.results[host.name]['msg'] = "NTP servers already configured"
-                    self.results[host.name]['changed'] = False
-                    change_list.append(False)
+                    self.results[host.name]['ntp_servers'] = self.ntp_servers
+                    if ntp_servers_to_change:
+                        self.results[host.name]['ntp_servers_changed'] = self.get_differt_entries(
+                            ntp_servers_configured,
+                            ntp_servers_to_change
+                        )
+                        self.update_ntp_servers(
+                            host=host,
+                            ntp_servers_configured=ntp_servers_configured,
+                            ntp_servers_to_change=ntp_servers_to_change,
+                            operation='overwrite'
+                        )
+                        self.results[host.name]['changed'] = True
+                        change_list.append(True)
+                    else:
+                        if self.verbose:
+                            self.results[host.name]['msg'] = "NTP servers already configured"
+                        self.results[host.name]['changed'] = False
+                        change_list.append(False)
+            else:
+                self.results[host.name]['changed'] = False
+                self.results[host.name]['msg'] = "Host %s is disconnected and cannot be changed." % host.name
 
         if any(change_list):
             changed = True


### PR DESCRIPTION
##### SUMMARY
`vmware_host_ntp` failes (crashes) when trying to configure a host that is disconnected.

Fixes #539 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_host_ntp

##### ADDITIONAL INFORMATION
I've stolen this solution from `vmware_host_kernel_manager`.
