### PR TITLE
vmware_host_iscsi/test: ignore pre-existing state

### DIFF
--- a/tests/integration/targets/vmware_host_iscsi/tasks/main.yml
+++ b/tests/integration/targets/vmware_host_iscsi/tasks/main.yml
@@ -16,11 +16,6 @@
         validate_certs: false
         esxi_hostname: "{{ esxi1 }}"
         state: enabled
-      register: prepare_iscsi_enabled_result
-
-    - assert:
-        that:
-          - prepare_iscsi_enabled_result.changed is sameas true
 
     - vmware_host_iscsi:
         hostname: "{{ vcenter_hostname }}"


### PR DESCRIPTION
Do not rely on the initial state of the host.