### PR TITLE
vmware_dvs_portgroup: Fix the issues that the module hasn’t the idempotency when it is configured the multiple VLAN

### DIFF
--- a/changelogs/fragments/638-vmware_dvs_portgroup.yml
+++ b/changelogs/fragments/638-vmware_dvs_portgroup.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_dvs_portgroup - fixed the issue that the VLAN configuration isn't compared correctly in the module (https://github.com/ansible-collections/community.vmware/pull/638).

--- a/plugins/modules/vmware_dvs_portgroup.py
+++ b/plugins/modules/vmware_dvs_portgroup.py
@@ -500,7 +500,7 @@ class VMwareDvsPortgroup(PyVmomi):
         if self.module.params['vlan_trunk']:
             if not isinstance(defaultPortConfig.vlan, vim.dvs.VmwareDistributedVirtualSwitch.TrunkVlanSpec):
                 return 'update'
-            if map(lambda x: (x.start, x.end), defaultPortConfig.vlan.vlanId) != self.create_vlan_list():
+            if list(map(lambda x: (x.start, x.end), defaultPortConfig.vlan.vlanId)) != self.create_vlan_list():
                 return 'update'
         elif self.module.params['vlan_private']:
             if not isinstance(defaultPortConfig.vlan, vim.dvs.VmwareDistributedVirtualSwitch.PvlanSpec):

--- a/tests/integration/targets/vmware_dvs_portgroup/tasks/main.yml
+++ b/tests/integration/targets/vmware_dvs_portgroup/tasks/main.yml
@@ -629,3 +629,74 @@
         - assert:
             that:
               - delete_dvswitch_with_special_characters_result.changed is sameas true
+
+    # https://github.com/ansible-collections/community.vmware/issues/637
+    # The test if the vmware_dvs_portgroup has the idempotency when it is configured the multiple VLAN.
+    - name: Create the test dvs port group for the issues 637
+      vmware_dvs_portgroup:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        portgroup_name: "dvpg637"
+        switch_name: "{{ dvswitch1 }}"
+        vlan_id: "1500,1501"
+        vlan_trunk: true
+        num_ports: 120
+        portgroup_type: earlyBinding
+        network_policy:
+          promiscuous: false
+          forged_transmits: true
+          mac_changes: true
+        state: present
+      register: create_test_dvs_port_group_issues_637_result
+
+    - assert:
+        that:
+          - create_test_dvs_port_group_issues_637_result.changed is sameas true
+
+    - name: Create the test dvs port group for the issues 637(idempotency check)
+      vmware_dvs_portgroup:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        portgroup_name: "dvpg637"
+        switch_name: "{{ dvswitch1 }}"
+        vlan_id: "1500,1501"
+        vlan_trunk: true
+        num_ports: 120
+        portgroup_type: earlyBinding
+        network_policy:
+          promiscuous: false
+          forged_transmits: true
+          mac_changes: true
+        state: present
+      register: create_test_dvs_port_group_issues_637_idempotency_check_result
+
+    - assert:
+        that:
+          - create_test_dvs_port_group_issues_637_idempotency_check_result.changed is sameas false
+
+    - name: Delete the test dvs port group for the issues 637
+      vmware_dvs_portgroup:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        portgroup_name: "dvpg637"
+        switch_name: "{{ dvswitch1 }}"
+        vlan_id: "1500,1501"
+        vlan_trunk: true
+        num_ports: 120
+        portgroup_type: earlyBinding
+        network_policy:
+          promiscuous: false
+          forged_transmits: true
+          mac_changes: true
+        state: absent
+      register: delete_test_dvs_port_group_issues_637_idempotency_check_result
+
+    - assert:
+        that:
+          - delete_test_dvs_port_group_issues_637_idempotency_check_result.changed is sameas true


### PR DESCRIPTION
##### SUMMARY

The vmware_dvs_portgroup hasn't the idempotency when configuring the multiple VLAN.  
This PR will fix that issue.

fixes: https://github.com/ansible-collections/community.vmware/issues/637

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

plugins/modules/vmware_dvs_portgroup.py
tests/integration/targets/vmware_dvs_portgroup/tasks/main.yml
changelogs/fragments/638-vmware_dvs_portgroup.yml

##### ADDITIONAL INFORMATION

tested on vCenter/ESXi 7.0