### PR TITLE
vmware_content_deploy_template: Use datacenter value

### DIFF
--- a/changelogs/fragments/707-datastore_cluster.yml
+++ b/changelogs/fragments/707-datastore_cluster.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- vmware_content_deploy_template - use datacenter instead of datastore to get information about datastoreFolder (https://github.com/ansible-collections/community.vmware/issues/707).

--- a/plugins/modules/vmware_content_deploy_template.py
+++ b/plugins/modules/vmware_content_deploy_template.py
@@ -202,7 +202,7 @@ class VmwareContentDeployTemplate(VmwareRestClient):
             self.datastore_id = self.get_datastore_by_name(self.datacenter, self.datastore)
         if self.datastore_cluster:
             # Find the datastore by the given datastore cluster name
-            datastore_cluster = self.pyv.find_datastore_cluster_by_name(self.datastore_cluster, folder=self.datastore_id.datastoreFolder)
+            datastore_cluster = self.pyv.find_datastore_cluster_by_name(self.datastore_cluster, datacenter=self.datacenter_id)
             if not datastore_cluster:
                 self.module.fail_json(msg="Failed to find the datastore cluster %s" % self.datastore_cluster)
             self.datastore_id = self.pyv.get_recommended_datastore(datastore_cluster)


### PR DESCRIPTION
##### SUMMARY

Use datacenter instead of datastore to gather information
about the datastore cluster.

Fixes: #707

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/707-datastore_cluster.yml
plugins/modules/vmware_content_deploy_template.py
