### PR TITLE
New module: vmware_guest_storage_policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Name | Description
 [community.vmware.vmware_guest_serial_port](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_guest_serial_port_module.rst)|Manage serial ports on an existing VM
 [community.vmware.vmware_guest_snapshot](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_guest_snapshot_module.rst)|Manages virtual machines snapshots in vCenter
 [community.vmware.vmware_guest_snapshot_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_guest_snapshot_info_module.rst)|Gather info about virtual machine's snapshots in vCenter
+[community.vmware.vmware_guest_storage_policy](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_guest_storage_policy_module.rst)|Set VM Home and disk(s) storage policy profiles.
 [community.vmware.vmware_guest_tools_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_guest_tools_info_module.rst)|Gather info about VMware tools installed in VM
 [community.vmware.vmware_guest_tools_upgrade](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_guest_tools_upgrade_module.rst)|Module to upgrade VMTools
 [community.vmware.vmware_guest_tools_wait](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_guest_tools_wait_module.rst)|Wait for VMware tools to become available

--- a/docs/community.vmware.vmware_guest_storage_policy_module.rst
+++ b/docs/community.vmware.vmware_guest_storage_policy_module.rst
@@ -1,0 +1,416 @@
+.. _community.vmware.vmware_guest_storage_policy_module:
+
+
+********************************************
+community.vmware.vmware_guest_storage_policy
+********************************************
+
+**Set VM Home and disk(s) storage policy profiles.**
+
+
+Version added: 1.9.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- This module can be used to enforce storage policy profiles per disk and/or VM Home on a virtual machine.
+
+
+
+Requirements
+------------
+The below requirements are needed on the host that executes this module.
+
+- pyVmomi
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+            <th width="100%">Comments</th>
+        </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>disk</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=dictionary</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>A list of disks with storage profile policies to enforce.</div>
+                        <div>All values and parameters are case sensitive.</div>
+                        <div>At least one of <code>disk</code> and <code>vm_home</code> are required parameters.</div>
+                </td>
+            </tr>
+                                <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>policy</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Name of the storage profile policy to enforce for the disk.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>unit_number</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Disk Unit Number.</div>
+                        <div>Valid values range from 0 to 15.</div>
+                </td>
+            </tr>
+
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>folder</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Destination folder, absolute or relative path to find an existing guest.</div>
+                        <div>This is a required parameter if multiple VMs are found with same name.</div>
+                        <div>The folder should include the datacenter. ESX&#x27;s datacenter is ha-datacenter.</div>
+                        <div>Examples:</div>
+                        <div>folder: /ha-datacenter/vm</div>
+                        <div>folder: ha-datacenter/vm</div>
+                        <div>folder: /datacenter1/vm</div>
+                        <div>folder: datacenter1/vm</div>
+                        <div>folder: /datacenter1/vm/folder1</div>
+                        <div>folder: datacenter1/vm/folder1</div>
+                        <div>folder: /folder1/datacenter1/vm</div>
+                        <div>folder: folder1/datacenter1/vm</div>
+                        <div>folder: /folder1/datacenter1/vm/folder2</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>hostname</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The hostname or IP address of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_HOST</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>moid</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Managed Object ID of the instance to manage if known, this is a unique identifier only within a single vCenter instance.</div>
+                        <div>One of <code>name</code>, <code>uuid</code>, or <code>moid</code> are required to define the virtual machine.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Name of the virtual machine.</div>
+                        <div>One of <code>name</code>, <code>uuid</code>, or <code>moid</code> are required to define the virtual machine.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The password of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PASSWORD</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: pass, pwd</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">443</div>
+                </td>
+                <td>
+                        <div>The port number of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PORT</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>proxy_host</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Address of a proxy that will receive all HTTPS requests and relay them.</div>
+                        <div>The format is a hostname or a IP.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PROXY_HOST</code> will be used instead.</div>
+                        <div>This feature depends on a version of pyvmomi greater than v6.7.1.2018.12</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>proxy_port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Port of the HTTP proxy that will receive all HTTPS requests and relay them.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PROXY_PORT</code> will be used instead.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>username</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The username of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_USER</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: admin, user</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>uuid</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>UUID of the virtual machine.</div>
+                        <div>One of <code>name</code>, <code>uuid</code>, or <code>moid</code> are required to define the virtual machine.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>validate_certs</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>no</li>
+                                    <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Allows connection when SSL certificates are not valid. Set to <code>false</code> when certificates are not trusted.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_VALIDATE_CERTS</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                        <div>If set to <code>true</code>, please make sure Python &gt;= 2.7.9 is installed on the given machine.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>vm_home</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>A storage profile policy to set on VM Home.</div>
+                        <div>All values and parameters are case sensitive.</div>
+                        <div>At least one of <code>disk</code> or <code>vm_home</code> are required parameters.</div>
+                </td>
+            </tr>
+    </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - Tested on vSphere 6.0 and 6.5
+
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    - name: Enforce storepol1 policy for disk 0 and 1 using UUID
+      community.vmware.vmware_guest_storage_policy:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: no
+        uuid: cefd316c-fc19-45f3-a539-2cd03427a78d
+        disk:
+          - unit_number: 0
+            policy: storepol1
+          - unit_number: 1
+            policy: storepol1
+      delegate_to: localhost
+      register: policy_status
+
+    - name: Enforce storepol1 policy for VM Home using name
+      community.vmware.vmware_guest_storage_policy:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: no
+        name: hostname1
+        vm_home: storepol1
+      delegate_to: localhost
+
+
+
+Return Values
+-------------
+Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>changed_policies</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">dictionary</span>
+                    </div>
+                </td>
+                <td>always</td>
+                <td>
+                            <div>Dictionary containing the changed policies of disk (list of dictionaries) and vm_home.</div>
+                    <br/>
+                        <div style="font-size: smaller"><b>Sample:</b></div>
+                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{&#x27;disk&#x27;: [{&#x27;policy&#x27;: &#x27;storepol1&#x27;, &#x27;unit_number&#x27;: 0}], &#x27;vm_home&#x27;: &#x27;storepol1&#x27;}</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>msg</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>always</td>
+                <td>
+                            <div>Informational message on the job result.</div>
+                    <br/>
+                        <div style="font-size: smaller"><b>Sample:</b></div>
+                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">Policies successfully set.</div>
+                </td>
+            </tr>
+    </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Tyler Gates (@tgates81)

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -70,6 +70,7 @@ action_groups:
   - vmware_guest_serial_port
   - vmware_guest_snapshot
   - vmware_guest_snapshot_info
+  - vmware_guest_storage_policy
   - vmware_guest_tools_info
   - vmware_guest_tools_upgrade
   - vmware_guest_tools_wait

--- a/plugins/modules/vmware_guest_storage_policy.py
+++ b/plugins/modules/vmware_guest_storage_policy.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# Copyright (c) 2021, Tyler Gates <tgates81@gmail.com>
+# Copyright: (c) 2021, Tyler Gates <tgates81@gmail.com>
 #
 # Special thanks to:
 #   * Vadim Aleksandrov <valeksandrov@me.com>: Original author of python script
@@ -27,13 +27,13 @@ module: vmware_guest_storage_policy
 short_description: Set VM Home and disk(s) storage policy profiles.
 description:
     - This module can be used to enforce storage policy profiles per disk and/or VM Home on a virtual machine.
-version_added: 1.8.0
+version_added: 1.9.0
 author:
     - Tyler Gates (@tgates81)
 notes:
     - Tested on vSphere 6.0 and 6.5
 requirements:
-    - PyVmomi
+    - pyVmomi
 options:
    name:
      description:
@@ -160,11 +160,11 @@ except ImportError:
     PYVMOMI_IMP_ERR = traceback.format_exc()
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
-from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, vmware_argument_spec, wait_for_task
+from ansible_collections.community.vmware.plugins.module_utils.vmware import vmware_argument_spec, wait_for_task
 from ansible_collections.community.vmware.plugins.module_utils.vmware_spbm import SPBM
 
 
-class PyVmomiHelper(SPBM):
+class SPBM_helper(SPBM):
     def __init__(self, module):
         super().__init__(module)
 
@@ -411,9 +411,9 @@ def run_module():
         # so we should leave the input folder path unmodified
         module.params['folder'] = module.params['folder'].rstrip('/')
 
-    pyv = PyVmomiHelper(module)
+    spbm_h = SPBM_helper(module)
     # Check if the VM exists before continuing
-    vm = pyv.get_vm()
+    vm = spbm_h.get_vm()
     if not vm:
         module.fail_json(msg="Unable to find virtual machine `%s'" %
                          (module.params.get('name')
@@ -421,7 +421,7 @@ def run_module():
                           or module.params.get('moid')))
 
     try:
-        pyv.ensure_storage_policies(vm)
+        spbm_h.ensure_storage_policies(vm)
     except Exception as e:
         module.fail_json(msg="Failed to set storage policies for virtual"
                              "machine '%s' with exception: %s"

--- a/plugins/modules/vmware_guest_storage_policy.py
+++ b/plugins/modules/vmware_guest_storage_policy.py
@@ -20,9 +20,6 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
 
 DOCUMENTATION = r'''
 ---

--- a/plugins/modules/vmware_guest_storage_policy.py
+++ b/plugins/modules/vmware_guest_storage_policy.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 #
-# (c) 2021, Tyler Gates <tgates81@gmail.com>
+# Copyright (c) 2021, Tyler Gates <tgates81@gmail.com>
 #
 # Special thanks to:
 #   * Vadim Aleksandrov <valeksandrov@me.com>: Original author of python script
@@ -27,7 +27,7 @@ module: vmware_guest_storage_policy
 short_description: Set VM Home and disk(s) storage policy profiles.
 description:
     - This module can be used to enforce storage policy profiles per disk and/or VM Home on a virtual machine.
-version_added: 1.7.0
+version_added: 1.8.0
 author:
     - Tyler Gates (@tgates81)
 notes:
@@ -97,12 +97,13 @@ options:
          - Name of the storage profile policy to enforce for the disk.
          type: str
          required: True
-extends_documentation_fragment: vmware.documentation
+extends_documentation_fragment:
+- community.vmware.vmware.documentation
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 - name: Enforce storepol1 policy for disk 0 and 1 using UUID
-  vmware_guest_storage_policy:
+  community.vmware.vmware_guest_storage_policy:
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
@@ -117,7 +118,7 @@ EXAMPLES = '''
   register: policy_status
 
 - name: Enforce storepol1 policy for VM Home using name
-  vmware_guest_storage_policy:
+  community.vmware.vmware_guest_storage_policy:
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
@@ -127,7 +128,7 @@ EXAMPLES = '''
   delegate_to: localhost
 '''
 
-RETURN = """
+RETURN = r"""
 policy_status:
     description: Information about changed storage profile policies.
     returned: always
@@ -155,7 +156,6 @@ try:
 except ImportError:
     HAS_PYVMOMI = False
     PYVMOMI_IMP_ERR = traceback.format_exc()
-import re
 import ssl
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
@@ -438,9 +438,9 @@ def run_module():
     vm = pyv.get_vm()
     if not vm:
         module.fail_json(msg="Unable to find virtual machine `%s'" %
-                         (module.params.get('name') or
-                          module.params.get('uuid') or
-                          module.params.get('moid')))
+                         (module.params.get('name')
+                          or module.params.get('uuid')
+                          or module.params.get('moid')))
 
     try:
         pyv.ensure_storage_policies(vm)

--- a/plugins/modules/vmware_guest_storage_policy.py
+++ b/plugins/modules/vmware_guest_storage_policy.py
@@ -1,0 +1,461 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# (c) 2021, Tyler Gates <tgates81@gmail.com>
+#
+# Special thanks to:
+#   * Vadim Aleksandrov <valeksandrov@me.com>: Original author of python script
+#                                              `set_vm_storage_policy.py` from
+#                                              which most methods were derived.
+#   * William Lam (https://github.com/lamw): Author of script
+#                                            `list_vm_storage_policy.py` whose
+#                                            ideas were inspiration for
+#                                            Vadim's script.
+#   * Abhijeet Kasurde <akasurde@redhat.com>: Ansible modulization loosely
+#                                             modeled after
+#                                             `vmware_guest_disk.py'.
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+DOCUMENTATION = r'''
+---
+module: vmware_guest_storage_policy
+short_description: Set VM Home and disk(s) storage policy profiles.
+description:
+    - This module can be used to enforce storage policy profiles per disk and/or VM Home on a virtual machine.
+version_added: 1.7.0
+author:
+    - Tyler Gates (@tgates81)
+notes:
+    - Tested on vSphere 6.0 and 6.5
+requirements:
+    - PyVmomi
+options:
+   name:
+     description:
+     - Name of the virtual machine.
+     - One of C(name), C(uuid), or C(moid) are required to define the virtual machine.
+     type: str
+     required: False
+   uuid:
+     description:
+     - UUID of the virtual machine.
+     - One of C(name), C(uuid), or C(moid) are required to define the virtual machine.
+     type: str
+     required: False
+   moid:
+     description:
+     - Managed Object ID of the instance to manage if known, this is a unique identifier only within a single vCenter instance.
+     - One of C(name), C(uuid), or C(moid) are required to define the virtual machine.
+     type: str
+     required: False
+   folder:
+     description:
+     - Destination folder, absolute or relative path to find an existing guest.
+     - This is a required parameter if multiple VMs are found with same name.
+     - The folder should include the datacenter. ESX's datacenter is ha-datacenter.
+     - 'Examples:'
+     - '   folder: /ha-datacenter/vm'
+     - '   folder: ha-datacenter/vm'
+     - '   folder: /datacenter1/vm'
+     - '   folder: datacenter1/vm'
+     - '   folder: /datacenter1/vm/folder1'
+     - '   folder: datacenter1/vm/folder1'
+     - '   folder: /folder1/datacenter1/vm'
+     - '   folder: folder1/datacenter1/vm'
+     - '   folder: /folder1/datacenter1/vm/folder2'
+     type: str
+     required: False
+   vm_home:
+     description:
+     - A storage profile policy to set on VM Home.
+     - All values and parameters are case sensitive.
+     - At least one of C(disk) or C(vm_home) are required parameters.
+     required: False
+     type: str
+   disk:
+     description:
+     - A list of disks with storage profile policies to enforce.
+     - All values and parameters are case sensitive.
+     - At least one of C(disk) and C(vm_home) are required parameters.
+     required: False
+     type: list
+     elements: dict
+     suboptions:
+       unit_number:
+         description:
+         - Disk Unit Number.
+         - Valid values range from 0 to 15.
+         type: int
+         required: True
+       policy:
+         description:
+         - Name of the storage profile policy to enforce for the disk.
+         type: str
+         required: True
+extends_documentation_fragment: vmware.documentation
+'''
+
+EXAMPLES = '''
+- name: Enforce storepol1 policy for disk 0 and 1 using UUID
+  vmware_guest_storage_policy:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: no
+    uuid: cefd316c-fc19-45f3-a539-2cd03427a78d
+    disk:
+      - unit_number: 0
+        policy: storepol1
+      - unit_number: 1
+        policy: storepol1
+  delegate_to: localhost
+  register: policy_status
+
+- name: Enforce storepol1 policy for VM Home using name
+  vmware_guest_storage_policy:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: no
+    name: hostname1
+    vm_home: storepol1
+  delegate_to: localhost
+'''
+
+RETURN = """
+policy_status:
+    description: Information about changed storage profile policies.
+    returned: always
+    type: dict
+    sample: {
+        "msg": "",
+        "changed_policies": {
+            "disk": [
+                {
+                    "policy": "storepol1",
+                    "unit_number": 0
+                }
+            ],
+            "vm_home": "storepol1"
+        },
+    }
+"""
+
+import traceback
+from ansible.module_utils.basic import missing_required_lib
+PYVMOMI_IMP_ERR = None
+try:
+    from pyVmomi import pbm, vim, VmomiSupport, SoapStubAdapter
+    HAS_PYVMOMI = True
+except ImportError:
+    HAS_PYVMOMI = False
+    PYVMOMI_IMP_ERR = traceback.format_exc()
+import re
+import ssl
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
+from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, vmware_argument_spec, wait_for_task
+
+
+class PyVmomiHelper(PyVmomi):
+    def __init__(self, module):
+        super().__init__(module)
+
+    def PbmConnect(self, stubAdapter):
+        """
+        Connect to the VMware Storage Policy Server.
+
+        :param stubAdapter: The ServiceInstance stub adapter.
+        :type stubAdapter: SoapStubAdapter
+        :returns: A VMware Storage Policy Service content object.
+        :rtype: ServiceContent
+        """
+
+        sslContext = None
+        if not self.module.params.get('validate_certs'):
+            sslContext = ssl._create_unverified_context()
+
+        VmomiSupport.GetRequestContext()["vcSessionCookie"] = \
+            stubAdapter.cookie.split('"')[1]
+        hostname = stubAdapter.host.split(":")[0]
+        pbmStub = SoapStubAdapter(
+            host=hostname,
+            version="pbm.version.version1",
+            path="/pbm/sdk",
+            poolSize=0,
+            sslContext=sslContext)
+        pbmSi = pbm.ServiceInstance("ServiceInstance", pbmStub)
+        pbmContent = pbmSi.RetrieveContent()
+        return pbmContent
+
+    def SearchStorageProfileByName(self, profileManager, name):
+        """
+        Search VMware storage policy profile by name.
+
+        :param profileManager: A VMware Storage Policy Service manager object.
+        :type profileManager: pbm.profile.ProfileManager
+        :param name: A VMware Storage Policy profile name.
+        :type name: str
+        :returns: A VMware Storage Policy profile object.
+        :rtype: pbm.profile.Profile
+        """
+
+        profileIds = profileManager.PbmQueryProfile(
+            resourceType=pbm.profile.ResourceType(resourceType="STORAGE"),
+            profileCategory="REQUIREMENT"
+        )
+        if len(profileIds) > 0:
+            storageProfiles = profileManager.PbmRetrieveContent(
+                profileIds=profileIds)
+
+        for storageProfile in storageProfiles:
+            if storageProfile.name == name:
+                return storageProfile
+
+    def CheckAssociatedStorageProfile(self, profileManager, ref, name):
+        """
+        Check the associated storage policy profile.
+
+        :param profileManager: A VMware Storage Policy Service manager object.
+        :type profileManager: pbm.profile.ProfileManager
+        :param ref: A server object ref to a virtual machine, virtual disk,
+            or datastore.
+        :type ref: pbm.ServerObjectRef
+        :param name: A VMware storage policy profile name.
+        :type name: str
+        :returns: True if storage policy profile by name is associated to ref.
+        :rtype: bool
+        """
+
+        profileIds = profileManager.PbmQueryAssociatedProfile(ref)
+        if len(profileIds) > 0:
+            profiles = profileManager.PbmRetrieveContent(profileIds=profileIds)
+            for profile in profiles:
+                if profile.name == name:
+                    return True
+        return False
+
+    def SetVMHomeStorageProfile(self, vm, profile):
+        """
+        Set VM Home storage policy profile.
+
+        :param vm: A virtual machine object.
+        :type vm: VirtualMachine
+        :param profile: A VMware Storage Policy profile.
+        :type profile: pbm.profile.Profile
+        :returns: VMware task object.
+        :rtype: Task
+        """
+
+        spec = vim.vm.ConfigSpec()
+        profileSpec = vim.vm.DefinedProfileSpec()
+        profileSpec.profileId = profile.profileId.uniqueId
+        spec.vmProfile = [profileSpec]
+        return vm.ReconfigVM_Task(spec)
+
+    def GetVirtualDiskObj(self, vm, unit_number):
+        """
+        Get a virtual disk object.
+
+        :param vm: A virtual machine object.
+        :type vm: VirtualMachine
+        :param unit_number: virtual machine's disk unit number.
+        :type unit_number: int
+        :returns: VirtualDisk object if exists, else None.
+        :rtype: VirtualDisk, None
+        """
+        for device in vm.config.hardware.device:
+            if not isinstance(device, vim.vm.device.VirtualDisk):
+                continue
+            if int(device.unitNumber) == int(unit_number):
+                return device
+
+        return None
+
+    def SetVMDiskStorageProfile(self, vm, unit_number, profile):
+        """
+        Set VM's disk storage policy profile.
+
+        :param vm: A virtual machine object
+        :type vm: VirtualMachine
+        :param unit_number: virtual machine's disk unit number.
+        :type unit_number: int
+        :param profile: A VMware Storage Policy profile
+        :type profile: pbm.profile.Profile
+        :returns: VMware task object.
+        :rtype: Task
+        """
+
+        spec = vim.vm.ConfigSpec()
+        profileSpec = vim.vm.DefinedProfileSpec()
+        profileSpec.profileId = profile.profileId.uniqueId
+
+        deviceSpec = vim.vm.device.VirtualDeviceSpec()
+        deviceSpec.operation = vim.vm.device.VirtualDeviceSpec.Operation.edit
+        disk_obj = self.GetVirtualDiskObj(vm, unit_number)
+        deviceSpec.device = disk_obj
+        deviceSpec.profile = [profileSpec]
+        spec.deviceChange = [deviceSpec]
+        return vm.ReconfigVM_Task(spec)
+
+    def ensure_storage_policies(self, vm_obj):
+        """
+        Ensure VM storage profile policies.
+
+        :param vm_obj: VMware VM object.
+        :type vm_obj: VirtualMachine
+        :exits: self.module.exit_json on success, else self.module.fail_json.
+        """
+
+        disks = self.module.params.get('disk')
+        vm_home = self.module.params.get('vm_home')
+        success_msg = "Policies successfully set."
+        result = dict(
+            changed=False,
+            msg="",
+            changed_policies=dict(disk=[],
+                                  vm_home="",
+                                  ),
+        )
+
+        # Connect into vcenter and get the profile manager for the VM.
+        pbm_content = self.PbmConnect(vm_obj._stub)
+        pm = pbm_content.profileManager
+
+        #
+        # VM HOME
+        #
+        if vm_home:
+            policy = vm_home
+            pmObjectType = pbm.ServerObjectRef.ObjectType("virtualMachine")
+            pmRef = pbm.ServerObjectRef(key=vm_obj._moId,
+                                        objectType=pmObjectType)
+            pol_obj = self.SearchStorageProfileByName(pm, policy)
+
+            if not pol_obj:
+                self.module.fail_json(msg="Unable to find storage policy `%s' "
+                                          "for vm_home" % policy)
+
+            if not self.CheckAssociatedStorageProfile(pm, pmRef, policy):
+                # Existing policy is different than requested. Set, wait for
+                # task success, and exit.
+                if not self.module.check_mode:
+                    task = self.SetVMHomeStorageProfile(vm_obj, pol_obj)
+                    wait_for_task(task)  # will raise an Exception on failure
+                result['changed'] = True
+                result['changed_policies']['vm_home'] = policy
+
+        #
+        # DISKS
+        #
+        if disks is None:
+            disks = list()
+        # Check the requested disks[] information is sane or fail by looking up
+        # and storing the object(s) in a new dict.
+        disks_objs = dict()  # {unit_number: {disk: <obj>, policy: <obj>}}
+        for disk in disks:
+            policy = str(disk['policy'])
+            unit_number = int(disk['unit_number'])
+            disk_obj = self.GetVirtualDiskObj(vm_obj, unit_number)
+            pol_obj = self.SearchStorageProfileByName(pm, policy)
+            if not (disk_obj or policy):
+                self.module.fail_json(msg="Unable to find storage policy `%s' "
+                                          "for disk %s" % (policy, disk))
+            disks_objs[unit_number] = dict(disk=disk_obj, policy=pol_obj)
+
+        # All requested profiles are valid. Iterate through each disk and set
+        # accordingly.
+        for disk in disks:
+            policy = str(disk['policy'])
+            unit_number = int(disk['unit_number'])
+            disk_obj = disks_objs[unit_number]['disk']
+            pol_obj = disks_objs[unit_number]['policy']
+            pmObjectType = pbm.ServerObjectRef.ObjectType("virtualDiskId")
+            pmRef = pbm.ServerObjectRef(key="%s:%s"
+                                            % (vm_obj._moId, disk_obj.key),
+                                        objectType=pmObjectType)
+
+            if not self.CheckAssociatedStorageProfile(pm, pmRef, policy):
+                # Existing policy is different than requested. Set, wait for
+                # task success, and exit.
+                if not self.module.check_mode:
+                    task = self.SetVMDiskStorageProfile(vm_obj, unit_number,
+                                                        pol_obj)
+                    wait_for_task(task)
+                result['changed'] = True
+                result['changed_policies']['disk'].append(disk)
+
+        #
+        # END
+        #
+        # Check our results and exit.
+        if result['changed']:
+            result['msg'] = success_msg
+        self.module.exit_json(**result)
+
+
+def run_module():
+    argument_spec = vmware_argument_spec()
+    argument_spec.update(
+        name=dict(type='str'),
+        uuid=dict(type='str'),
+        moid=dict(type='str'),
+        folder=dict(type='str'),
+        disk=dict(type='list',
+                  required=False,
+                  elements='dict',
+                  options=dict(
+                       unit_number=dict(type='int', required=True),
+                       policy=dict(type='str', required=True)
+                  )),
+        vm_home=dict(type='str'),
+    )
+    module = AnsibleModule(
+        supports_check_mode=True,
+        argument_spec=argument_spec,
+        required_one_of=[
+            ['name', 'uuid', 'moid'],
+            ['disk', 'vm_home'],
+        ],
+    )
+
+    if not HAS_PYVMOMI:
+        module.fail_json(msg=missing_required_lib("pyVmomi"),
+                         exception=PYVMOMI_IMP_ERR)
+
+    if module.params['folder']:
+        # FindByInventoryPath() does not require an absolute path
+        # so we should leave the input folder path unmodified
+        module.params['folder'] = module.params['folder'].rstrip('/')
+
+    pyv = PyVmomiHelper(module)
+    # Check if the VM exists before continuing
+    vm = pyv.get_vm()
+    if not vm:
+        module.fail_json(msg="Unable to find virtual machine `%s'" %
+                         (module.params.get('name') or
+                          module.params.get('uuid') or
+                          module.params.get('moid')))
+
+    try:
+        pyv.ensure_storage_policies(vm)
+    except Exception as e:
+        module.fail_json(msg="Failed to set storage policies for virtual"
+                             "machine '%s' with exception: %s"
+                             % (vm.name, to_native(e)))
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/vmware_guest_storage_policy.py
+++ b/plugins/modules/vmware_guest_storage_policy.py
@@ -338,8 +338,11 @@ class PyVmomiHelper(SPBM):
             unit_number = int(disk['unit_number'])
             disk_obj = self.GetVirtualDiskObj(vm_obj, unit_number)
             pol_obj = self.SearchStorageProfileByName(pm, policy)
-            if not (disk_obj or policy):
-                result['msg'] = "Unable to find storage policy `%s' for disk %s" % (policy, disk)
+            if not pol_obj:
+                result['msg'] = "Unable to find storage policy `%s' for disk %s." % (policy, disk)
+                self.module.fail_json(**result)
+            if not disk_obj:
+                result['msg'] = "Unable to find disk for unit_number `%s'. 7 will be reserved for SCSI adapters." % unit_number
                 self.module.fail_json(**result)
             disks_objs[unit_number] = dict(disk=disk_obj, policy=pol_obj)
 

--- a/tests/integration/targets/vmware_guest_storage_policy/aliases
+++ b/tests/integration/targets/vmware_guest_storage_policy/aliases
@@ -1,0 +1,3 @@
+cloud/vcenter
+needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_guest_storage_policy/tasks/main.yml
+++ b/tests/integration/targets/vmware_guest_storage_policy/tasks/main.yml
@@ -15,6 +15,7 @@
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
+        validate_certs: false
       register: existing_profiles
 
     - name: "Setup: Create category"

--- a/tests/integration/targets/vmware_guest_storage_policy/tasks/main.yml
+++ b/tests/integration/targets/vmware_guest_storage_policy/tasks/main.yml
@@ -115,7 +115,6 @@
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
-        datacenter: "{{ dc1 }}"
         validate_certs: false
         name: "{{ virtual_machines[0].name }}"
         disk:

--- a/tests/integration/targets/vmware_guest_storage_policy/tasks/main.yml
+++ b/tests/integration/targets/vmware_guest_storage_policy/tasks/main.yml
@@ -108,7 +108,7 @@
     - name: "003: assert that changed_policies.vm_home is not set"
       assert:
         that:
-          - vm_home_sp.changed_policies.vm_home == ""
+          - vm_home_sp_idp.changed_policies.vm_home == ""
 
     - name: "004: Assign storage policy to disk unit {{ unit_number }} check_mode test"
       vmware_guest_storage_policy: &disk_args

--- a/tests/integration/targets/vmware_guest_storage_policy/tasks/main.yml
+++ b/tests/integration/targets/vmware_guest_storage_policy/tasks/main.yml
@@ -167,14 +167,23 @@
           - disk_sp_idp.changed_policies.disk == []
 
   always:
-    - name: "Cleanup: Rollback storage policy profile"
-      vmware_vm_storage_policy:
+    - name: "007: Cleanup: Rollback storage policy profile"
+      vmware_guest_storage_policy:
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
         validate_certs: false
-        name: "{{ existing_profiles[0].name }}"
-        state: "present"
+        name: "{{ virtual_machines[0].name }}"
+        vm_home: "{{ existing_profiles.spbm_profiles[0].name }}"
+        disk:
+          - unit_number: "{{ unit_number }}"
+            policy: "{{ existing_profiles.spbm_profiles[0].name }}"
+      register: rollback_storage_policy
+
+    - name: "007: assert that changes were made"
+      assert:
+        that:
+          - rollback_storage_policy is changed
 
     - name: "Cleanup: Delete Tag"
       vmware_tag:

--- a/tests/integration/targets/vmware_guest_storage_policy/tasks/main.yml
+++ b/tests/integration/targets/vmware_guest_storage_policy/tasks/main.yml
@@ -1,0 +1,213 @@
+# Test code for the vmware_guest_storage_policy module.
+# Copyright: (c) 2020, @tgates81 <tgates81@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- when: vcsim is not defined
+  block:
+    - import_role:
+        name: prepare_vmware_tests
+      vars:
+        setup_attach_host: true
+        setup_virtualmachines: true
+
+    - name: "Setup: find existing storage profile(s) for later rollback"
+      vmware_vm_storage_policy_info:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+      register: existing_profiles
+
+    - name: "Setup: Create category"
+      vmware_category:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        category_name: "{{ category }}"
+        category_cardinality: "multiple"
+        state: "present"
+      register: category_create
+
+    - name: "Setup: Set category id"
+      set_fact:
+        category_id: "{{ category_create['category_results']['category_id'] }}"
+
+    - name: "Setup: Create tag"
+      vmware_tag:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        tag_name: "{{ tag }}"
+        category_id: "{{ category_id }}"
+        state: "present"
+      register: tag_create
+
+    - name: "Setup: Create vSphere tag-based storage policy: {{ storage_policy }}"
+      vmware_vm_storage_policy:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        name: "{{ storage_policy }}"
+        description: "test storage policy for vmware_guest_storage_policy"
+        tag_category: "{{ category }}"
+        tag_name: "{{ tag }}"
+        tag_affinity: true
+        state: "present"
+      register: new_sp
+
+    - name: "001: Assign storage policy to VM check_mode test"
+      vmware_guest_storage_policy: &vm_home_args
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        datacenter: "{{ dc1 }}"
+        validate_certs: false
+        name: "{{ virtual_machines[0].name }}"
+        vm_home: "{{ storage_policy }}"
+      register: vm_home_sp_cm
+      check_mode: true
+
+    - name: "001: assert that changes were made"
+      assert:
+        that:
+          - vm_home_sp_cm is changed
+
+    - name: "001: assert that changed_policies.vm_home is properly set"
+      assert:
+        that:
+          - vm_home_sp_cm.changed_policies.vm_home == storage_policy
+
+    - name: "002: Assign storage policy to VM"
+      vmware_guest_storage_policy:
+        <<: *vm_home_args
+      register: vm_home_sp
+
+    - name: "002: assert that changes were made"
+      assert:
+        that:
+          - vm_home_sp is changed
+
+    - name: "002: assert that changed_policies.vm_home is properly set"
+      assert:
+        that:
+          - vm_home_sp.changed_policies.vm_home == storage_policy
+
+
+    - name: "003: Assign storage policy to VM idempotence test"
+      vmware_guest_storage_policy:
+        <<: *vm_home_args
+      register: vm_home_sp_idp
+
+    - name: "003: assert that changes were not made"
+      assert:
+        that:
+          - vm_home_sp_idp is not changed
+
+    - name: "003: assert that changed_policies.vm_home is not set"
+      assert:
+        that:
+          - vm_home_sp.changed_policies.vm_home == ""
+
+    - name: "004: Assign storage policy to disk unit {{ unit_number }} check_mode test"
+      vmware_guest_storage_policy: &disk_args
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        datacenter: "{{ dc1 }}"
+        validate_certs: false
+        name: "{{ virtual_machines[0].name }}"
+        disk:
+          - unit_number: "{{ unit_number }}"
+            policy: "{{ storage_policy }}"
+      register: disk_sp_cm
+      check_mode: true
+
+    - name: "004: assert that changes were made"
+      assert:
+        that:
+          - disk_sp_cm is changed
+
+    - name: "004: assert that changed_policies.disk is properly set"
+      assert:
+        that:
+          - disk_sp_cm.changed_policies.disk[0].unit_number == unit_number
+          - disk_sp_cm.changed_policies.disk[0].policy == storage_policy
+
+    - name: "005: Assign storage policy to disk unit {{ unit_number }}"
+      vmware_guest_storage_policy:
+        <<: *disk_args
+      register: disk_sp
+
+    - name: "005: assert that changes were made"
+      assert:
+        that:
+          - disk_sp is changed
+
+    - name: "005: assert that changed_policies.disk is properly set"
+      assert:
+        that:
+          - disk_sp.changed_policies.disk[0].unit_number == unit_number
+          - disk_sp.changed_policies.disk[0].policy == storage_policy
+
+    - name: "006: Assign storage policy to disk unit {{ unit_number }} idempotence test"
+      vmware_guest_storage_policy:
+        <<: *disk_args
+      register: disk_sp_idp
+
+    - name: "006: assert that changes were not made"
+      assert:
+        that:
+          - disk_sp_idp is not changed
+
+    - name: "006: assert that changed_policies.disk is not set"
+      assert:
+        that:
+          - disk_sp_idp.changed_policies.disk == []
+
+  always:
+    - name: "Cleanup: Rollback storage policy profile"
+      vmware_vm_storage_policy:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        name: "{{ existing_profiles[0].name }}"
+        state: "present"
+
+    - name: "Cleanup: Delete Tag"
+      vmware_tag:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        tag_name: "{{ tag }}"
+        state: "absent"
+      register: delete_tag
+
+    - name: "Cleanup: Delete Category"
+      vmware_category:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        category_name: "{{ category }}"
+        state: "absent"
+      register: delete_category
+
+    - name: "Cleanup: Remove storage policy"
+      vmware_vm_storage_policy:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        name: "{{ storage_policy }}"
+        state: "absent"
+      register: policy_delete
+
+  vars:
+    storage_policy: "vm_guest_storage_profile_policy001"
+    category: "vm_guest_storage_profile_cat001"
+    tag: "vm_guest_storage_profile_tag001"
+    unit_number: 0

--- a/tests/integration/targets/vmware_guest_storage_policy/tasks/main.yml
+++ b/tests/integration/targets/vmware_guest_storage_policy/tasks/main.yml
@@ -63,7 +63,6 @@
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
-        datacenter: "{{ dc1 }}"
         validate_certs: false
         name: "{{ virtual_machines[0].name }}"
         vm_home: "{{ storage_policy }}"

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -186,6 +186,8 @@ plugins/modules/vmware_guest_snapshot_info.py compile-2.6!skip
 plugins/modules/vmware_guest_snapshot_info.py import-2.6!skip
 plugins/modules/vmware_guest_snapshot.py compile-2.6!skip
 plugins/modules/vmware_guest_snapshot.py import-2.6!skip
+plugins/modules/vmware_guest_storage_policy.py compile-2.6!skip
+plugins/modules/vmware_guest_storage_policy.py import-2.6!skip
 plugins/modules/vmware_guest_tools_info.py compile-2.6!skip
 plugins/modules/vmware_guest_tools_info.py import-2.6!skip
 plugins/modules/vmware_guest_tools_upgrade.py compile-2.6!skip

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -196,6 +196,8 @@ plugins/modules/vmware_guest_snapshot_info.py compile-2.6!skip
 plugins/modules/vmware_guest_snapshot_info.py import-2.6!skip
 plugins/modules/vmware_guest_snapshot.py compile-2.6!skip
 plugins/modules/vmware_guest_snapshot.py import-2.6!skip
+plugins/modules/vmware_guest_storage_policy.py compile-2.6!skip
+plugins/modules/vmware_guest_storage_policy.py import-2.6!skip
 plugins/modules/vmware_guest_tools_info.py compile-2.6!skip
 plugins/modules/vmware_guest_tools_info.py import-2.6!skip
 plugins/modules/vmware_guest_tools_upgrade.py compile-2.6!skip

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -211,6 +211,8 @@ plugins/modules/vmware_guest_snapshot_info.py compile-2.6!skip
 plugins/modules/vmware_guest_snapshot_info.py import-2.6!skip
 plugins/modules/vmware_guest_snapshot.py compile-2.6!skip
 plugins/modules/vmware_guest_snapshot.py import-2.6!skip
+plugins/modules/vmware_guest_storage_policy.py compile-2.6!skip
+plugins/modules/vmware_guest_storage_policy.py import-2.6!skip
 plugins/modules/vmware_guest_tools_info.py compile-2.6!skip
 plugins/modules/vmware_guest_tools_info.py import-2.6!skip
 plugins/modules/vmware_guest_tools_upgrade.py compile-2.6!skip


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/community.vmware/pull/668

##### SUMMARY
New module submission
vmware_guest_storage_policy: Set VM Home and disk(s) storage policy profiles.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
vmware_guest_storage_policy: Set VM Home and disk(s) storage policy profiles.

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
- name: Enforce storepol1 policy for disk 0 and 1 using UUID
  vmware_guest_storage_policy:
    hostname: "{{ vcenter_hostname }}"
    username: "{{ vcenter_username }}"
    password: "{{ vcenter_password }}"
    validate_certs: no
    uuid: cefd316c-fc19-45f3-a539-2cd03427a78d
    disk:
      - unit_number: 0
        policy: storepol1
      - unit_number: 1
        policy: storepol1
  delegate_to: localhost
  register: policy_status

- name: Enforce storepol1 policy for VM Home using name
  vmware_guest_storage_policy:
    hostname: "{{ vcenter_hostname }}"
    username: "{{ vcenter_username }}"
    password: "{{ vcenter_password }}"
    validate_certs: no
    name: hostname1
    vm_home: storepol1
  delegate_to: localhost


RETURN VALUES:
- policy_status
        Information about changed storage profile policies.

        returned: always
        sample:
          changed_policies:
            disk:
            - policy: storepol1
              unit_number: 0
            vm_home: storepol1
          msg: ''
        
        type: dict
```
