### PR TITLE
vmware_vm_inventory: get hostname's FQDN

### DIFF
--- a/changelogs/fragments/vmware_inventory_example.yml
+++ b/changelogs/fragments/vmware_inventory_example.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- vmware_vm_inventory - add an example of FQDN as hostname (https://github.com/ansible-collections/community.vmware/issues/678).

--- a/docs/community.vmware.vmware_vm_inventory_inventory.rst
+++ b/docs/community.vmware.vmware_vm_inventory_inventory.rst
@@ -689,8 +689,25 @@ Examples
         filters:
         - "tag_category.OS is defined and 'Linux' in tag_category.OS"
 
-
-
+    # customizing hostnames based on VM's FQDN. The second hostnames template acts as a fallback mechanism.
+        plugin: community.vmware.vmware_vm_inventory
+        strict: False
+        hostname: 10.65.223.31
+        username: administrator@vsphere.local
+        password: Esxi@123$%
+        validate_certs: False
+        with_tags: False
+        hostnames:
+         - 'config.name+"."+guest.ipStack.0.dnsConfig.domainName'
+         - 'config.name'
+        properties:
+          - 'config.name'
+          - 'config.guestId'
+          - 'guest.hostName'
+          - 'guest.ipAddress'
+          - 'guest.guestFamily'
+          - 'guest.ipStack'      
+    
 
 Status
 ------

--- a/plugins/inventory/vmware_vm_inventory.py
+++ b/plugins/inventory/vmware_vm_inventory.py
@@ -167,7 +167,6 @@ EXAMPLES = r'''
     username: administrator@vsphere.local
     password: Esxi@123$%
     validate_certs: False
-    with_tags: False
     properties:
     - 'name'
     - 'config.name'
@@ -238,7 +237,6 @@ EXAMPLES = r'''
     username: administrator@vsphere.local
     password: Esxi@123$%
     validate_certs: False
-    with_tags: False
     properties:
     - 'name'
     - 'config.name'
@@ -305,7 +303,6 @@ EXAMPLES = r'''
     username: administrator@vsphere.local
     password: Esxi@123$%
     validate_certs: False
-    with_tags: False
     hostnames:
      - 'config.name+"."+guest.ipStack.0.dnsConfig.domainName'
      - 'config.name'
@@ -315,7 +312,7 @@ EXAMPLES = r'''
       - 'guest.hostName'
       - 'guest.ipAddress'
       - 'guest.guestFamily'
-      - 'guest.ipStack'      
+      - 'guest.ipStack'
 '''
 
 import ssl

--- a/plugins/inventory/vmware_vm_inventory.py
+++ b/plugins/inventory/vmware_vm_inventory.py
@@ -297,6 +297,25 @@ EXAMPLES = r'''
     with_nested_properties: True
     filters:
     - "tag_category.OS is defined and 'Linux' in tag_category.OS"
+
+# customizing hostnames based on VM's FQDN. The second hostnames template acts as a fallback mechanism.
+    plugin: community.vmware.vmware_vm_inventory
+    strict: False
+    hostname: 10.65.223.31
+    username: administrator@vsphere.local
+    password: Esxi@123$%
+    validate_certs: False
+    with_tags: False
+    hostnames:
+     - 'config.name+"."+guest.ipStack.0.dnsConfig.domainName'
+     - 'config.name'
+    properties:
+      - 'config.name'
+      - 'config.guestId'
+      - 'guest.hostName'
+      - 'guest.ipAddress'
+      - 'guest.guestFamily'
+      - 'guest.ipStack'      
 '''
 
 import ssl


### PR DESCRIPTION
##### SUMMARY
relates to the issue
https://github.com/ansible-collections/community.vmware/issues/678

How to customize hostname in inventory file to use FQDN


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
community.vmware
inventory plugin

