### PR TITLE
vmware_content_deploy_ovf_template does not respect folder path

### DIFF
--- a/plugins/module_utils/vmware_rest_client.py
+++ b/plugins/module_utils/vmware_rest_client.py
@@ -341,7 +341,9 @@ class VmwareRestClient(object):
                     if part == datacenter_name or part == "":
                         continue
                     else:
-                        filter_spec = Folder.FilterSpec(type=Folder.Type.VIRTUAL_MACHINE,names=set([part]),datacenters=set([datacenter]))
+                        filter_spec = Folder.FilterSpec(type=Folder.Type.VIRTUAL_MACHINE,
+                                                        names=set([part]),
+                                                        datacenters=set([datacenter]))
                     p_folder_obj = self.api_client.vcenter.Folder.list(filter_spec)
                     if not p_folder_obj:
                         self.module.fail_json(msg="Could not find folder %s" % part)

--- a/plugins/module_utils/vmware_rest_client.py
+++ b/plugins/module_utils/vmware_rest_client.py
@@ -338,15 +338,14 @@ class VmwareRestClient(object):
             p_folder_obj = None
             for part in folder_name:
                 if p_folder_obj is None:
-                    if part == datacenter_name or part == "":
+                    if part in (datacenter_name, ""):
                         continue
-                    else:
-                        filter_spec = Folder.FilterSpec(type=Folder.Type.VIRTUAL_MACHINE,
-                                                        names=set([part]),
-                                                        datacenters=set([datacenter]))
+                    filter_spec = Folder.FilterSpec(type=Folder.Type.VIRTUAL_MACHINE,
+                                                    names=set([part]),
+                                                    datacenters=set([datacenter]))
                     p_folder_obj = self.api_client.vcenter.Folder.list(filter_spec)
                     if not p_folder_obj:
-                        self.module.fail_json(msg="Could not find folder %s" % part)
+                        self.module.fail_json(msg="Could not find parent folder %s" % part)
                 else:
                     folder_id = p_folder_obj[0].folder if len(p_folder_obj) > 0 else None
                     filter_spec = Folder.FilterSpec(type=Folder.Type.VIRTUAL_MACHINE,

--- a/plugins/module_utils/vmware_rest_client.py
+++ b/plugins/module_utils/vmware_rest_client.py
@@ -348,7 +348,7 @@ class VmwareRestClient(object):
                     if not p_folder_obj:
                         self.module.fail_json(msg="Could not find folder %s" % part)
                 else:
-                    folder_id = p_folder_obj[0].folder if len(p_folder_obj) > 0 else None 
+                    folder_id = p_folder_obj[0].folder if len(p_folder_obj) > 0 else None
                     filter_spec = Folder.FilterSpec(type=Folder.Type.VIRTUAL_MACHINE,
                                                     names=set([part]),
                                                     datacenters=set([datacenter]),

--- a/plugins/modules/vmware_content_deploy_ovf_template.py
+++ b/plugins/modules/vmware_content_deploy_ovf_template.py
@@ -61,7 +61,7 @@ options:
       - '   folder: ha-datacenter/vm, use the vm folder in datacenter ha-datacenter'
       - '   folder: /datacenter1/vm, use the vm folder in datacenter datacenter1'
       - '   folder: datacenter1/vm, use the vm folder in datacenter datacenter1'
-      - '   folder: /datacenter1/vm/folder1/folder2, use folder2 in datacenter ha-datacenter that has as parent folder called folder1'
+      - '   folder: /datacenter1/vm/folder1/folder2, use folder2 in datacenter ha-datacenter that has as parent folder called folder1 (and folder1 has the default vm parent folder)'
       type: str
       required: True
     host:

--- a/plugins/modules/vmware_content_deploy_ovf_template.py
+++ b/plugins/modules/vmware_content_deploy_ovf_template.py
@@ -61,7 +61,7 @@ options:
       - '   folder: ha-datacenter/vm, use the vm folder in datacenter ha-datacenter'
       - '   folder: /datacenter1/vm, use the vm folder in datacenter datacenter1'
       - '   folder: datacenter1/vm, use the vm folder in datacenter datacenter1'
-      - '   folder: /datacenter1/vm/folder1/folder2, use folder2 in datacenter ha-datacenter that has as parent folder called folder1 (and folder1 has the default vm parent folder)'
+      - '   folder: /datacenter1/vm/folder1/folder2, use folder2 in datacenter ha-datacenter that has as parent folder called folder1'
       type: str
       required: True
     host:

--- a/plugins/modules/vmware_content_deploy_ovf_template.py
+++ b/plugins/modules/vmware_content_deploy_ovf_template.py
@@ -61,7 +61,7 @@ options:
       - '   folder: ha-datacenter/vm, use the vm folder in datacenter ha-datacenter'
       - '   folder: /datacenter1/vm, use the vm folder in datacenter datacenter1'
       - '   folder: datacenter1/vm, use the vm folder in datacenter datacenter1'
-      - '   folder: /datacenter1/vm/folder1/folder2, use folder2 in datacenter ha-datacenter that has as parent folder called folder1'
+      - '   folder: /datacenter1/vm/folder1/folder2, use folder2 in datacenter datacenter1 that has as parent folder called folder1'
       type: str
       required: True
     host:

--- a/plugins/modules/vmware_content_deploy_ovf_template.py
+++ b/plugins/modules/vmware_content_deploy_ovf_template.py
@@ -53,20 +53,20 @@ options:
       required: True
     folder:
       description:
-      - Name of the folder in datacenter in which to place deployed VM.
-      type: str
-      required: True
-    host:
-      description:
-      - Name of the folder in datacenter in which to place deployed VM. Either a folder or an absolute path.
+      - Name of the folder in the datacenter in which to place deployed VM. Either a folder or an absolute path.
       - This parameter is case sensitive.
       - 'Examples:'
-	  - '   folder: folder1 , use the first folder with name folder1'
+      - '   folder: folder1 , use the first folder with name folder1'
       - '   folder: /ha-datacenter/vm , use the vm folder in datacenter ha-datacenter'
       - '   folder: ha-datacenter/vm, use the vm folder in datacenter ha-datacenter'
       - '   folder: /datacenter1/vm, use the vm folder in datacenter datacenter1'
       - '   folder: datacenter1/vm, use the vm folder in datacenter datacenter1'
       - '   folder: /datacenter1/vm/folder1/folder2, use folder2 in datacenter ha-datacenter that has as parent folder called folder1'
+      type: str
+      required: True
+    host:
+      description:
+      - Name of the ESX Host in datacenter in which to place deployed VM. The host has to be a member of the cluster that contains the resource pool.
       type: str
       required: True
     resource_pool:

--- a/plugins/modules/vmware_content_deploy_ovf_template.py
+++ b/plugins/modules/vmware_content_deploy_ovf_template.py
@@ -58,7 +58,15 @@ options:
       required: True
     host:
       description:
-      - Name of the ESX Host in datacenter in which to place deployed VM. The host has to be a member of the cluster that contains the resource pool.
+      - Name of the folder in datacenter in which to place deployed VM. Either a folder or an absolute path.
+      - This parameter is case sensitive.
+      - 'Examples:'
+	  - '   folder: folder1 , use the first folder with name folder1'
+      - '   folder: /ha-datacenter/vm , use the vm folder in datacenter ha-datacenter'
+      - '   folder: ha-datacenter/vm, use the vm folder in datacenter ha-datacenter'
+      - '   folder: /datacenter1/vm, use the vm folder in datacenter datacenter1'
+      - '   folder: datacenter1/vm, use the vm folder in datacenter datacenter1'
+      - '   folder: /datacenter1/vm/folder1/folder2, use folder2 in datacenter ha-datacenter that has as parent folder called folder1'
       type: str
       required: True
     resource_pool:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
fixes #688
Currently the deploy folder is the first folder the rest api returns. 
So if you deploy to folder PROD it will always deploy to /customerA/PROD and never /customerB/TST. Currently there is no way to supply an absolute path.

/customerA/PROD
/customerA/TST
/customerB/PROD
/customerB/TST


This PR changes this if the folder has a "/" it will lookup the parent folders so that you can specify a absolute path.
folder syntax should be the same as the vm_guest module

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

community.vmware/plugins/modules/vmware_content_deploy_ovf_template.py
community.vmware/plugins/module_utils/vmware_rest_client.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
