### PR TITLE
vmware_recommended_datastore new module

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ Name | Description
 [community.vmware.vmware_portgroup](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_portgroup_module.rst)|Create a VMware portgroup
 [community.vmware.vmware_portgroup_facts](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_portgroup_facts_module.rst)|Gathers facts about an ESXi host's Port Group configuration
 [community.vmware.vmware_portgroup_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_portgroup_info_module.rst)|Gathers info about an ESXi host's Port Group configuration
+[community.vmware.vmware_recommended_datastore](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_recommended_datastore_module.rst)|Returns the recommended datastore from a SDRS-enabled datastore cluster
 [community.vmware.vmware_resource_pool](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_resource_pool_module.rst)|Add/remove resource pools to/from vCenter
 [community.vmware.vmware_resource_pool_facts](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_resource_pool_facts_module.rst)|Gathers facts about resource pool information
 [community.vmware.vmware_resource_pool_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_resource_pool_info_module.rst)|Gathers info about resource pool information

--- a/docs/community.vmware.vmware_recommended_datastore_module.rst
+++ b/docs/community.vmware.vmware_recommended_datastore_module.rst
@@ -1,0 +1,274 @@
+.. _community.vmware.vmware_recommended_datastore_module:
+
+
+*********************************************
+community.vmware.vmware_recommended_datastore
+*********************************************
+
+**Returns the recommended datastore from a SDRS-enabled datastore cluster**
+
+
+Version added: 1.11.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- This module provides the recommended datastore name from a datastore cluster only if the SDRS is enabled for the specified datastore cluster
+
+
+
+Requirements
+------------
+The below requirements are needed on the host that executes this module.
+
+- python >= 3
+- PyVmomi
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+            <th width="100%">Comments</th>
+        </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>datacenter</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Name of the datacenter.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>datastore_cluster</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Name of the datastore cluster.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>hostname</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The hostname or IP address of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_HOST</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The password of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PASSWORD</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: pass, pwd</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">443</div>
+                </td>
+                <td>
+                        <div>The port number of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PORT</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>proxy_host</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Address of a proxy that will receive all HTTPS requests and relay them.</div>
+                        <div>The format is a hostname or a IP.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PROXY_HOST</code> will be used instead.</div>
+                        <div>This feature depends on a version of pyvmomi greater than v6.7.1.2018.12</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>proxy_port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Port of the HTTP proxy that will receive all HTTPS requests and relay them.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PROXY_PORT</code> will be used instead.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>username</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The username of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_USER</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: admin, user</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>validate_certs</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>no</li>
+                                    <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Allows connection when SSL certificates are not valid. Set to <code>false</code> when certificates are not trusted.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_VALIDATE_CERTS</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                        <div>If set to <code>true</code>, please make sure Python &gt;= 2.7.9 is installed on the given machine.</div>
+                </td>
+            </tr>
+    </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - Tested on vSphere 6.7 and 7.0.2
+   - Supports Check mode.
+
+
+
+Examples
+--------
+
+.. code-block:: yaml
+
+    - name: Get recommended datastore from a Storage DRS-enabled datastore cluster
+      community.vmware.vmware_recommended_datastore:
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        validate_certs: no
+        datastore_cluster: '{{ datastore_cluster_name }}'
+        datacenter: '{{ datacenter }}'
+      register: recommended_ds
+
+
+
+Return Values
+-------------
+Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>recommended_datastore</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>always</td>
+                <td>
+                            <div>metadata about the recommended datastore</div>
+                    <br/>
+                        <div style="font-size: smaller"><b>Sample:</b></div>
+                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{&#x27;recommended_datastore&#x27;: &#x27;datastore-01&#x27;}</div>
+                </td>
+            </tr>
+    </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Unknown (@MalfuncEddie)
+- Alina Buzachis (@alinabuzachis)
+- Abhijeet Kasurde (@Akasurde)

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -124,6 +124,7 @@ action_groups:
   - vmware_object_role_permission
   - vmware_portgroup
   - vmware_portgroup_info
+  - vmware_recommended_datastore
   - vmware_resource_pool
   - vmware_resource_pool_info
   - vmware_tag

--- a/plugins/modules/vmware_recommended_datastore.py
+++ b/plugins/modules/vmware_recommended_datastore.py
@@ -4,129 +4,103 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+
 __metaclass__ = type
 
 
-DOCUMENTATION = r'''
+DOCUMENTATION = r"""
 ---
 module: vmware_recommended_datastore
 short_description: Returns the recommended datastore from a SDRS-enabled datastore cluster
 description:
-- This module provides the recommended datastores from a datastore cluster only if the SDRS is enabled for the specified datastore cluster
+- This module provides the recommended datastore name from a datastore cluster only if the SDRS is enabled for the specified datastore cluster
 author:
-- @MalfuncEddie - original code of Abhijeet Kasurde (@Akasurde)
+- Unknown (@MalfuncEddie)
+- Alina Buzachis (@alinabuzachis)
+- Abhijeet Kasurde (@Akasurde)
 notes:
-- Tested on vSphere 6.7
+- Tested on vSphere 6.7 and 7.0.2
+- Supports Check mode.
 requirements:
-- python >= 2.6
+- python >= 3
 - PyVmomi
 options:
-  datastore_cluster_name:
+  datacenter:
     description:
-    - Name of the datastore cluster
-    - This is required
+    - Name of the datacenter.
+    type: str
+    required: True
+  datastore_cluster:
+    description:
+    - Name of the datastore cluster.
     type: str
     required: True
 extends_documentation_fragment:
 - community.vmware.vmware.documentation
-'''
+version_added: '1.11.0'
+"""
 
 
-EXAMPLES = r'''
+EXAMPLES = r"""
 - name: Get recommended datastore from a Storage DRS-enabled datastore cluster
   community.vmware.vmware_recommended_datastore:
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
-    datastore_cluster_name: "{{ datastore_cluster_name }}"
-  delegate_to: localhost
+    validate_certs: no
+    datastore_cluster: '{{ datastore_cluster_name }}'
+    datacenter: '{{ datacenter }}'
   register: recommended_ds
-'''
+"""
 
 
-RETURN = r'''
-vmware_recommended_datastore:
+RETURN = r"""
+recommended_datastore:
   description: metadata about the recommended datastore
   returned: always
-  type: dict
+  type: str
   sample: {
-    'changed': False,
-    'recommended_datastore': 'datastorecluster-01',
-    'failed': False
+    'recommended_datastore': 'datastore-01'
   }
-'''
-
-try:
-    from pyVmomi import vim
-except ImportError:
-    pass
+"""
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, vmware_argument_spec, find_obj
+from ansible_collections.community.vmware.plugins.module_utils.vmware import (
+    PyVmomi,
+    vmware_argument_spec,
+)
 
 
 class VmwareDatastoreClusterInfo(PyVmomi):
     def __init__(self, module):
         super(VmwareDatastoreClusterInfo, self).__init__(module)
-        datastore_cluster_name = self.params.get('datastore_cluster')
-        datastore_cluster = find_obj(self.content, [vim.StoragePod], datastore_cluster_name)
-        datastore_name = self.get_recommended_datastore(datastore_cluster_obj=datastore_cluster)
-        result = dict(
-          changed=False,
-          recommended_datastore=datastore_name
+        self.module = module
+        self.params = module.params
+        datacenter_name = self.params.get("datacenter")
+        datacenter_obj = self.find_datacenter_by_name(datacenter_name)
+        if datacenter_obj is None:
+            self.module.fail_json(
+                msg="Unable to find datacenter with name %s" % datacenter_name
+            )
+        datastore_cluster_name = self.params.get("datastore_cluster")
+        datastore_cluster_obj = self.find_datastore_cluster_by_name(
+            datastore_cluster_name, datacenter=datacenter_obj
         )
+
+        datastore_name = self.get_recommended_datastore(
+            datastore_cluster_obj=datastore_cluster_obj
+        )
+        if not datastore_name:
+            datastore_name = ""
+        result = dict(changed=False, recommended_datastore=datastore_name)
         self.module.exit_json(**result)
-
-
-    def get_recommended_datastore(self, datastore_cluster_obj=None):
-        """
-        Function to return Storage DRS recommended datastore from datastore cluster
-        Args:
-            datastore_cluster_obj: datastore cluster managed object
-        Returns: Name of recommended datastore from the given datastore cluster
-        """
-
-        if datastore_cluster_obj is None:
-            return None
-
-        # Check if Datastore Cluster provided by user is SDRS ready
-        sdrs_status = datastore_cluster_obj.podStorageDrsEntry.storageDrsConfig.podConfig.enabled
-
-        if sdrs_status:
-            # We can get storage recommendation only if SDRS is enabled on given datastorage cluster
-            pod_sel_spec = vim.storageDrs.PodSelectionSpec()
-            pod_sel_spec.storagePod = datastore_cluster_obj
-            storage_spec = vim.storageDrs.StoragePlacementSpec()
-            storage_spec.podSelectionSpec = pod_sel_spec
-            storage_spec.type = 'create'
-            try:
-                rec = self.content.storageResourceManager.RecommendDatastores(storageSpec=storage_spec)
-                rec_action = rec.recommendations[0].action[0]
-                return rec_action.destination.name
-            except Exception:
-                # There is some error so we fall back to general workflow
-                pass
-
-        datastore = None
-        datastore_freespace = 0
-        for ds_elem in datastore_cluster_obj.childEntity:
-            if isinstance(ds_elem, vim.Datastore) and ds_elem.summary.freeSpace > datastore_freespace:
-                # If datastore field is provided, filter destination datastores
-                if not self.is_datastore_valid(datastore_obj=ds_elem):
-                    continue
-
-                datastore = ds_elem
-                datastore_freespace = ds_elem.summary.freeSpace
-
-        if datastore:
-            return datastore.name
-        return None
 
 
 def main():
     argument_spec = vmware_argument_spec()
     argument_spec.update(
-        datastore_cluster_name=dict(type='str', required=True)
+        datacenter=dict(type="str", required=True),
+        datastore_cluster=dict(type="str", required=True),
     )
     module = AnsibleModule(
         argument_spec=argument_spec,
@@ -136,5 +110,5 @@ def main():
     VmwareDatastoreClusterInfo(module)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/plugins/modules/vmware_recommended_datastore.py
+++ b/plugins/modules/vmware_recommended_datastore.py
@@ -1,0 +1,140 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2018, Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = r'''
+---
+module: vmware_recommended_datastore
+short_description: Returns the recommended datastore from a SDRS-enabled datastore cluster
+description:
+- This module provides the recommended datastores from a datastore cluster only if the SDRS is enabled for the specified datastore cluster
+author:
+- @MalfuncEddie - original code of Abhijeet Kasurde (@Akasurde)
+notes:
+- Tested on vSphere 6.7
+requirements:
+- python >= 2.6
+- PyVmomi
+options:
+  datastore_cluster_name:
+    description:
+    - Name of the datastore cluster
+    - This is required
+    type: str
+    required: True
+extends_documentation_fragment:
+- community.vmware.vmware.documentation
+'''
+
+
+EXAMPLES = r'''
+- name: Get recommended datastore from a Storage DRS-enabled datastore cluster
+  community.vmware.vmware_recommended_datastore:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    datastore_cluster_name: "{{ datastore_cluster_name }}"
+  delegate_to: localhost
+  register: recommended_ds
+'''
+
+
+RETURN = r'''
+vmware_recommended_datastore:
+  description: metadata about the recommended datastore
+  returned: always
+  type: dict
+  sample: {
+    'changed': False,
+    'recommended_datastore': 'datastorecluster-01',
+    'failed': False
+  }
+'''
+
+try:
+    from pyVmomi import vim
+except ImportError:
+    pass
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, vmware_argument_spec, find_obj
+
+
+class VmwareDatastoreClusterInfo(PyVmomi):
+    def __init__(self, module):
+        super(VmwareDatastoreClusterInfo, self).__init__(module)
+        datastore_cluster_name = self.params.get('datastore_cluster')
+        datastore_cluster = find_obj(self.content, [vim.StoragePod], datastore_cluster_name)
+        datastore_name = self.get_recommended_datastore(datastore_cluster_obj=datastore_cluster)
+        result = dict(
+          changed=False,
+          recommended_datastore=datastore_name
+        )
+        self.module.exit_json(**result)
+
+
+    def get_recommended_datastore(self, datastore_cluster_obj=None):
+        """
+        Function to return Storage DRS recommended datastore from datastore cluster
+        Args:
+            datastore_cluster_obj: datastore cluster managed object
+        Returns: Name of recommended datastore from the given datastore cluster
+        """
+
+        if datastore_cluster_obj is None:
+            return None
+
+        # Check if Datastore Cluster provided by user is SDRS ready
+        sdrs_status = datastore_cluster_obj.podStorageDrsEntry.storageDrsConfig.podConfig.enabled
+
+        if sdrs_status:
+            # We can get storage recommendation only if SDRS is enabled on given datastorage cluster
+            pod_sel_spec = vim.storageDrs.PodSelectionSpec()
+            pod_sel_spec.storagePod = datastore_cluster_obj
+            storage_spec = vim.storageDrs.StoragePlacementSpec()
+            storage_spec.podSelectionSpec = pod_sel_spec
+            storage_spec.type = 'create'
+            try:
+                rec = self.content.storageResourceManager.RecommendDatastores(storageSpec=storage_spec)
+                rec_action = rec.recommendations[0].action[0]
+                return rec_action.destination.name
+            except Exception:
+                # There is some error so we fall back to general workflow
+                pass
+
+        datastore = None
+        datastore_freespace = 0
+        for ds_elem in datastore_cluster_obj.childEntity:
+            if isinstance(ds_elem, vim.Datastore) and ds_elem.summary.freeSpace > datastore_freespace:
+                # If datastore field is provided, filter destination datastores
+                if not self.is_datastore_valid(datastore_obj=ds_elem):
+                    continue
+
+                datastore = ds_elem
+                datastore_freespace = ds_elem.summary.freeSpace
+
+        if datastore:
+            return datastore.name
+        return None
+
+
+def main():
+    argument_spec = vmware_argument_spec()
+    argument_spec.update(
+        datastore_cluster_name=dict(type='str', required=True)
+    )
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    VmwareDatastoreClusterInfo(module)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/vmware_recommended_datastore/aliases
+++ b/tests/integration/targets/vmware_recommended_datastore/aliases
@@ -1,0 +1,3 @@
+cloud/vcenter
+needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_recommended_datastore/tasks/main.yml
+++ b/tests/integration/targets/vmware_recommended_datastore/tasks/main.yml
@@ -1,0 +1,92 @@
+# Test code for the vmware_recommended_datastore module.
+# Copyright: (c) 2021, Abhijeet Kasurde <akasurde@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Set Datastore cluster name
+  set_fact:
+    dsc: "DSC1"
+
+- when: vcsim is not defined
+  block:
+  - import_role:
+      name: prepare_vmware_tests
+    vars:
+      setup_attach_host: true
+      setup_datastore: true
+
+  - name: Get list of info about datastores
+    vmware_datastore_info:
+      validate_certs: false
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      datacenter: "{{ dc1 }}"
+      gather_nfs_mount_info: true
+    register: datastore_info_0001
+
+  - name: Get datastore name for adding in datastore cluster
+    set_fact:
+      datastore_name: "{{ datastore_info_0001['datastores'][0]['name'] }}"
+
+  - name: Add a datastore cluster to datacenter
+    vmware_datastore_cluster:
+      hostname: '{{ vcenter_hostname }}'
+      username: '{{ vcenter_username }}'
+      password: '{{ vcenter_password }}'
+      validate_certs: false
+      datacenter_name: "{{ dc1 }}"
+      datastore_cluster_name: "{{ dsc }}"
+      enable_sdrs: true
+      state: present
+    register: add_dsc
+
+  - name: Check if datastore cluster is added successfully
+    assert:
+      that:
+       - add_dsc.changed
+
+  - name: Add a datastore in the given datastore cluster
+    vmware_datastore_cluster_manager:
+      hostname: '{{ vcenter_hostname }}'
+      username: '{{ vcenter_username }}'
+      password: '{{ vcenter_password }}'
+      validate_certs: false
+      datacenter_name: "{{ dc1 }}"
+      datastore_cluster_name: "{{ dsc }}"
+      datastores:
+      - "{{ datastore_name }}"
+    register: add_ds
+
+  - name: Check if datastore is added in datastore cluster
+    assert:
+      that:
+        - add_ds.changed
+
+  - name: Gather information about recommended datastore
+    vmware_recommended_datastore:
+      hostname: '{{ vcenter_hostname }}'
+      username: '{{ vcenter_username }}'
+      password: '{{ vcenter_password }}'
+      validate_certs: false
+      datacenter: "{{ dc1 }}"
+      datastore_cluster: DSC1
+    register: dsc_info
+
+  - name: Check if datastore information is returned
+    assert:
+      that:
+        - dsc_info.recommended_datastore is defined
+        - dsc_info.recommended_datastore == datastore_name
+
+  always:
+  - name: Delete a datastore cluster to datacenter
+    vmware_datastore_cluster:
+      hostname: '{{ vcenter_hostname }}'
+      username: '{{ vcenter_username }}'
+      password: '{{ vcenter_password }}'
+      validate_certs: false
+      datacenter_name: "{{ dc1 }}"
+      datastore_cluster_name: "{{ dsc }}"
+      state: absent
+    register: delete_dsc
+    ignore_errors: true

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -323,6 +323,8 @@ plugins/modules/vmware_portgroup_info.py compile-2.6!skip
 plugins/modules/vmware_portgroup_info.py import-2.6!skip
 plugins/modules/vmware_portgroup.py compile-2.6!skip
 plugins/modules/vmware_portgroup.py import-2.6!skip
+plugins/modules/vmware_recommended_datastore.py compile-2.6!skip
+plugins/modules/vmware_recommended_datastore.py import-2.6!skip
 plugins/modules/vmware_resource_pool_facts.py compile-2.6!skip
 plugins/modules/vmware_resource_pool_facts.py import-2.6!skip
 plugins/modules/vmware_resource_pool_info.py compile-2.6!skip

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -333,6 +333,8 @@ plugins/modules/vmware_portgroup_info.py compile-2.6!skip
 plugins/modules/vmware_portgroup_info.py import-2.6!skip
 plugins/modules/vmware_portgroup.py compile-2.6!skip
 plugins/modules/vmware_portgroup.py import-2.6!skip
+plugins/modules/vmware_recommended_datastore.py compile-2.6!skip
+plugins/modules/vmware_recommended_datastore.py import-2.6!skip
 plugins/modules/vmware_resource_pool_facts.py compile-2.6!skip
 plugins/modules/vmware_resource_pool_facts.py import-2.6!skip
 plugins/modules/vmware_resource_pool_info.py compile-2.6!skip

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -305,6 +305,8 @@ plugins/modules/vmware_portgroup_info.py compile-2.6!skip
 plugins/modules/vmware_portgroup_info.py import-2.6!skip
 plugins/modules/vmware_portgroup.py compile-2.6!skip
 plugins/modules/vmware_portgroup.py import-2.6!skip
+plugins/modules/vmware_recommended_datastore.py compile-2.6!skip
+plugins/modules/vmware_recommended_datastore.py import-2.6!skip
 plugins/modules/vmware_resource_pool_facts.py compile-2.6!skip
 plugins/modules/vmware_resource_pool_facts.py import-2.6!skip
 plugins/modules/vmware_resource_pool_info.py compile-2.6!skip

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -375,6 +375,8 @@ plugins/modules/vmware_portgroup_info.py compile-2.6!skip
 plugins/modules/vmware_portgroup_info.py import-2.6!skip
 plugins/modules/vmware_portgroup.py compile-2.6!skip
 plugins/modules/vmware_portgroup.py import-2.6!skip
+plugins/modules/vmware_recommended_datastore.py compile-2.6!skip
+plugins/modules/vmware_recommended_datastore.py import-2.6!skip
 plugins/modules/vmware_resource_pool_facts.py compile-2.6!skip
 plugins/modules/vmware_resource_pool_facts.py import-2.6!skip
 plugins/modules/vmware_resource_pool_facts.py validate-modules:deprecation-mismatch


### PR DESCRIPTION
##### SUMMARY
vmware_recommended_datastore: Returns the recommended datastore from a SDRS-enabled datastore cluster
- This module provides the recommended datastores from a datastore cluster only if the SDRS is enabled for the specified datastore cluster


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_recommended_datastore

