### PR TITLE
vmware_first_class_disk: New module

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Name | Description
 [community.vmware.vmware_dvswitch_uplink_pg](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_dvswitch_uplink_pg_module.rst)|Manage uplink portproup configuration of a Distributed Switch
 [community.vmware.vmware_evc_mode](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_evc_mode_module.rst)|Enable/Disable EVC mode on vCenter
 [community.vmware.vmware_export_ovf](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_export_ovf_module.rst)|Exports a VMware virtual machine to an OVF file, device files and a manifest file
+[community.vmware.vmware_first_class_disk](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_first_class_disk_module.rst)|Manage VMware vSphere First Class Disks
 [community.vmware.vmware_folder_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_folder_info_module.rst)|Provides information about folders in a datacenter
 [community.vmware.vmware_guest](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_guest_module.rst)|Manages virtual machines in vCenter
 [community.vmware.vmware_guest_boot_facts](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_guest_boot_facts_module.rst)|Gather facts about boot options for the given virtual machine

--- a/docs/community.vmware.vmware_first_class_disk_module.rst
+++ b/docs/community.vmware.vmware_first_class_disk_module.rst
@@ -1,0 +1,304 @@
+.. _community.vmware.vmware_first_class_disk_module:
+
+
+****************************************
+community.vmware.vmware_first_class_disk
+****************************************
+
+**Manage VMware vSphere First Class Disks**
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- This module can be used to manage (create, delete) VMware vSphere First Class Disks.
+
+
+
+Requirements
+------------
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.6
+- PyVmomi
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+            <th width="100%">Comments</th>
+        </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>datacenter_name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The name of the datacenter.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>datastore_name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Name of datastore or datastore cluster to be used for the disk.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>disk_name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The name of the disk.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>hostname</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The hostname or IP address of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_HOST</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The password of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PASSWORD</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: pass, pwd</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">443</div>
+                </td>
+                <td>
+                        <div>The port number of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PORT</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>proxy_host</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Address of a proxy that will receive all HTTPS requests and relay them.</div>
+                        <div>The format is a hostname or a IP.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PROXY_HOST</code> will be used instead.</div>
+                        <div>This feature depends on a version of pyvmomi greater than v6.7.1.2018.12</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>proxy_port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Port of the HTTP proxy that will receive all HTTPS requests and relay them.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PROXY_PORT</code> will be used instead.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>size</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Disk storage size, an integer plus a unit.</div>
+                        <div>There is no space allowed in between size number and unit.</div>
+                        <div>Allowed units are MB, GB and TB.</div>
+                        <div>Examples:</div>
+                        <div>size: 2048MB</div>
+                        <div>size: 10GB</div>
+                        <div>size: 1TB</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                    <li>absent</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>If the disk should be present or absent.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>username</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The username of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_USER</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: admin, user</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>validate_certs</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>no</li>
+                                    <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Allows connection when SSL certificates are not valid. Set to <code>false</code> when certificates are not trusted.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_VALIDATE_CERTS</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                        <div>If set to <code>true</code>, please make sure Python &gt;= 2.7.9 is installed on the given machine.</div>
+                </td>
+            </tr>
+    </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - Tested on vSphere 7.0
+
+
+
+Examples
+--------
+
+.. code-block:: yaml
+
+    - name: Create Disk
+      community.vmware.vmware_first_class_disk:
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        datastore_name: '{{ datastore_name }}'
+        disk_name: '1GBDisk'
+        size: '1GB'
+        state: present
+      delegate_to: localhost
+
+    - name: Delete Disk
+      community.vmware.vmware_first_class_disk:
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        datastore_name: '{{ datastore_name }}'
+        disk_name: 'FirstClassDisk'
+        state: absent
+      delegate_to: localhost
+
+
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Mario Lenz (@mariolenz)

--- a/docs/community.vmware.vmware_first_class_disk_module.rst
+++ b/docs/community.vmware.vmware_first_class_disk_module.rst
@@ -293,6 +293,43 @@ Examples
 
 
 
+Return Values
+-------------
+Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>first_class_disk</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">dictionary</span>
+                    </div>
+                </td>
+                <td>changed</td>
+                <td>
+                            <div>First-class disk returned when created, deleted or changed</div>
+                    <br/>
+                        <div style="font-size: smaller"><b>Sample:</b></div>
+                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{
+      &quot;name&quot;: &quot;1GBDisk&quot;
+      &quot;datastore_name&quot;: &quot;DS0&quot;
+      &quot;size_mb&quot;: &quot;1024&quot;
+      &quot;state&quot;: &quot;present&quot;
+    }</div>
+                </td>
+            </tr>
+    </table>
+    <br/><br/>
+
 
 Status
 ------

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -44,6 +44,7 @@ action_groups:
   - vmware_dvswitch_uplink_pg
   - vmware_evc_mode
   - vmware_export_ovf
+  - vmware_first_class_disk
   - vmware_folder_info
   - vmware_guest
   - vmware_guest_boot_info

--- a/plugins/module_utils/vmware.py
+++ b/plugins/module_utils/vmware.py
@@ -1558,6 +1558,30 @@ class PyVmomi(object):
 
         self.module.fail_json(msg="No vmdk file found for path specified [%s]" % vmdk_path)
 
+    def find_first_class_disk_by_name(self, disk_name, datastore_obj):
+        """
+        Get first-class disk managed object by name
+        Args:
+            disk_name: Name of the first-class disk
+            datastore_obj: Managed object of datastore
+
+        Returns: First-class disk managed object if found else None
+
+        """
+
+        if self.is_vcenter():
+            for id in self.content.vStorageObjectManager.ListVStorageObject(datastore_obj):
+                disk = self.content.vStorageObjectManager.RetrieveVStorageObject(id, datastore_obj)
+                if disk.config.name == disk_name:
+                    return disk
+        else:
+            for id in self.content.vStorageObjectManager.HostListVStorageObject(datastore_obj):
+                disk = self.content.vStorageObjectManager.HostRetrieveVStorageObject(id, datastore_obj)
+                if disk.config.name == disk_name:
+                    return disk
+
+        return None
+
     #
     # Conversion to JSON
     #

--- a/plugins/modules/vmware_first_class_disk.py
+++ b/plugins/modules/vmware_first_class_disk.py
@@ -7,7 +7,7 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: vmware_first_class_disk
 short_description: Manage VMware vSphere First Class Disks
@@ -51,7 +51,7 @@ options:
 extends_documentation_fragment: vmware.documentation
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Create Disk
   community.vmware.vmware_first_class_disk:
     hostname: '{{ vcenter_hostname }}'

--- a/plugins/modules/vmware_first_class_disk.py
+++ b/plugins/modules/vmware_first_class_disk.py
@@ -1,0 +1,233 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2015, Joseph Callen <jcallen () csc.com>
+# Copyright: (c) 2018, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = '''
+---
+module: vmware_first_class_disk
+short_description: Manage VMware vSphere First Class Disks
+description:
+    - This module can be used to manage (create, delete) VMware vSphere First Class Disks.
+author:
+- Mario Lenz (@mariolenz)
+notes:
+    - Tested on vSphere 7.0
+requirements:
+    - "python >= 2.6"
+    - PyVmomi
+options:
+    datacenter_name:
+      description: The name of the datacenter.
+      type: str
+    datastore_name:
+      description: Name of datastore or datastore cluster to be used for the disk.
+      required: True
+      type: str
+    disk_name:
+      description: The name of the disk.
+      required: True
+      type: str
+    size:
+      description:
+        - Disk storage size, an integer plus a unit.
+        - There is no space allowed in between size number and unit.
+        - Allowed units are MB, GB and TB.
+        - 'Examples:'
+        - '   size: 2048MB'
+        - '   size: 10GB'
+        - '   size: 1TB'
+      type: str
+    state:
+      description: If the disk should be present or absent.
+      choices: [ present, absent ]
+      default: present
+      type: str
+extends_documentation_fragment: vmware.documentation
+'''
+
+EXAMPLES = '''
+- name: Create Disk
+  community.vmware.vmware_first_class_disk:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    datastore_name: '{{ datastore_name }}'
+    disk_name: '1GBDisk'
+    size: '1GB'
+    state: present
+  delegate_to: localhost
+
+- name: Delete Disk
+  community.vmware.vmware_first_class_disk:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    datastore_name: '{{ datastore_name }}'
+    disk_name: 'FirstClassDisk'
+    state: absent
+  delegate_to: localhost
+'''
+
+RETURN = """#
+"""
+
+import re
+try:
+    from pyVmomi import vim, vmodl
+except ImportError:
+    pass
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, TaskError, vmware_argument_spec, wait_for_task
+from ansible.module_utils._text import to_native
+
+
+class FirstClassDisk(PyVmomi):
+    def __init__(self, module):
+        super(FirstClassDisk, self).__init__(module)
+        self.datacenter_name = self.params['datacenter_name']
+        self.datastore_name = self.params['datastore_name']
+        self.disk_name = self.params['disk_name']
+        self.desired_state = module.params['state']
+
+        self.size_mb = None
+        if self.params['size']:
+            size_regex = re.compile(r'(\d+)([MGT]B)')
+            disk_size_m = size_regex.match(self.params['size'])
+            if disk_size_m:
+                number = disk_size_m.group(1)
+                unit = disk_size_m.group(2)
+            else:
+                self.module.fail_json(msg="Failed to parse disk size, please review value provided using documentation.")
+
+            number = int(number)
+            if unit == "GB":
+                self.size_mb = 1024 * number
+            elif unit == "TB":
+                self.size_mb = 1048576 * number
+            else:
+                self.size_mb = number
+
+        self.datastore_obj = self.find_datastore_by_name(datastore_name=self.datastore_name, datacenter_name=self.datacenter_name)
+        if not self.datastore_obj:
+            self.module.fail_json(msg='Failed to find datastore %s.' % self.datastore_name)
+
+        self.disk = self.find_first_class_disk_by_name(self.disk_name, self.datastore_obj)
+
+    def create(self):
+        changed = False
+        if not self.disk:
+            changed = True
+            if not self.module.check_mode:
+                backing_spec = vim.vslm.CreateSpec.DiskFileBackingSpec()
+                backing_spec.datastore = self.datastore_obj
+
+                vslm_create_spec = vim.vslm.CreateSpec()
+                vslm_create_spec.backingSpec = backing_spec
+                vslm_create_spec.capacityInMB = self.size_mb
+                vslm_create_spec.name = self.disk_name
+
+                try:
+                    if self.is_vcenter():
+                        task = self.content.vStorageObjectManager.CreateDisk_Task(vslm_create_spec)
+                    else:
+                        task = self.content.vStorageObjectManager.HostCreateDisk_Task(vslm_create_spec)
+                    wait_for_task(task)
+                except vmodl.RuntimeFault as runtime_fault:
+                    self.module.fail_json(msg=to_native(runtime_fault.msg))
+                except vmodl.MethodFault as method_fault:
+                    self.module.fail_json(msg=to_native(method_fault.msg))
+                except TaskError as task_e:
+                    self.module.fail_json(msg=to_native(task_e))
+                except Exception as generic_exc:
+                    self.module.fail_json(msg="Failed to create disk"
+                                              " due to generic exception %s" % to_native(generic_exc))
+        else:
+            if self.size_mb < self.disk.config.capacityInMB:
+                self.module.fail_json(msg="Given disk size is smaller than current size (%dMB < %dMB). "
+                                          "Reducing disks is not allowed."
+                                          % (self.size_mb, self.disk.config.capacityInMB))
+            elif self.size_mb > self.disk.config.capacityInMB:
+                changed = True
+                if not self.module.check_mode:
+                    try:
+                        if self.is_vcenter():
+                            task = self.content.vStorageObjectManager.ExtendDisk_Task(self.disk.config.id,
+                                                                                      self.datastore_obj,
+                                                                                      self.size_mb)
+                        else:
+                            task = self.content.vStorageObjectManager.HostExtendDisk_Task(self.disk.config.id,
+                                                                                          self.datastore_obj,
+                                                                                          self.size_mb)
+                        wait_for_task(task)
+                    except vmodl.RuntimeFault as runtime_fault:
+                        self.module.fail_json(msg=to_native(runtime_fault.msg))
+                    except vmodl.MethodFault as method_fault:
+                        self.module.fail_json(msg=to_native(method_fault.msg))
+                    except TaskError as task_e:
+                        self.module.fail_json(msg=to_native(task_e))
+                    except Exception as generic_exc:
+                        self.module.fail_json(msg="Failed to increase disk size"
+                                                  " due to generic exception %s" % to_native(generic_exc))
+
+        self.module.exit_json(changed=changed, result=None)
+
+    def delete(self):
+        changed = False
+        if self.disk:
+            changed = True
+            if not self.module.check_mode:
+                try:
+                    if self.is_vcenter():
+                        task = self.content.vStorageObjectManager.DeleteVStorageObject_Task(self.disk.config.id,
+                                                                                            self.datastore_obj)
+                    else:
+                        task = self.content.vStorageObjectManager.HostDeleteVStorageObject_Task(self.disk.config.id,
+                                                                                                self.datastore_obj)
+                    wait_for_task(task)
+                except vmodl.RuntimeFault as runtime_fault:
+                    self.module.fail_json(msg=to_native(runtime_fault.msg))
+                except vmodl.MethodFault as method_fault:
+                    self.module.fail_json(msg=to_native(method_fault.msg))
+                except TaskError as task_e:
+                    self.module.fail_json(msg=to_native(task_e))
+                except Exception as generic_exc:
+                    self.module.fail_json(msg="Failed to delete disk"
+                                              " due to generic exception %s" % to_native(generic_exc))
+
+        self.module.exit_json(changed=changed, result=None)
+
+
+def main():
+    argument_spec = vmware_argument_spec()
+    argument_spec.update(
+        dict(
+            datacenter_name=dict(type='str'),
+            datastore_name=dict(required=True, type='str'),
+            disk_name=dict(required=True, type='str'),
+            size=dict(type='str'),
+            state=dict(default='present', choices=['present', 'absent'], type='str')
+        )
+    )
+
+    module = AnsibleModule(argument_spec=argument_spec,
+                           required_if=[
+                               ['state', 'present', ['size']]
+                           ],
+                           supports_check_mode=True)
+
+    first_class_disk = FirstClassDisk(module)
+
+    if first_class_disk.desired_state == 'present':
+        first_class_disk.create()
+    if first_class_disk.desired_state == 'absent':
+        first_class_disk.delete()
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/vmware_first_class_disk/aliases
+++ b/tests/integration/targets/vmware_first_class_disk/aliases
@@ -1,0 +1,5 @@
+cloud/vcenter
+needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_1esxi
+zuul/vmware/vcenter_1esxi_with_nested
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_first_class_disk/tasks/main.yml
+++ b/tests/integration/targets/vmware_first_class_disk/tasks/main.yml
@@ -1,0 +1,293 @@
+# Test code for the vmware_first_class_disk module.
+# Copyright: (c) 2021, Mario Lenz <m@riolenz.de>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- when: vcsim is not defined
+  block:
+  - import_role:
+      name: prepare_vmware_tests
+    vars:
+      setup_attach_host: true
+      setup_datastore: true
+
+  - name: Create first-class disk through vCenter (check mode)
+    vmware_first_class_disk: &disk_vcenter_create
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      disk_name: "firstclassdisk"
+      size: 1GB
+      datastore_name: "{{ rw_datastore }}"
+      state: present
+      validate_certs: false
+    check_mode: true
+    register: result_create_vcenter_check_mode
+
+  - debug:
+      var: result_create_vcenter_check_mode
+
+  - name: assert that first-class disk would be created
+    assert:
+      that:
+        - result_create_vcenter_check_mode is changed
+
+  - name: Create first-class disk through vCenter
+    vmware_first_class_disk:
+      <<: *disk_vcenter_create
+    register: result_create_vcenter
+
+  - debug:
+      var: result_create_vcenter
+
+  - name: assert that first-class disk is created
+    assert:
+      that:
+        - result_create_vcenter is changed
+
+  - name: Create first-class disk through vCenter again (idempotency)
+    vmware_first_class_disk:
+      <<: *disk_vcenter_create
+    register: result_create_vcenter_again
+
+  - debug:
+      var: result_create_vcenter_again
+
+  - name: assert that first-class disk would not be created
+    assert:
+      that:
+        - result_create_vcenter_again is not changed
+
+  - name: Increase disk size through vCenter (check mode)
+    vmware_first_class_disk: &disk_vcenter_increase
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      disk_name: "firstclassdisk"
+      size: 2GB
+      datastore_name: "{{ rw_datastore }}"
+      state: present
+      validate_certs: false
+    check_mode: true
+    register: result_increase_vcenter_check_mode
+
+  - debug:
+      var: result_increase_vcenter_check_mode
+
+  - name: assert that disk size would be increased
+    assert:
+      that:
+        - result_increase_vcenter_check_mode is changed
+
+  - name: Increase disk size through vCenter
+    vmware_first_class_disk:
+      <<: *disk_vcenter_increase
+    register: result_increase_vcenter
+
+  - debug:
+      var: result_increase_vcenter
+
+  - name: assert that disk size was increased
+    assert:
+      that:
+        - result_increase_vcenter is changed
+
+  - name: Increase disk size through vCenter again (idempotency)
+    vmware_first_class_disk:
+      <<: *disk_vcenter_increase
+    register: result_increase_vcenter_again
+
+  - debug:
+      var: result_increase_vcenter_again
+
+  - name: assert that disk size would not be increased
+    assert:
+      that:
+        - result_increase_vcenter_again is not changed
+
+
+  - name: Delete first-class disk through vCenter (check mode)
+    vmware_first_class_disk: &disk_vcenter_delete
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      disk_name: "firstclassdisk"
+      datastore_name: "{{ rw_datastore }}"
+      state: absent
+      validate_certs: false
+    check_mode: true
+    register: result_delete_vcenter_check_mode
+
+  - debug:
+      var: result_delete_vcenter_check_mode
+
+  - name: assert that first-class disk would be deleted
+    assert:
+      that:
+        - result_delete_vcenter_check_mode is changed
+
+  - name: Delete first-class disk through vCenter
+    vmware_first_class_disk:
+      <<: *disk_vcenter_delete
+    register: result_delete_vcenter
+
+  - debug:
+      var: result_delete_vcenter
+
+  - name: assert that first-class disk is deleted
+    assert:
+      that:
+        - result_delete_vcenter is changed
+
+  - name: Delete first-class disk through vCenter again (idempotency)
+    vmware_first_class_disk:
+      <<: *disk_vcenter_delete
+    register: result_delete_vcenter_again
+
+  - debug:
+      var: result_delete_vcenter_again
+
+  - name: assert that first-class disk would not be deleted
+    assert:
+      that:
+        - result_delete_vcenter_again is not changed
+
+  - name: Create first-class disk through ESXi (check mode)
+    vmware_first_class_disk: &disk_esxi_create
+      hostname: "{{ esxi1 }}"
+      username: "{{ esxi_user }}"
+      password: "{{ esxi_password }}"
+      disk_name: "firstclassdisk"
+      size: 1GB
+      datastore_name: "{{ rw_datastore }}"
+      state: present
+      validate_certs: false
+    check_mode: true
+    register: result_create_esxi_check_mode
+
+  - debug:
+      var: result_create_esxi_check_mode
+
+  - name: assert that first-class disk would be created
+    assert:
+      that:
+        - result_create_esxi_check_mode is changed
+
+  - name: Create first-class disk through ESXi
+    vmware_first_class_disk:
+      <<: *disk_esxi_create
+    register: result_create_esxi
+
+  - debug:
+      var: result_create_esxi
+
+  - name: assert that first-class disk is created
+    assert:
+      that:
+        - result_create_esxi is changed
+
+  - name: Create first-class disk through ESXi again (idempotency)
+    vmware_first_class_disk:
+      <<: *disk_esxi_create
+    register: result_create_esxi_again
+
+  - debug:
+      var: result_create_esxi_again
+
+  - name: assert that first-class disk would not be created
+    assert:
+      that:
+        - result_create_esxi_again is not changed
+
+  - name: Increase disk size through ESXi (check mode)
+    vmware_first_class_disk: &disk_esxi_increase
+      hostname: "{{ esxi1 }}"
+      username: "{{ esxi_user }}"
+      password: "{{ esxi_password }}"
+      disk_name: "firstclassdisk"
+      size: 2GB
+      datastore_name: "{{ rw_datastore }}"
+      state: present
+      validate_certs: false
+    check_mode: true
+    register: result_increase_esxi_check_mode
+
+  - debug:
+      var: result_increase_esxi_check_mode
+
+  - name: assert that disk size would be increased
+    assert:
+      that:
+        - result_increase_esxi_check_mode is changed
+
+  - name: Increase disk size through ESXi
+    vmware_first_class_disk:
+      <<: *disk_esxi_increase
+    register: result_increase_esxi
+
+  - debug:
+      var: result_increase_esxi
+
+  - name: assert that disk size was increased
+    assert:
+      that:
+        - result_increase_esxi is changed
+
+  - name: Increase disk size through ESXi again (idempotency)
+    vmware_first_class_disk:
+      <<: *disk_esxi_increase
+    register: result_increase_esxi_again
+
+  - debug:
+      var: result_increase_esxi_again
+
+  - name: assert that disk size would not be increased
+    assert:
+      that:
+        - result_increase_esxi_again is not changed
+
+
+  - name: Delete first-class disk through ESXi (check mode)
+    vmware_first_class_disk: &disk_esxi_delete
+      hostname: "{{ esxi1 }}"
+      username: "{{ esxi_user }}"
+      password: "{{ esxi_password }}"
+      disk_name: "firstclassdisk"
+      datastore_name: "{{ rw_datastore }}"
+      state: absent
+      validate_certs: false
+    check_mode: true
+    register: result_delete_esxi_check_mode
+
+  - debug:
+      var: result_delete_esxi_check_mode
+
+  - name: assert that first-class disk would be deleted
+    assert:
+      that:
+        - result_delete_esxi_check_mode is changed
+
+  - name: Delete first-class disk through ESXi
+    vmware_first_class_disk:
+      <<: *disk_esxi_delete
+    register: result_delete_esxi
+
+  - debug:
+      var: result_delete_esxi
+
+  - name: assert that first-class disk is deleted
+    assert:
+      that:
+        - result_delete_esxi is changed
+
+  - name: Delete first-class disk through ESXi again (idempotency)
+    vmware_first_class_disk:
+      <<: *disk_esxi_delete
+    register: result_delete_esxi_again
+
+  - debug:
+      var: result_delete_esxi_again
+
+  - name: assert that first-class disk would not be deleted
+    assert:
+      that:
+        - result_delete_esxi_again is not changed


### PR DESCRIPTION
##### SUMMARY
A new module to create, re-size and delete [first class disks](https://cormachogan.com/2018/11/21/a-primer-on-first-class-disks-improved-virtual-disks/).

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
vmware_first_class_disk

##### ADDITIONAL INFORMATION
FCDs can be useful when you need to manage virtual disks independently from VMs. For example, if you have to re-build a VM but don't want to loose your data (for example because it's so much that recovering from backup would take too much time). FCDs allow you to

1. Create a FCD and attach it to a VM
2. Detach the FCD from the VM
3. Re-create the VM
4. Attach the FCD to the fresh VM

While this is possible with old-school VMDKs, this is quite painful. In the long run, vmware_guest_disk should also be FCD-aware but I wanted to start with a module to create them in the first place.
