### PR TITLE
vmware_guest: Fix disk parameter validation

### DIFF
--- a/changelogs/fragments/703-vmware_guest.yml
+++ b/changelogs/fragments/703-vmware_guest.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_guest - fixed a bug that made the module fail when disk.controller_number or disk.unit_number are 0 (https://github.com/ansible-collections/community.vmware/issues/703).

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -2477,7 +2477,7 @@ class PyVmomiHelper(PyVmomi):
         """
         controllers = []
         for disk_spec in self.params.get('disk'):
-            if not disk_spec['controller_type'] or not disk_spec['controller_number'] or not disk_spec['unit_number']:
+            if disk_spec['controller_type'] is None or disk_spec['controller_number'] is None or disk_spec['unit_number'] is None:
                 self.module.fail_json(msg="'disk.controller_type', 'disk.controller_number' and 'disk.unit_number' are"
                                           " mandatory parameters when configure multiple disk controllers and disks.")
 

--- a/tests/integration/targets/vmware_guest/defaults/main.yml
+++ b/tests/integration/targets/vmware_guest/defaults/main.yml
@@ -19,6 +19,7 @@ vmware_guest_test_playbooks:
   - mac_address_d1_c1_f0.yml
   - max_connections.yml
   - mem_reservation.yml
+  - multiple_disk_controllers_d1_c1_f0.yml
   - network_negative_test.yml
   - network_with_device.yml
 # Currently, VCSIM doesn't support DVPG (as portkeys are not available) so commenting this test

--- a/tests/integration/targets/vmware_guest/tasks/multiple_disk_controllers_d1_c1_f0.yml
+++ b/tests/integration/targets/vmware_guest/tasks/multiple_disk_controllers_d1_c1_f0.yml
@@ -1,215 +1,217 @@
 # Test code for the vmware_guest module.
 # Copyright: (c) 2020, Diane Wang <dianew@vmware.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-- name: create a new VM with multiple scsi controllers
-  vmware_guest:
-    validate_certs: false
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    datacenter: "{{ dc1 }}"
-    folder: vm
-    cluster: "{{ ccr1 }}"
-    resource_pool: Resources
-    name: test_vm1
-    guest_id: centos64Guest
-    datastore: "{{ rw_datastore }}"
-    hardware:
-      memory_mb: 512
-      num_cpus: 1
-    disk:
-    - controller_type: lsilogicsas
-      controller_number: 0
-      unit_number: 0
-      size_mb: 512
-      type: thin
-    - controller_type: paravirtual
-      controller_number: 1
-      unit_number: 0
-      size_mb: 256
-      type: eagerzeroedthick
-  register: multi_scsi_disk_vm
+- when: vcsim is not defined
+  block:
+    - name: create a new VM with multiple scsi controllers
+      vmware_guest:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        datacenter: "{{ dc1 }}"
+        folder: vm
+        cluster: "{{ ccr1 }}"
+        resource_pool: Resources
+        name: test_vm1
+        guest_id: centos64Guest
+        datastore: "{{ rw_datastore }}"
+        hardware:
+          memory_mb: 512
+          num_cpus: 1
+        disk:
+        - controller_type: lsilogicsas
+          controller_number: 0
+          unit_number: 0
+          size_mb: 512
+          type: thin
+        - controller_type: paravirtual
+          controller_number: 1
+          unit_number: 0
+          size_mb: 256
+          type: eagerzeroedthick
+      register: multi_scsi_disk_vm
 
-- debug: var=multi_scsi_disk_vm
+    - debug: var=multi_scsi_disk_vm
 
-- name: assert that VM was deployed
-  assert:
-    that:
-      - "multi_scsi_disk_vm.changed == true"
+    - name: assert that VM was deployed
+      assert:
+        that:
+          - "multi_scsi_disk_vm.changed == true"
 
-- name: reconfigure created VM with multiple scsi controllers
-  vmware_guest:
-    validate_certs: false
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    datacenter: "{{ dc1 }}"
-    folder: vm
-    cluster: "{{ ccr1 }}"
-    resource_pool: Resources
-    name: test_vm1
-    datastore: "{{ rw_datastore }}"
-    state: present
-    disk:
-    - controller_type: lsilogicsas
-      controller_number: 0
-      unit_number: 0
-      disk_mode: independent_persistent
-    - controller_type: paravirtual
-      controller_number: 1
-      unit_number: 0
-      size_mb: 512
-  register: multi_scsi_disk_vm
+    - name: reconfigure created VM with multiple scsi controllers
+      vmware_guest:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        datacenter: "{{ dc1 }}"
+        folder: vm
+        cluster: "{{ ccr1 }}"
+        resource_pool: Resources
+        name: test_vm1
+        datastore: "{{ rw_datastore }}"
+        state: present
+        disk:
+        - controller_type: lsilogicsas
+          controller_number: 0
+          unit_number: 0
+          disk_mode: independent_persistent
+        - controller_type: paravirtual
+          controller_number: 1
+          unit_number: 0
+          size_mb: 512
+      register: multi_scsi_disk_vm
 
-- debug: var=multi_scsi_disk_vm
+    - debug: var=multi_scsi_disk_vm
 
-- name: assert that VM was configured
-  assert:
-    that:
-      - "multi_scsi_disk_vm.changed == true"
+    - name: assert that VM was configured
+      assert:
+        that:
+          - "multi_scsi_disk_vm.changed == true"
 
-- name: create a new VM with multiple sata controllers
-  vmware_guest:
-    validate_certs: false
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    folder: vm
-    datacenter: "{{ dc1 }}"
-    cluster: "{{ ccr1 }}"
-    resource_pool: Resources
-    name: test_vm2
-    guest_id: centos64Guest
-    datastore: "{{ rw_datastore }}"
-    hardware:
-      memory_mb: 512
-      num_cpus: 1
-    disk:
-    - controller_type: sata
-      controller_number: 0
-      unit_number: 0
-      size_mb: 512
-      disk_mode: independent_persistent
-    - controller_type: sata
-      controller_number: 1
-      unit_number: 0
-      size_mb: 256
-    - controller_type: sata
-      controller_number: 2
-      unit_number: 0
-      size_mb: 256
-  register: multi_sata_disk_vm
+    - name: create a new VM with multiple sata controllers
+      vmware_guest:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        folder: vm
+        datacenter: "{{ dc1 }}"
+        cluster: "{{ ccr1 }}"
+        resource_pool: Resources
+        name: test_vm2
+        guest_id: centos64Guest
+        datastore: "{{ rw_datastore }}"
+        hardware:
+          memory_mb: 512
+          num_cpus: 1
+        disk:
+        - controller_type: sata
+          controller_number: 0
+          unit_number: 0
+          size_mb: 512
+          disk_mode: independent_persistent
+        - controller_type: sata
+          controller_number: 1
+          unit_number: 0
+          size_mb: 256
+        - controller_type: sata
+          controller_number: 2
+          unit_number: 0
+          size_mb: 256
+      register: multi_sata_disk_vm
 
-- debug: var=multi_sata_disk_vm
+    - debug: var=multi_sata_disk_vm
 
-- name: assert that VM was deployed
-  assert:
-    that:
-      - "multi_sata_disk_vm.changed == true"
+    - name: assert that VM was deployed
+      assert:
+        that:
+          - "multi_sata_disk_vm.changed == true"
 
-- name: reconfigure created new VM with multiple sata controllers
-  vmware_guest:
-    validate_certs: false
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    folder: vm
-    datacenter: "{{ dc1 }}"
-    cluster: "{{ ccr1 }}"
-    resource_pool: Resources
-    name: test_vm2
-    state: present
-    datastore: "{{ rw_datastore }}"
-    disk:
-    - controller_type: sata
-      controller_number: 0
-      unit_number: 0
-      size_mb: 512
-      disk_mode: persistent
-    - controller_type: sata
-      controller_number: 1
-      unit_number: 0
-      size_mb: 512
-  register: multi_sata_disk_vm
+    - name: reconfigure created new VM with multiple sata controllers
+      vmware_guest:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        folder: vm
+        datacenter: "{{ dc1 }}"
+        cluster: "{{ ccr1 }}"
+        resource_pool: Resources
+        name: test_vm2
+        state: present
+        datastore: "{{ rw_datastore }}"
+        disk:
+        - controller_type: sata
+          controller_number: 0
+          unit_number: 0
+          size_mb: 512
+          disk_mode: persistent
+        - controller_type: sata
+          controller_number: 1
+          unit_number: 0
+          size_mb: 512
+      register: multi_sata_disk_vm
 
-- debug: var=multi_sata_disk_vm
+    - debug: var=multi_sata_disk_vm
 
-- name: assert that VM was deployed
-  assert:
-    that:
-      - "multi_sata_disk_vm.changed == true"
+    - name: assert that VM was deployed
+      assert:
+        that:
+          - "multi_sata_disk_vm.changed == true"
 
-- name: create a new VM with multiple nvme controllers
-  vmware_guest:
-    validate_certs: false
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    folder: vm
-    datacenter: "{{ dc1 }}"
-    cluster: "{{ ccr1 }}"
-    resource_pool: Resources
-    name: test_vm3
-    guest_id: centos64Guest
-    datastore: "{{ rw_datastore }}"
-    hardware:
-      memory_mb: 512
-      num_cpus: 1
-      version: 14
-    disk:
-    - controller_type: nvme
-      controller_number: 0
-      unit_number: 0
-      size_mb: 512
-    - controller_type: nvme
-      controller_number: 1
-      unit_number: 0
-      size_mb: 256
-      type: thin
-    - controller_type: nvme
-      controller_number: 2
-      unit_number: 0
-      size_mb: 256
-  register: multi_nvme_disk_vm
+    - name: create a new VM with multiple nvme controllers
+      vmware_guest:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        folder: vm
+        datacenter: "{{ dc1 }}"
+        cluster: "{{ ccr1 }}"
+        resource_pool: Resources
+        name: test_vm3
+        guest_id: centos64Guest
+        datastore: "{{ rw_datastore }}"
+        hardware:
+          memory_mb: 512
+          num_cpus: 1
+          version: 14
+        disk:
+        - controller_type: nvme
+          controller_number: 0
+          unit_number: 0
+          size_mb: 512
+        - controller_type: nvme
+          controller_number: 1
+          unit_number: 0
+          size_mb: 256
+          type: thin
+        - controller_type: nvme
+          controller_number: 2
+          unit_number: 0
+          size_mb: 256
+      register: multi_nvme_disk_vm
 
-- debug: var=multi_nvme_disk_vm
+    - debug: var=multi_nvme_disk_vm
 
-- name: assert that VM was deployed
-  assert:
-    that:
-      - "multi_nvme_disk_vm.changed == true"
+    - name: assert that VM was deployed
+      assert:
+        that:
+          - "multi_nvme_disk_vm.changed == true"
 
-- name: reconfigure created new VM with multiple types of controllers
-  vmware_guest:
-    validate_certs: false
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    folder: vm
-    datacenter: "{{ dc1 }}"
-    cluster: "{{ ccr1 }}"
-    resource_pool: Resources
-    name: test_vm3
-    state: present
-    datastore: "{{ rw_datastore }}"
-    disk:
-    - controller_type: nvme
-      controller_number: 0
-      unit_number: 1
-      size_mb: 512
-    - controller_type: sata
-      controller_number: 1
-      unit_number: 0
-      size_mb: 256
-    - controller_type: paravirtual
-      controller_number: 0
-      unit_number: 0
-      size_mb: 256
-  register: multi_nvme_disk_vm
+    - name: reconfigure created new VM with multiple types of controllers
+      vmware_guest:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        folder: vm
+        datacenter: "{{ dc1 }}"
+        cluster: "{{ ccr1 }}"
+        resource_pool: Resources
+        name: test_vm3
+        state: present
+        datastore: "{{ rw_datastore }}"
+        disk:
+        - controller_type: nvme
+          controller_number: 0
+          unit_number: 1
+          size_mb: 512
+        - controller_type: sata
+          controller_number: 1
+          unit_number: 0
+          size_mb: 256
+        - controller_type: paravirtual
+          controller_number: 0
+          unit_number: 0
+          size_mb: 256
+      register: multi_nvme_disk_vm
 
-- debug: var=multi_nvme_disk_vm
+    - debug: var=multi_nvme_disk_vm
 
-- name: assert that VM was deployed
-  assert:
-    that:
-      - "multi_nvme_disk_vm.changed == true"
+    - name: assert that VM was deployed
+      assert:
+        that:
+          - "multi_nvme_disk_vm.changed == true"


### PR DESCRIPTION
##### SUMMARY
The module fails when `disk.controller_number` or `disk.unit_number` are 0.

Fixes #703 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_guest

##### ADDITIONAL INFORMATION
https://github.com/ansible-collections/community.vmware/blob/f913056612c776b6527aa3c373fe7cb7358d2762/plugins/modules/vmware_guest.py#L2480

When `disk.controller_number` or `disk.unit_number` are 0, the module fails because `not 0` is `True`. 0 is a valid value, the module should only fail if these parameters are not defined at all.