### PR TITLE
iscsi_info: don't depend on the initial state of the host

### DIFF
--- a/tests/integration/targets/vmware_host_iscsi_info/tasks/iscsi_info_module_test_tasks.yml
+++ b/tests/integration/targets/vmware_host_iscsi_info/tasks/iscsi_info_module_test_tasks.yml
@@ -12,10 +12,6 @@
     state: enabled
   register: enable_iscsi_result
 
-- assert:
-    that:
-      - enable_iscsi_result.changed is sameas true
-
 - name: Gather iSCSI configuration for setting vmhba variable
   vmware_host_iscsi_info:
     hostname: "{{ hostname }}"


### PR DESCRIPTION
Ensure we don't depend on the state of the host. `iscsi` can actually
be already enabled.