### PR TITLE
vmware_category: Add namespace to associable types

### DIFF
--- a/changelogs/fragments/579_vmware_category.yml
+++ b/changelogs/fragments/579_vmware_category.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- vmware_category - append namespace to associable types (https://github.com/ansible-collections/community.vmware/issues/579).


### PR DESCRIPTION
##### SUMMARY

In vCenter 7.0.1, namespace is required in associable types.

Fixes: #579

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/579_vmware_category.yml
