### PR TITLE
Add esxi_hostname support in vmware_deploy_ovf module

### DIFF
--- a/changelogs/fragments/670-vmware_deploy_ovf_and_vmware.yml
+++ b/changelogs/fragments/670-vmware_deploy_ovf_and_vmware.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - vmware_deploy_ovf - fixed an issue that deploy template in datacenter with more than one standalone hosts (https://github.com/ansible-collections/community.vmware/pull/670).
+  - vmware - add the default value of parameter resource_pool_name in the find_resource_pool_by_name function (https://github.com/ansible-collections/community.vmware/pull/670).

--- a/plugins/module_utils/vmware.py
+++ b/plugins/module_utils/vmware.py
@@ -1483,7 +1483,7 @@ class PyVmomi(object):
         return None
 
     # Resource pool
-    def find_resource_pool_by_name(self, resource_pool_name, folder=None):
+    def find_resource_pool_by_name(self, resource_pool_name='Resources', folder=None):
         """
         Get resource pool managed object by name
         Args:

--- a/plugins/modules/vmware_deploy_ovf.py
+++ b/plugins/modules/vmware_deploy_ovf.py
@@ -30,6 +30,16 @@ options:
     cluster:
         description:
         - Cluster to deploy to.
+        - This is a required parameter, if C(esxi_hostname) is not set and C(hostname) is set to the vCenter server.
+        - C(esxi_hostname) and C(cluster) are mutually exclusive parameters.
+        - This parameter is case sensitive.
+        type: str
+    esxi_hostname:
+        description:
+        - The ESXi hostname where the virtual machine will run.
+        - This is a required parameter, if C(cluster) is not set and C(hostname) is set to the vCenter server.
+        - C(esxi_hostname) and C(cluster) are mutually exclusive parameters.
+        - This parameter is case sensitive.
         type: str
     datastore:
         default: datastore1
@@ -151,6 +161,16 @@ EXAMPLES = r'''
     networks: "{u'VM Network':u'{{ ProvisioningNetworkLabel }}'}"
     power_on: no
     ovf: /absolute/path/to/template/mytemplate.ova
+  delegate_to: localhost
+
+- community.vmware.vmware_deploy_ovf:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    datacenter: Datacenter1
+    esxi_hostname: test-server
+    datastore: test-datastore
+    ovf: /path/to/ubuntu-16.04-amd64.ovf
   delegate_to: localhost
 '''
 
@@ -321,12 +341,31 @@ class VMwareDeployOvf(PyVmomi):
         self.entity = None
 
     def get_objects(self):
+        # Get datacenter firstly
         self.datacenter = self.find_datacenter_by_name(self.params['datacenter'])
-        if not self.datacenter:
-            self.module.fail_json(msg='%(datacenter)s could not be located' % self.params)
+        if self.datacenter is None:
+            self.module.fail_json(msg="Datacenter '%(datacenter)s' could not be located" % self.params)
+
+        # Get cluster in datacenter if cluster configured
+        if self.params['cluster']:
+            cluster = self.find_cluster_by_name(self.params['cluster'], datacenter_name=self.datacenter)
+            if cluster is None:
+                self.module.fail_json(msg="Unable to find cluster '%(cluster)s'" % self.params)
+            self.resource_pool = self.find_resource_pool_by_cluster(self.params['resource_pool'], cluster=cluster)
+        # Or get ESXi host in datacenter if ESXi host configured
+        elif self.params['esxi_hostname']:
+            host = self.find_hostsystem_by_name(self.params['esxi_hostname'])
+            if host is None:
+                self.module.fail_json(msg="Unable to find host '%(esxi_hostname)s'" % self.params)
+            self.resource_pool = self.find_resource_pool_by_name(self.params['resource_pool'], folder=host.parent)
+        else:
+            self.resource_pool = self.find_resource_pool_by_name(self.params['resource_pool'])
+
+        if not self.resource_pool:
+            self.module.fail_json(msg="Resource pool '%(resource_pool)s' could not be located" % self.params)
 
         self.datastore = None
-        datastore_cluster_obj = self.find_datastore_cluster_by_name(self.params['datastore'])
+        datastore_cluster_obj = self.find_datastore_cluster_by_name(self.params['datastore'], datacenter=self.datacenter)
         if datastore_cluster_obj:
             datastore = None
             datastore_freespace = 0
@@ -340,21 +379,10 @@ class VMwareDeployOvf(PyVmomi):
             if datastore:
                 self.datastore = datastore
         else:
-            self.datastore = self.find_datastore_by_name(self.params['datastore'], self.datacenter)
+            self.datastore = self.find_datastore_by_name(self.params['datastore'], datacenter_name=self.datacenter)
 
-        if not self.datastore:
-            self.module.fail_json(msg='%(datastore)s could not be located' % self.params)
-
-        if self.params['cluster']:
-            cluster = self.find_cluster_by_name(self.params['cluster'], datacenter_name=self.datacenter)
-            if cluster is None:
-                self.module.fail_json(msg="Unable to find cluster '%(cluster)s'" % self.params)
-            self.resource_pool = self.find_resource_pool_by_cluster(self.params['resource_pool'], cluster=cluster)
-        else:
-            self.resource_pool = self.find_resource_pool_by_name(self.params['resource_pool'])
-
-        if not self.resource_pool:
-            self.module.fail_json(msg='%(resource_pool)s could not be located' % self.params)
+        if self.datastore is None:
+            self.module.fail_json(msg="Datastore '%(datastore)s' could not be located on specified ESXi host or datacenter" % self.params)
 
         for key, value in self.params['networks'].items():
             network = find_network_by_name(self.content, value, datacenter_name=self.datacenter)
@@ -628,6 +656,9 @@ def main():
         'cluster': {
             'default': None,
         },
+        'esxi_hostname': {
+            'default': None,
+        },
         'deployment_option': {
             'default': None,
         },
@@ -693,6 +724,9 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
+        mutually_exclusive=[
+            ['cluster', 'esxi_hostname'],
+        ],
     )
 
     deploy_ovf = VMwareDeployOvf(module)

--- a/plugins/modules/vmware_deploy_ovf.py
+++ b/plugins/modules/vmware_deploy_ovf.py
@@ -40,6 +40,7 @@ options:
         - This is a required parameter, if C(cluster) is not set and C(hostname) is set to the vCenter server.
         - C(esxi_hostname) and C(cluster) are mutually exclusive parameters.
         - This parameter is case sensitive.
+        version_added: '1.9.0'
         type: str
     datastore:
         default: datastore1


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #670

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_deploy_ovf

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
If more than one ESXi hosts in the same datacenter as standalone host, need to specify the target ESXi host to deploy the template, or it will fail with datastore not supported error.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
- hosts: localhost
  tasks:
    - name: Deploy VM from ovf template
      vmware_deploy_ovf:
        hostname: "192.18.228.10"
        username: "Administrator@vsphere.local"
        password: "Admin!23"
        validate_certs: "{{ valid_cert | default(False) }}"
        datacenter: "DC"
        # cluster: cls
        esxi_hostname: test-server.test.com
        datastore: "datastore2"
        networks: "{{ ovf_networks | default({'VM Network': 'VM Network'}) }}"
        ovf: "./test.ova"
        name: test_ovf_deploy
        allow_duplicates: False
        disk_provisioning: "thin"
        power_on: False
        wait_for_ip_address: False
      register: ovf_deploy
    - debug: var=ovf_deploy
```
