### PR TITLE
ensure the sanity tests pass with 2.10.5

### DIFF
--- a/tests/integration/targets/vmware_cluster_info/tasks/main.yml
+++ b/tests/integration/targets/vmware_cluster_info/tasks/main.yml
@@ -194,4 +194,3 @@
   assert:
     that:
       - all_cluster_result.clusters['Cluster/\%']
-

--- a/tests/integration/targets/vmware_guest/tasks/network_with_portgroup.yml
+++ b/tests/integration/targets/vmware_guest/tasks/network_with_portgroup.yml
@@ -100,7 +100,6 @@
         validate_certs: false
         datacenter: "{{ dc1 }}"
         esxi_hostname: "{{ esxi1 }}"
-        state: poweredon
         folder: "{{ f0 }}"
         name: test_vm_slash
         force: true

--- a/tests/integration/targets/vmware_guest_network/tasks/main.yml
+++ b/tests/integration/targets/vmware_guest_network/tasks/main.yml
@@ -454,7 +454,6 @@
           hostname: "{{ vcenter_hostname }}"
           username: "{{ vcenter_username }}"
           password: "{{ vcenter_password }}"
-          validate_certs: false
           name: test_vm1
           networks:
             - name: "{{ dvpg1 }}"
@@ -472,7 +471,6 @@
           hostname: "{{ vcenter_hostname }}"
           username: "{{ vcenter_username }}"
           password: "{{ vcenter_password }}"
-          validate_certs: false
           name: test_vm1
           networks:
             - name: 204dvpg
@@ -490,7 +488,6 @@
           hostname: "{{ vcenter_hostname }}"
           username: "{{ vcenter_username }}"
           password: "{{ vcenter_password }}"
-          validate_certs: false
           name: test_vm1
           networks:
             - name: VM Network
@@ -519,4 +516,3 @@
       - assert:
           that:
             - delete_integration_test_204_result.changed is sameas true
-


### PR DESCRIPTION
Address the following sanity errors:

```
Command exited with status 0 after 11.622503757476807 seconds.
ERROR: Found 6 yamllint issue(s) which need to be resolved:
ERROR: tests/integration/targets/vmware_cluster_info/tasks/main.yml:197:1: empty-lines: too many blank lines (1 > 0)
ERROR: tests/integration/targets/vmware_guest/tasks/network_with_portgroup.yml:107:9: key-duplicates: duplication of key "state" in mapping
ERROR: tests/integration/targets/vmware_guest_network/tasks/main.yml:457:11: key-duplicates: duplication of key "validate_certs" in mapping
ERROR: tests/integration/targets/vmware_guest_network/tasks/main.yml:475:11: key-duplicates: duplication of key "validate_certs" in mapping
ERROR: tests/integration/targets/vmware_guest_network/tasks/main.yml:493:11: key-duplicates: duplication of key "validate_certs" in mapping
ERROR: tests/integration/targets/vmware_guest_network/tasks/main.yml:522:1: empty-lines: too many blank lines (1 > 0)
See documentation for help: https://docs.ansible.com/ansible/devel/dev_guide/testing/sanity/yamllint.html
ERROR: The 1 sanity test(s) listed below (out of 33) failed. See error output above for details.
yamllint
Cleaning up temporary python directory: /tmp/python-o8dqv7sy-ansible
```

e.g: https://dashboard.zuul.ansible.com/t/ansible/build/6252096585224980811d5fe93e337232