### PR TITLE
vmware_guest_register_operation: Support the check mode

### DIFF
--- a/changelogs/fragments/626-vmware_guest_register_operation.yml
+++ b/changelogs/fragments/626-vmware_guest_register_operation.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_guest_register_operation - supported the check_mode

--- a/plugins/modules/vmware_guest_register_operation.py
+++ b/plugins/modules/vmware_guest_register_operation.py
@@ -191,8 +191,15 @@ class VMwareGuestRegisterOperation(PyVmomi):
                                   details=details)
 
         if self.state == "present":
-            if self.get_vm():
+            vm_obj = self.get_vm()
+            if vm_obj:
+                if self.module.check_mode:
+                    self.module.exit_json(**result)
                 self.module.exit_json(**result)
+            else:
+                if self.module.check_mode:
+                    result['changed'] = True
+                    self.module.exit_json(**result)
 
             if self.esxi_hostname:
                 host_obj = self.find_hostsystem_by_name(self.esxi_hostname)
@@ -228,6 +235,14 @@ class VMwareGuestRegisterOperation(PyVmomi):
 
         if self.state == "absent":
             vm_obj = self.get_vm()
+            if vm_obj:
+                if self.module.check_mode:
+                    result['changed'] = True
+                    self.module.exit_json(**result)
+            else:
+                if self.module.check_mode:
+                    self.module.exit_json(**result)
+
             if vm_obj:
                 try:
                     vm_obj.UnregisterVM()

--- a/tests/integration/targets/vmware_guest_register_operation/tasks/main.yml
+++ b/tests/integration/targets/vmware_guest_register_operation/tasks/main.yml
@@ -11,20 +11,19 @@
     setup_virtualmachines: true
     setup_resource_pool: true
 
-- block:
-  - name: gather facts of vm
-    vmware_guest_info:
-      hostname: "{{ vcenter_hostname }}"
-      username: "{{ vcenter_username }}"
-      password: "{{ vcenter_password }}"
-      validate_certs: false
-      datacenter: "{{ dc1 }}"
-      folder: "{{ f0 }}"
-      name: "{{ virtual_machines[0].name }}"
-    register: vm_facts
+- name: gather facts of vm
+  vmware_guest_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    datacenter: "{{ dc1 }}"
+    folder: "{{ f0 }}"
+    name: "{{ virtual_machines[0].name }}"
+  register: vm_facts
 
-  - name: get a vm vmx file path
-    set_fact: vm_vmx_file_path="{{ vm_facts.instance.hw_files[0] }}"
+- name: get a vm vmx file path
+  set_fact: vm_vmx_file_path="{{ vm_facts.instance.hw_files[0] }}"
 
 - name: Powered off the vm
   vmware_guest_powerstate:
@@ -36,6 +35,24 @@
     name: "{{ virtual_machines[0].name }}"
     state: powered-off
 
+- name: Unregister VM from inventory with check_mode
+  vmware_guest_register_operation:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    datacenter: "{{ dc1 }}"
+    folder: "/vm"
+    name: "{{ virtual_machines[0].name }}"
+    state: absent
+  check_mode: true
+  register: unregister_vm_inventory_check_mode_result
+
+- name: Make sure the changed occurred
+  assert:
+    that:
+      - unregister_vm_inventory_check_mode_result.changed is sameas true
+
 - name: Unregister VM from inventory
   vmware_guest_register_operation:
     hostname: "{{ vcenter_hostname }}"
@@ -46,6 +63,7 @@
     folder: "/vm"
     name: "{{ virtual_machines[0].name }}"
     state: absent
+  register: unregister_vm_inventory_result1
 
 - name: Gather all registered virtual machines
   vmware_vm_facts:
@@ -63,11 +81,32 @@
         | map(attribute='guest_name')
         | list
         | length == 0
+      - unregister_vm_inventory_result1.changed is sameas true
 
 - assert:
     that:
       - item.guest_name != virtual_machines[0].name
   loop: "{{ vms.virtual_machines }}"
+
+- name: Register VM to inventory with check_mode
+  vmware_guest_register_operation:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    datacenter: "{{ dc1 }}"
+    folder: "/vm"
+    esxi_hostname: "{{ esxi1 }}"
+    name: "{{ virtual_machines[0].name }}"
+    path: "{{ vm_vmx_file_path }}"
+    state: present
+  check_mode: true
+  register: register_vm_inventory_check_mode_result
+
+- name: Make sure the changed occurred
+  assert:
+    that:
+      - register_vm_inventory_check_mode_result.changed is sameas true
 
 - name: Register VM to inventory
   vmware_guest_register_operation:
@@ -81,6 +120,7 @@
     name: "{{ virtual_machines[0].name }}"
     path: "{{ vm_vmx_file_path }}"
     state: present
+  register: register_vm_inventory_result
 
 - name: Gather all registered virtual machines
   vmware_vm_facts:
@@ -99,6 +139,7 @@
         | map(attribute='guest_name')
         | list
         | length == 1
+      - register_vm_inventory_result.changed is sameas true
 
 - name: Unregister VM from inventory
   vmware_guest_register_operation:
@@ -110,6 +151,7 @@
     folder: "/vm"
     name: "{{ virtual_machines[0].name }}"
     state: absent
+  register: unregister_vm_inventory_result2
 
 - name: Gather all registered virtual machines
   vmware_vm_facts:
@@ -127,6 +169,27 @@
         | map(attribute='guest_name')
         | list
         | length == 0
+      - unregister_vm_inventory_result2.changed is sameas true
+
+- name: Register VM in Cluster with check_mode
+  vmware_guest_register_operation:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    datacenter: "{{ dc1 }}"
+    folder: "/vm"
+    cluster: "{{ ccr1 }}"
+    name: "{{ virtual_machines[0].name }}"
+    path: "{{ vm_vmx_file_path }}"
+    state: present
+  check_mode: true
+  register: register_vm_cluster_check_mode_result
+
+- name: Make sure the changed occurred
+  assert:
+    that:
+      - register_vm_cluster_check_mode_result.changed is sameas true
 
 - name: Register VM in Cluster
   vmware_guest_register_operation:
@@ -140,6 +203,7 @@
     name: "{{ virtual_machines[0].name }}"
     path: "{{ vm_vmx_file_path }}"
     state: present
+  register: register_vm_cluster_result
 
 - name: Gather all registered virtual machines
   vmware_vm_facts:
@@ -158,6 +222,7 @@
         | map(attribute='guest_name')
         | list
         | length == 1
+      - register_vm_cluster_result.changed is sameas true
 
 - name: Unregister VM from inventory
   vmware_guest_register_operation:
@@ -169,6 +234,7 @@
     folder: "/vm"
     name: "{{ virtual_machines[0].name }}"
     state: absent
+  register: unregister_vm_inventory_result3
 
 - name: Gather all registered virtual machines
   vmware_vm_facts:
@@ -186,6 +252,27 @@
         | map(attribute='guest_name')
         | list
         | length == 0
+      - unregister_vm_inventory_result3.changed is sameas true
+
+- name: Register VM in Resource pool with check_mode
+  vmware_guest_register_operation:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    datacenter: "{{ dc1 }}"
+    folder: "/vm"
+    resource_pool: DC0_C0_RP1
+    name: "{{ virtual_machines[0].name }}"
+    path: "{{ vm_vmx_file_path }}"
+    state: present
+  check_mode: true
+  register: register_vm_resource_pool_check_mode_result
+
+- name: Make sure the changed occurred
+  assert:
+    that:
+      - register_vm_resource_pool_check_mode_result.changed is sameas true
 
 - name: Register VM in Resource pool
   vmware_guest_register_operation:
@@ -199,6 +286,7 @@
     name: "{{ virtual_machines[0].name }}"
     path: "{{ vm_vmx_file_path }}"
     state: present
+  register: register_vm_resource_pool_result
 
 - name: Gather all registered virtual machines
   vmware_vm_facts:
@@ -216,6 +304,7 @@
         | map(attribute='guest_name')
         | list
         | length == 1
+      - register_vm_resource_pool_result.changed is sameas true
 
 - name: Gather facts of vm
   vmware_guest_info:
@@ -242,6 +331,7 @@
     name: "{{ virtual_machines[0].name }}"
     uuid: "{{ vm_uuid }}"
     state: absent
+  register: unregister_vm_inventory_result4
 
 - name: Gather all registered virtual machines
   vmware_vm_facts:
@@ -259,3 +349,4 @@
         | map(attribute='guest_name')
         | list
         | length == 0
+      - unregister_vm_inventory_result4.changed is sameas true


### PR DESCRIPTION
##### SUMMARY

The vmware_guest_register_operation hasn't supported the check mode.  
So, I want to add the check mode processing to the module by this PR.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/modules/vmware_guest_register_operation.py
tests/integration/targets/vmware_guest_register_operation/tasks/main.yml

##### ADDITIONAL INFORMATION

Tested on vCenter/ESXi 7.0