### PR TITLE
vmware_host_service_manager: enable the test-suite

### DIFF
--- a/tests/integration/targets/vmware_host_service_manager/aliases
+++ b/tests/integration/targets/vmware_host_service_manager/aliases
@@ -1,5 +1,3 @@
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
-# see: https://github.com/ansible-collections/vmware/issues/101
-disabled


### PR DESCRIPTION
##### SUMMARY
Enable `vmware_host_service_manager` tests again.

Fixes #101 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_host_service_manager

##### ADDITIONAL INFORMATION
The jobs referenced in #101 are inaccessible, I guess they've been log-rotated away. I want to enable the tests again to see what happens.

_edit:_ [build succeeded](https://dashboard.zuul.ansible.com/t/ansible/buildset/e5e7558fcb974eb8b5c8cb3c96a98a0c)