### PR TITLE
vmware_guest_register_operation: An error has been occurring when not specify a datacenter name

### DIFF
--- a/changelogs/fragments/693-vmware_guest_register_operation.yml
+++ b/changelogs/fragments/693-vmware_guest_register_operation.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - vmware_guest_register_operation - fix an issue that an error has been occurring when not specifying a datacenter name (https://github.com/ansible-collections/community.vmware/pull/693).
+  - vmware_guest_register_operation - fixed an issue that an error has been occurring when not specifying a datacenter name (https://github.com/ansible-collections/community.vmware/pull/693).

--- a/changelogs/fragments/693-vmware_guest_register_operation.yml
+++ b/changelogs/fragments/693-vmware_guest_register_operation.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_guest_register_operation - fix an issue that an error has been occurring when not specifying a datacenter name (https://github.com/ansible-collections/community.vmware/pull/693).

--- a/plugins/modules/vmware_guest_register_operation.py
+++ b/plugins/modules/vmware_guest_register_operation.py
@@ -24,6 +24,7 @@ options:
     - Destination datacenter for the register/unregister operation.
     - This parameter is case sensitive.
     type: str
+    default: ha-datacenter
   cluster:
     description:
     - Specify a cluster name to register VM.
@@ -255,7 +256,7 @@ class VMwareGuestRegisterOperation(PyVmomi):
 
 def main():
     argument_spec = vmware_argument_spec()
-    argument_spec.update(datacenter=dict(type="str"),
+    argument_spec.update(datacenter=dict(type="str", default="ha-datacenter"),
                          cluster=dict(type="str"),
                          folder=dict(type="str"),
                          name=dict(type="str", required=True),
@@ -267,6 +268,13 @@ def main():
                          state=dict(type="str", default="present", choices=["present", "absent"]))
 
     module = AnsibleModule(argument_spec=argument_spec,
+                           mutually_exclusive=[
+                               ['cluster', 'esxi_hostname'],
+                           ],
+                           required_one_of=[
+                               ['name', 'uuid'],
+                               ['cluster', 'esxi_hostname']
+                           ],
                            supports_check_mode=True)
 
     vmware_guest_register_operation = VMwareGuestRegisterOperation(module)


### PR DESCRIPTION
##### SUMMARY

The vmware_guest_register_operation module has been occurring an error when not specifying a datacenter name.  
This PR will fix the issue.

fixes: https://github.com/ansible-collections/community.vmware/issues/692

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

changelogs/fragments/693-vmware_guest_register_operation.yml
plugins/modules/vmware_guest_register_operation.py

##### ADDITIONAL INFORMATION

tested on vCenter/ESXi 7.0