### PR TITLE
vmware_host_iscsi: Support an iSCSI name changing option

### DIFF
--- a/changelogs/fragments/617-vmware_host_iscsi.yml
+++ b/changelogs/fragments/617-vmware_host_iscsi.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_host_iscsi - added a name(iqn) changing option for iSCSI (https://github.com/ansible-collections/community.vmware/pull/617).

--- a/docs/community.vmware.vmware_host_iscsi_module.rst
+++ b/docs/community.vmware.vmware_host_iscsi_module.rst
@@ -286,6 +286,7 @@ Parameters
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
                     </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.7.0</div>
                 </td>
                 <td>
                 </td>

--- a/docs/community.vmware.vmware_host_iscsi_module.rst
+++ b/docs/community.vmware.vmware_host_iscsi_module.rst
@@ -281,6 +281,24 @@ Parameters
                     <td class="elbow-placeholder"></td>
                 <td colspan="3">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>iscsi_name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The name for the iSCSI HBA adapter.</div>
+                        <div>This is iSCSI qualified name.</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: initiator_iqn</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="3">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>port_bind</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">

--- a/plugins/modules/vmware_host_iscsi.py
+++ b/plugins/modules/vmware_host_iscsi.py
@@ -34,6 +34,7 @@ options:
         - The name for the iSCSI HBA adapter.
         - This is iSCSI qualified name.
         type: str
+        version_added: '1.7.0'
         aliases:
         - initiator_iqn
       alias:

--- a/tests/integration/targets/vmware_host_iscsi/tasks/iscsi_module_test_tasks.yml
+++ b/tests/integration/targets/vmware_host_iscsi/tasks/iscsi_module_test_tasks.yml
@@ -46,6 +46,10 @@
     that:
       - enable_iscsi_idempotency_check_result.changed is sameas false
 
+- name: Set an iqn variable for an iSCSI name changing test
+  set_fact:
+    iqn: "iqn.1998-01.com.vmware:{{ hostname }}-012345"
+
 - name: Update a name for iSCSI of ESXi with check_mode
   vmware_host_iscsi:
     hostname: "{{ hostname }}"
@@ -54,7 +58,7 @@
     validate_certs: false
     esxi_hostname: "{{ esxi1 }}"
     iscsi_config:
-      iscsi_name: iqn.1998-01.com.vmware:example-012345
+      iscsi_name: "{{ iqn }}"
       vmhba_name: "{{ vmhba_name }}"
     state: present
   check_mode: true
@@ -72,7 +76,7 @@
     validate_certs: false
     esxi_hostname: "{{ esxi1 }}"
     iscsi_config:
-      iscsi_name: iqn.1998-01.com.vmware:example-012345
+      iscsi_name: "{{ iqn }}"
       vmhba_name: "{{ vmhba_name }}"
     state: present
   register: update_iscsi_name_result
@@ -80,7 +84,7 @@
 - assert:
     that:
       - update_iscsi_name_result.changed is sameas true
-      - update_iscsi_name_result.iscsi_properties.iscsi_name == 'iqn.1998-01.com.vmware:example-012345'
+      - update_iscsi_name_result.iscsi_properties.iscsi_name == iqn
 
 - name: Update a name for iSCSI of ESXi (idempotency check)
   vmware_host_iscsi:
@@ -90,7 +94,7 @@
     validate_certs: false
     esxi_hostname: "{{ esxi1 }}"
     iscsi_config:
-      iscsi_name: iqn.1998-01.com.vmware:example-012345
+      iscsi_name: "{{ iqn }}"
       vmhba_name: "{{ vmhba_name }}"
     state: present
   register: update_iscsi_name_idempotency_check_result

--- a/tests/integration/targets/vmware_host_iscsi/tasks/iscsi_module_test_tasks.yml
+++ b/tests/integration/targets/vmware_host_iscsi/tasks/iscsi_module_test_tasks.yml
@@ -46,6 +46,59 @@
     that:
       - enable_iscsi_idempotency_check_result.changed is sameas false
 
+- name: Update a name for iSCSI of ESXi with check_mode
+  vmware_host_iscsi:
+    hostname: "{{ hostname }}"
+    username: "{{ username }}"
+    password: "{{ password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    iscsi_config:
+      iscsi_name: iqn.1998-01.com.vmware:example-012345
+      vmhba_name: "{{ vmhba_name }}"
+    state: present
+  check_mode: true
+  register: update_iscsi_name_check_mode_result
+
+- assert:
+    that:
+      - update_iscsi_name_check_mode_result.changed is sameas true
+
+- name: Update a name for iSCSI of ESXi
+  vmware_host_iscsi:
+    hostname: "{{ hostname }}"
+    username: "{{ username }}"
+    password: "{{ password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    iscsi_config:
+      iscsi_name: iqn.1998-01.com.vmware:example-012345
+      vmhba_name: "{{ vmhba_name }}"
+    state: present
+  register: update_iscsi_name_result
+
+- assert:
+    that:
+      - update_iscsi_name_result.changed is sameas true
+      - update_iscsi_name_result.iscsi_properties.iscsi_name == 'iqn.1998-01.com.vmware:example-012345'
+
+- name: Update a name for iSCSI of ESXi (idempotency check)
+  vmware_host_iscsi:
+    hostname: "{{ hostname }}"
+    username: "{{ username }}"
+    password: "{{ password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    iscsi_config:
+      iscsi_name: iqn.1998-01.com.vmware:example-012345
+      vmhba_name: "{{ vmhba_name }}"
+    state: present
+  register: update_iscsi_name_idempotency_check_result
+
+- assert:
+    that:
+      - update_iscsi_name_idempotency_check_result.changed is sameas false
+
 - name: Update an alias for iSCSI of ESXi with check_mode
   vmware_host_iscsi:
     hostname: "{{ hostname }}"


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/community.vmware/pull/620

##### SUMMARY

This PR will add a new option for an iSCSI name changing.  
fixes: https://github.com/ansible-collections/community.vmware/issues/603

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

docs/community.vmware.vmware_host_iscsi_module.rst
plugins/modules/vmware_host_iscsi.py
tests/integration/targets/vmware_host_iscsi/tasks/iscsi_module_test_tasks.yml

##### ADDITIONAL INFORMATION

tested on vCenter/ESXi 7.0