### PR TITLE
vmware_vm_inventory/test: avoid shellcheck error

### DIFF
--- a/tests/integration/targets/vmware_vm_inventory/runme.sh
+++ b/tests/integration/targets/vmware_vm_inventory/runme.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# shellcheck disable=SC2086,SC2048
 set -eux
 export ANSIBLE_CONFIG=ansible.cfg
 ansible-playbook prepare_environment.yml $*


### PR DESCRIPTION
Ignore the two shellcheck warning in:
tests/integration/targets/vmware_vm_inventory/runme.sh