### PR TITLE
vmware_datastore_cluster_manager: Fix idempotency in check mode

### DIFF
--- a/changelogs/fragments/623-vmware_datastore_cluster_manager.yml
+++ b/changelogs/fragments/623-vmware_datastore_cluster_manager.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_datastore_cluster_manager - Fix idempotency in check mode (https://github.com/ansible-collections/community.vmware/issues/623).

--- a/plugins/modules/vmware_datastore_cluster_manager.py
+++ b/plugins/modules/vmware_datastore_cluster_manager.py
@@ -161,7 +161,7 @@ class VMwareDatastoreClusterManager(PyVmomi):
                 changed_list = [ds.name for ds in datastore_obj_list]
                 temp_result['current_datastores'] = temp_result['previous_datastores'].extend(changed_list)
                 temp_result['changed_datastores'] = changed_list
-                results['changed'] = True
+                results['changed'] = len(datastore_obj_list) > 0
                 results['datastore_cluster_info'] = temp_result
                 self.module.exit_json(**results)
 
@@ -191,7 +191,7 @@ class VMwareDatastoreClusterManager(PyVmomi):
                 for ds in changed_list:
                     temp_result['current_datastores'].pop(ds)
                 temp_result['changed_datastores'] = changed_list
-                results['changed'] = True
+                results['changed'] = len(datastore_obj_list) > 0
                 results['datastore_cluster_info'] = temp_result
                 self.module.exit_json(**results)
 


### PR DESCRIPTION
##### SUMMARY
When running in check mode the module is always reporting changed even when it is not detecting any changes.

Fixes #623 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_datastore_cluster_manager
