### PR TITLE
Fix to decode URL encoded dvs port group name

### DIFF
--- a/changelogs/fragments/648-vmware_dvs_portgroup_find_info.yml
+++ b/changelogs/fragments/648-vmware_dvs_portgroup_find_info.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - vmware_dvs_portgroup_find - fixed to decode the special characters URL-encoded in the dvs port group name (https://github.com/ansible-collections/community.vmware/pull/648).
+  - vmware_dvs_portgroup_info - fixed to decode the special characters URL-encoded in the dvs port group name (https://github.com/ansible-collections/community.vmware/pull/648).

--- a/plugins/modules/vmware_dvs_portgroup_find.py
+++ b/plugins/modules/vmware_dvs_portgroup_find.py
@@ -91,6 +91,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.vmware.plugins.module_utils.vmware import (
     vmware_argument_spec,
     PyVmomi)
+from ansible.module_utils.six.moves.urllib.parse import unquote
 
 
 class DVSPortgroupFindManager(PyVmomi):
@@ -167,14 +168,14 @@ class DVSPortgroupFindManager(PyVmomi):
             if self.cmp_vlans:
                 if self.vlan_match(pg.config.uplink, self.module.params['show_uplink'], vlan_id_list):
                     pglist.append(dict(
-                        name=pg.name,
+                        name=unquote(pg.name),
                         trunk=trunk,
                         pvlan=pvlan,
                         vlan_id=','.join(vlan_id_list),
                         dvswitch=pg.config.distributedVirtualSwitch.name))
             else:
                 pglist.append(dict(
-                    name=pg.name,
+                    name=unquote(pg.name),
                     trunk=trunk,
                     pvlan=pvlan,
                     vlan_id=','.join(vlan_id_list),

--- a/plugins/modules/vmware_dvs_portgroup_info.py
+++ b/plugins/modules/vmware_dvs_portgroup_info.py
@@ -130,6 +130,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.vmware.plugins.module_utils.vmware import vmware_argument_spec, PyVmomi, get_all_objs, find_dvs_by_name
+from ansible.module_utils.six.moves.urllib.parse import unquote
 
 
 class DVSPortgroupInfoManager(PyVmomi):
@@ -228,7 +229,7 @@ class DVSPortgroupInfoManager(PyVmomi):
                     vlan_info = self.get_vlan_info(dvs_pg.config.defaultPortConfig.vlan)
 
                 dvpg_details = dict(
-                    portgroup_name=dvs_pg.name,
+                    portgroup_name=unquote(dvs_pg.name),
                     num_ports=dvs_pg.config.numPorts,
                     dvswitch_name=dvs_pg.config.distributedVirtualSwitch.name,
                     description=dvs_pg.config.description,

--- a/tests/integration/targets/vmware_dvs_portgroup_find/tasks/main.yml
+++ b/tests/integration/targets/vmware_dvs_portgroup_find/tasks/main.yml
@@ -40,3 +40,63 @@
       - dvspgvlid_0001.dvs_portgroups is defined
       - dvspgvlid_0001.dvs_portgroups[1] is defined
       - dvspgvlid_0001.dvs_portgroups[1].vlan_id == "0"
+
+# https://github.com/ansible-collections/community.vmware/pull/648
+- name: The test for the dvportgroup with special characters
+  when: vcsim is not defined
+  block:
+    - name: Create dvPortGroup with special characters
+      vmware_dvs_portgroup:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        switch_name: "{{ dvswitch1 }}"
+        portgroup_name: 'dvportgroup\/%'
+        vlan_id: 1
+        num_ports: 8
+        portgroup_type: earlyBinding
+        state: present
+      register: create_dvportgroup_with_special_characters_result
+
+    - name: Make sure if the dvportgroup name with special characters is created
+      assert:
+        that:
+          - create_dvportgroup_with_special_characters_result.changed is sameas true
+
+    - name: get list of portgroups
+      vmware_dvs_portgroup_find:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+      register: dvspg_0002
+
+    - name: Make sure if the dvportgroup name with special characters is created
+      assert:
+        that:
+          - >-
+           dvspg_0002.dvs_portgroups
+           | map(attribute='name')
+           | select('==', 'dvportgroup\/%')
+           | list
+           | length == 1
+
+    - name: Delete dvPortGroup with special characters
+      vmware_dvs_portgroup:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        switch_name: "{{ dvswitch1 }}"
+        portgroup_name: 'dvportgroup\/%'
+        vlan_id: 1
+        num_ports: 8
+        portgroup_type: earlyBinding
+        state: absent
+      register: delete_dvportgroup_with_special_characters_result
+
+    - name: Make sure if the dvportgroup is deleted
+      assert:
+        that:
+          - delete_dvportgroup_with_special_characters_result.changed is sameas true

--- a/tests/integration/targets/vmware_dvs_portgroup_info/tasks/main.yml
+++ b/tests/integration/targets/vmware_dvs_portgroup_info/tasks/main.yml
@@ -37,6 +37,59 @@
         that:
           - dvs_results.dvs_portgroup_info is defined
 
+    # https://github.com/ansible-collections/community.vmware/pull/648
+    - name: The test for the dvportgroup with special characters
+      block:
+        - name: Create dvPortGroup with special characters
+          vmware_dvs_portgroup:
+            hostname: "{{ vcenter_hostname }}"
+            username: "{{ vcenter_username }}"
+            password: "{{ vcenter_password }}"
+            validate_certs: false
+            switch_name: "{{ dvswitch1 }}"
+            portgroup_name: 'dvportgroup\/%'
+            vlan_id: 1
+            num_ports: 8
+            portgroup_type: earlyBinding
+            state: present
+          register: create_dvportgroup_with_special_characters_result
+
+        - name: Make sure if the dvportgroup name with special characters is created
+          assert:
+            that:
+              - create_dvportgroup_with_special_characters_result.changed is sameas true
+
+        - <<: *dvs_info
+
+        - name: Make sure if the dvportgroup name with special characters exists
+          assert:
+            that:
+              - >-
+               dvs_results.dvs_portgroup_info.DVSwitch
+               | map(attribute='portgroup_name')
+               | select('==', 'dvportgroup\/%')
+               | list
+               | length == 1
+
+        - name: Delete dvPortGroup with special characters
+          vmware_dvs_portgroup:
+            hostname: "{{ vcenter_hostname }}"
+            username: "{{ vcenter_username }}"
+            password: "{{ vcenter_password }}"
+            validate_certs: false
+            switch_name: "{{ dvswitch1 }}"
+            portgroup_name: 'dvportgroup\/%'
+            vlan_id: 1
+            num_ports: 8
+            portgroup_type: earlyBinding
+            state: absent
+          register: delete_dvportgroup_with_special_characters_result
+
+        - name: Make sure if the dvportgroup is deleted
+          assert:
+            that:
+              - delete_dvportgroup_with_special_characters_result.changed is sameas true
+
 # Testcase 0002: Get portgroup info for a given dvswitch
 - name: get info for a given dvswitch
   vmware_dvs_portgroup_info:


### PR DESCRIPTION
Depends-On: #668

##### SUMMARY

In the following modules hadn't been decoded URL encoded dvs port group name.

* vmware_dvs_portgroup_find
* vmware_dvs_portgroup_info

This PR will fix to decode it.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/modules/vmware_dvs_portgroup_find.py  
plugins/modules/vmware_dvs_portgroup_info.py

##### ADDITIONAL INFORMATION

tested on vCenter 7.0
