### PR TITLE
vcenter_license: Fix the bug that the license doesn't assign in vCenter Server 7.0u1c

### DIFF
--- a/changelogs/fragments/643-vcenter_license.yml
+++ b/changelogs/fragments/643-vcenter_license.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vcenter_license - fixed a bug that the license doesn't assign in VCSA 7.0u1c (https://github.com/ansible-collections/community.vmware/pull/643).

--- a/plugins/modules/vcenter_license.py
+++ b/plugins/modules/vcenter_license.py
@@ -228,7 +228,7 @@ def main():
                 if 'esx' not in key.editionKey:
                     module.warn('License key "%s" edition "%s" is not suitable for ESXi server' % (license, key.editionKey))
             # backward compatibility - check if it's is a vCenter licence key
-            elif pyv.content.about.name in key.name:
+            elif pyv.content.about.name in key.name or 'vCenter Server' in key.name:
                 entityId = pyv.content.about.instanceUuid
 
         # if we have found a cluster, an esxi or a vCenter object we try to assign the licence


### PR DESCRIPTION
##### SUMMARY

The module has the bug that the new or existing license doesn't assign in vCenter Server 7.0u1c.  
The cause of the bug is key.name changed the following like.

* 7.0u1 or less

```
VMware vCenter Server 7 Standard
```

* 7.0u1c

```
vCenter Server 7 Standard
```

This way, the VMware string seems to be removed in VCSA 7.0u1c.  
This PR will fix to assign correctly the license.

fixes: https://github.com/ansible-collections/community.vmware/issues/616

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

changelogs/fragments/643-vcenter_license.yml
plugins/modules/vcenter_license.py

##### ADDITIONAL INFORMATION

tested on vCenter 7.0u1c/7.0u1/6.7