### PR TITLE
Enable vmComponentProtecting for APD/PDL response

### DIFF
--- a/changelogs/fragments/676_vmware_cluster_ha.yml
+++ b/changelogs/fragments/676_vmware_cluster_ha.yml
@@ -1,0 +1,2 @@
+bugfixes: 
+- vmware_cluster_ha - fix enabling APD or PDL response (https://github.com/ansible-collections/community.vmware/issues/676).

--- a/plugins/modules/vmware_cluster_ha.py
+++ b/plugins/modules/vmware_cluster_ha.py
@@ -395,6 +395,10 @@ class VMwareCluster(PyVmomi):
                     das_vm_config.vmComponentProtectionSettings = vim.cluster.VmComponentProtectionSettings()
                     das_vm_config.vmComponentProtectionSettings.vmStorageProtectionForAPD = self.params.get('apd_response')
                     das_vm_config.vmComponentProtectionSettings.vmStorageProtectionForPDL = self.params.get('pdl_response')
+                    if (self.params['apd_response'] != "disabled" or self.params['pdl_response'] != "disabled"):
+                        cluster_config_spec.dasConfig.vmComponentProtecting = 'enabled'
+                    else:
+                        cluster_config_spec.dasConfig.vmComponentProtecting = 'disabled'
 
                     cluster_config_spec.dasConfig.defaultVmSettings = das_vm_config
 


### PR DESCRIPTION
##### SUMMARY
There is a bug configuring APD or PDL response on the cluster level.

Fixes #676 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_cluster_ha
