### PR TITLE
vmware_host: add a new state option the disconnected

### DIFF
--- a/changelogs/fragments/589_vmware_host.yml
+++ b/changelogs/fragments/589_vmware_host.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_host - added a new state option, the ``disconnected`` (https://github.com/ansible-collections/community.vmware/pull/589).

--- a/docs/community.vmware.vmware_host_module.rst
+++ b/docs/community.vmware.vmware_host_module.rst
@@ -360,6 +360,7 @@ Parameters
                                     <li>absent</li>
                                     <li>add_or_reconnect</li>
                                     <li>reconnect</li>
+                                    <li>disconnected</li>
                         </ul>
                 </td>
                 <td>
@@ -369,6 +370,7 @@ Parameters
                         <div>If set to <code>absent</code>, do nothing if host already does not exists.</div>
                         <div>If set to <code>add_or_reconnect</code>, add the host if it&#x27;s absent else reconnect it and update the location.</div>
                         <div>If set to <code>reconnect</code>, then reconnect the host if it&#x27;s present and update the location.</div>
+                        <div>If set to <code>disconnected</code>, disconnect the host if the host already exists.</div>
                 </td>
             </tr>
             <tr>

--- a/plugins/modules/vmware_host.py
+++ b/plugins/modules/vmware_host.py
@@ -799,7 +799,11 @@ class VMwareHost(PyVmomi):
         result = None
 
         if self.module.check_mode:
-            result = "Host would be disconnected host from vCenter '%s'" % self.vcenter
+            if self.host.runtime.connectionState == 'disconnected':
+                result = "Host already disconnected"
+                changed = False
+            else:
+                result = "Host would be disconnected host from vCenter '%s'" % self.vcenter
         else:
             if self.host.runtime.connectionState == 'disconnected':
                 changed = False

--- a/tests/integration/targets/vmware_host/tasks/main.yml
+++ b/tests/integration/targets/vmware_host/tasks/main.yml
@@ -233,6 +233,24 @@
         that:
           - disconnect_host_idempotency_result.changed is false
 
+    - name: disconnect host with check_mode again
+      vmware_host:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        datacenter: "{{ dc1 }}"
+        cluster: "{{ ccr1 }}"
+        esxi_hostname: '{{ esxi1 }}'
+        state: disconnected
+      check_mode: true
+      register: disconnect_host_check_mode_again_result
+
+    - name: ensure not to occur the changed
+      assert:
+        that:
+          - disconnect_host_check_mode_again_result.changed is false
+
     - name: reconnect host
       vmware_host:
         hostname: "{{ vcenter_hostname }}"

--- a/tests/integration/targets/vmware_host/tasks/main.yml
+++ b/tests/integration/targets/vmware_host/tasks/main.yml
@@ -177,3 +177,69 @@
           # https://github.com/vmware/govmomi/blob/master/govc/USAGE.md#events
           # "govc events ..." need to be callable from
           # https://github.com/ansible/vcenter-test-container/flask_control.py
+
+## Testcase: Disconnect Host
+- when: vcsim is not defined
+  block:
+    - name: disconnect host with check_mode
+      vmware_host:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        datacenter: "{{ dc1 }}"
+        cluster: "{{ ccr1 }}"
+        esxi_hostname: '{{ esxi1 }}'
+        state: disconnected
+      check_mode: true
+      register: disconnect_host_check_mode_result
+
+    - name: ensure to occur the changed
+      assert:
+        that:
+          - disconnect_host_check_mode_result.changed is true
+
+    - name: disconnect host
+      vmware_host:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        datacenter: "{{ dc1 }}"
+        cluster: "{{ ccr1 }}"
+        esxi_hostname: '{{ esxi1 }}'
+        state: disconnected
+      register: disconnect_host_result
+
+    - name: ensure host system has been disconnected
+      assert:
+        that:
+          - disconnect_host_result.changed is true
+
+    - name: disconnect host(idempotency)
+      vmware_host:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        datacenter: "{{ dc1 }}"
+        cluster: "{{ ccr1 }}"
+        esxi_hostname: '{{ esxi1 }}'
+        state: disconnected
+      register: disconnect_host_idempotency_result
+
+    - name: ensure not to occur the changed
+      assert:
+        that:
+          - disconnect_host_idempotency_result.changed is false
+
+    - name: reconnect host
+      vmware_host:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        datacenter: "{{ dc1 }}"
+        cluster: "{{ ccr1 }}"
+        esxi_hostname: '{{ esxi1 }}'
+        state: reconnect


### PR DESCRIPTION
##### SUMMARY

This PR will add a new state option(disconnected) to the vmware_host module.  
By supporting the disconnected option, we can execute new integration tests for the disconnected state host.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

docs/community.vmware.vmware_host_module.rst
plugins/modules/vmware_host.py
tests/integration/targets/vmware_host/tasks/main.yml

##### ADDITIONAL INFORMATION

tested vCenter/ESXi 6.7