### PR TITLE
vmware_deploy_ovf: Fix an issue that a return value hasn’t the instance key when the power_on parameter is False

### DIFF
--- a/changelogs/fragments/698-vmware_deploy_ovf.yml
+++ b/changelogs/fragments/698-vmware_deploy_ovf.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_deploy_ovf - fixed an issue that a return value hasn’t the instance key when the power_on parameter is False (https://github.com/ansible-collections/community.vmware/pull/698).

--- a/changelogs/fragments/698-vmware_deploy_ovf.yml
+++ b/changelogs/fragments/698-vmware_deploy_ovf.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - vmware_deploy_ovf - fixed an issue that a return value hasn’t the instance key when the power_on parameter is False (https://github.com/ansible-collections/community.vmware/pull/698).
+  - vmware_deploy_ovf - fixed an issue that a return value hasn't the instance key when the power_on parameter is False (https://github.com/ansible-collections/community.vmware/pull/698).

--- a/plugins/modules/vmware_deploy_ovf.py
+++ b/plugins/modules/vmware_deploy_ovf.py
@@ -610,7 +610,7 @@ class VMwareDeployOvf(PyVmomi):
                     self.module.fail_json(msg='Waiting for IP address timed out')
 
         if not facts:
-            facts.update(gather_vm_facts(self.content, self.entity))
+            facts.update(dict(instance=gather_vm_facts(self.content, self.entity)))
 
         return facts
 


### PR DESCRIPTION
##### SUMMARY

vmware_deploy_ovf module has a bug that a return value hasn't the instance key when the power_on parameter is False.  
This PR will fix the issue.

fixes: https://github.com/ansible-collections/community.vmware/issues/691

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

changelogs/fragments/698-vmware_deploy_ovf.yml
plugins/modules/vmware_deploy_ovf.py

##### ADDITIONAL INFORMATION

tested on vCenter/ESXi 7.0