### PR TITLE
Correctly return VSAN status

### DIFF
--- a/changelogs/fragments/673-vmware_cluster_info.yml
+++ b/changelogs/fragments/673-vmware_cluster_info.yml
@@ -1,0 +1,2 @@
+bugfixes: 
+- vmware_cluster_info - return VSAN status correctly (https://github.com/ansible-collections/community.vmware/issues/673).

--- a/plugins/modules/vmware_cluster_info.py
+++ b/plugins/modules/vmware_cluster_info.py
@@ -280,8 +280,8 @@ class VmwreClusterInfoManager(PyVmomi):
                 drs_config = cluster.configurationEx.drsConfig
 
                 # VSAN
-                if hasattr(cluster.configurationEx, 'vsanConfig'):
-                    vsan_config = cluster.configurationEx.vsanConfig
+                if hasattr(cluster.configurationEx, 'vsanConfigInfo'):
+                    vsan_config = cluster.configurationEx.vsanConfigInfo
                     enabled_vsan = vsan_config.enabled,
                     vsan_auto_claim_storage = vsan_config.defaultConfig.autoClaimStorage,
 


### PR DESCRIPTION
##### SUMMARY
vmware_cluster_info doesn't return VSAN status correctly.

Fixes #673

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_cluster_info