### PR TITLE
vmware_guest: Remove unnecessary hardware version check

### DIFF
--- a/changelogs/fragments/636_vmware_guest.yml
+++ b/changelogs/fragments/636_vmware_guest.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- vmware_guest - Remove unnecessary hardware version check (https://github.com/ansible-collections/community.vmware/issues/636).

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -1741,7 +1741,6 @@ class PyVmomiHelper(PyVmomi):
 
         temp_version = self.params['hardware']['version']
         if temp_version is not None:
-            hw_version_check_failed = False
             if temp_version.lower() == 'latest':
                 # Check is to make sure vm_obj is not of type template
                 if vm_obj and not vm_obj.config.template:
@@ -1757,14 +1756,9 @@ class PyVmomiHelper(PyVmomi):
                 try:
                     temp_version = int(temp_version)
                 except ValueError:
-                    hw_version_check_failed = True
-
-                if temp_version not in range(3, 18):
-                    hw_version_check_failed = True
-
-                if hw_version_check_failed:
                     self.module.fail_json(msg="Failed to set hardware.version '%s' value as valid"
-                                          " values range from 3 (ESX 2.x) to 17 (ESXi 7.0)." % temp_version)
+                                          " values are either 'latest' or a number." % temp_version)
+
                 # Hardware version is denoted as "vmx-10"
                 version = "vmx-%02d" % temp_version
                 self.configspec.version = version

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -1757,7 +1757,8 @@ class PyVmomiHelper(PyVmomi):
                     temp_version = int(temp_version)
                 except ValueError:
                     self.module.fail_json(msg="Failed to set hardware.version '%s' value as valid"
-                                          " values are either 'latest' or a number." % temp_version)
+                                          " values are either 'latest' or a number."
+                                          " Please check VMware documentation for valid VM hardware versions." % temp_version)
 
                 # Hardware version is denoted as "vmx-10"
                 version = "vmx-%02d" % temp_version


### PR DESCRIPTION
##### SUMMARY
Checking the virtual HW version to be in the `range(3, 18)` is quite unnecessary.

Fixes #636 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_guest

##### ADDITIONAL INFORMATION
We need to change the range of valid versions for every new release. And anyway, it doesn't prevent anyone from using a theoretically(!) valid version with a vCenter or ESXi that doesn't support it; like version 18 with vCenter / ESXi 6.5.