### PR TITLE
vmware_vm_storage_policy: Fix an issue that a pyvmomi SOAP error message displayed

### DIFF
--- a/changelogs/fragments/682-vmware_vm_storage_policy.yml
+++ b/changelogs/fragments/682-vmware_vm_storage_policy.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_vm_storage_policy - fixed an issue that an error for pyvmomi(SDK) occurred when a tag or category doesn't exist (https://github.com/ansible-collections/community.vmware/pull/682).

--- a/tests/integration/targets/vmware_vm_storage_policy/tasks/main.yml
+++ b/tests/integration/targets/vmware_vm_storage_policy/tasks/main.yml
@@ -88,6 +88,50 @@
       that:
         - not policy_delete.changed
 
+  # The tests are the failure test for issue 677.
+  # https://github.com/ansible-collections/community.vmware/issues/677
+  - name: The failure test when tag_category not exists
+    community.vmware.vmware_vm_storage_policy:
+      hostname: '{{ vcenter_hostname }}'
+      username: '{{ vcenter_username }}'
+      password: '{{ vcenter_password }}'
+      validate_certs: false
+      name: "storage policy for issue 667"
+      description: "issue667"
+      tag_category: "issue667"
+      tag_name: "{{ tag_one }}"
+      tag_affinity: true
+      state: "present"
+    ignore_errors: true
+    register: policy_failure_test1
+
+  - name: Make sure if the task failed and an error message showed including tag_category name
+    assert:
+      that:
+        - policy_failure_test1.failed is true
+        - "'issue667 is not found in vCenter Server tag categories' in policy_failure_test1.msg"
+
+  - name: The failure test when tag_name not exists
+    community.vmware.vmware_vm_storage_policy:
+      hostname: '{{ vcenter_hostname }}'
+      username: '{{ vcenter_username }}'
+      password: '{{ vcenter_password }}'
+      validate_certs: false
+      name: "storage policy for issue 667"
+      description: "issue667"
+      tag_category: "{{ cat_one }}"
+      tag_name: "issue667"
+      tag_affinity: true
+      state: "present"
+    ignore_errors: true
+    register: policy_failure_test2
+
+  - name: Make sure if the task failed and an error message showed including tag_name name
+    assert:
+      that:
+        - policy_failure_test2.failed is true
+        - "'issue667 is not found in vCenter Server tags' in policy_failure_test2.msg"
+
   always:
 
   - name: Delete Tags

--- a/tests/integration/targets/vmware_vm_storage_policy/tasks/main.yml
+++ b/tests/integration/targets/vmware_vm_storage_policy/tasks/main.yml
@@ -105,10 +105,10 @@
     ignore_errors: true
     register: policy_failure_test1
 
-  - name: Make sure if the task failed and an error message showed including tag_category name
+  - name: Make sure if the task failed and an error message displayed including tag_category name
     assert:
       that:
-        - policy_failure_test1.failed is true
+        - policy_failure_test1.failed is sameas true
         - "'issue667 is not found in vCenter Server tag categories' in policy_failure_test1.msg"
 
   - name: The failure test when tag_name not exists
@@ -126,10 +126,10 @@
     ignore_errors: true
     register: policy_failure_test2
 
-  - name: Make sure if the task failed and an error message showed including tag_name name
+  - name: Make sure if the task failed and an error message displayed including tag_name name
     assert:
       that:
-        - policy_failure_test2.failed is true
+        - policy_failure_test2.failed is sameas true
         - "'issue667 is not found in vCenter Server tags' in policy_failure_test2.msg"
 
   always:


### PR DESCRIPTION
##### SUMMARY

The vmware_vm_storage_policy module has been displaying pyvmomi error when a tag or category doesn't exist.  
This PR will fix to be displayed a suitable error message, not pyvmomi error.

fixes: https://github.com/ansible-collections/community.vmware/issues/677

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

changelogs/fragments/682-vmware_vm_storage_policy.yml
plugins/modules/vmware_vm_storage_policy.py
tests/integration/targets/vmware_vm_storage_policy/tasks/main.yml

##### ADDITIONAL INFORMATION

tested on vCenter 7.0