### PR TITLE
vmware_resource_pool: Add parent_resource_pool parameter

### DIFF
--- a/changelogs/fragments/717-vmware_resource_pool.yml
+++ b/changelogs/fragments/717-vmware_resource_pool.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_resource_pool - Add parent_resource_pool parameter which is mutually exclusive with cluster and esxi_hostname (https://github.com/ansible-collections/community.vmware/issues/717)

--- a/plugins/modules/vmware_resource_pool.py
+++ b/plugins/modules/vmware_resource_pool.py
@@ -41,9 +41,10 @@ options:
         version_added: '1.5.0'
     parent_resource_pool:
         description:
-            - Name of the parent resource pool
+            - Name of the parent resource pool.
             - This parameter is required if C(cluster) or C(esxi_hostname) is not specified.
         type: str
+        version_added: '1.9.0'
     resource_pool:
         description:
             - Resource pool name to manage.
@@ -248,7 +249,7 @@ class VMwareResourcePool(PyVmomi):
         if module.params['parent_resource_pool']:
             self.compute_resource_obj = find_resource_pool_by_name(self.content, module.params['parent_resource_pool'])
             if self.compute_resource_obj is None:
-                self.module.fail_json(msg="Unable to find recourse pool with name %s" % module.params['parent_resource_pool'])
+                self.module.fail_json(msg="Unable to find resource pool with name %s" % module.params['parent_resource_pool'])
 
 
     def select_resource_pool(self):

--- a/plugins/modules/vmware_resource_pool.py
+++ b/plugins/modules/vmware_resource_pool.py
@@ -30,15 +30,20 @@ options:
     cluster:
         description:
             - Name of the cluster to configure the resource pool.
-            - This parameter is required if C(esxi_hostname) is not specified.
+            - This parameter is required if C(esxi_hostname) or C(parent_resource_pool) is not specified.
         type: str
     esxi_hostname:
         description:
             - Name of the host to configure the resource pool.
             - The host must not be member of a cluster.
-            - This parameter is required if C(cluster) is not specified.
+            - This parameter is required if C(cluster) or C(parent_resource_pool) is not specified.
         type: str
         version_added: '1.5.0'
+    parent_resource_pool:
+        description:
+            - Name of the parent resource pool
+            - This parameter is required if C(cluster) or C(esxi_hostname) is not specified.
+        type: str
     resource_pool:
         description:
             - Resource pool name to manage.
@@ -197,7 +202,7 @@ except ImportError:
 
 from ansible.module_utils._text import to_native
 from ansible_collections.community.vmware.plugins.module_utils.vmware import get_all_objs, vmware_argument_spec, find_datacenter_by_name, \
-    find_cluster_by_name, find_object_by_name, wait_for_task, PyVmomi
+    find_cluster_by_name, find_object_by_name, wait_for_task, find_resource_pool_by_name, PyVmomi
 from ansible.module_utils.basic import AnsibleModule
 
 
@@ -223,6 +228,7 @@ class VMwareResourcePool(PyVmomi):
         self.cpu_reservation = module.params['cpu_reservation']
         self.cpu_expandable_reservations = module.params[
             'cpu_expandable_reservations']
+        self.parent_resource_pool = module.params['parent_resource_pool']
         self.resource_pool_obj = None
 
         self.dc_obj = find_datacenter_by_name(self.content, self.datacenter)
@@ -239,10 +245,16 @@ class VMwareResourcePool(PyVmomi):
             if self.compute_resource_obj is None:
                 self.module.fail_json(msg="Unable to find host with name %s" % module.params['esxi_hostname'])
 
+        if module.params['parent_resource_pool']:
+            self.compute_resource_obj = find_resource_pool_by_name(self.content, module.params['parent_resource_pool'])
+            if self.compute_resource_obj is None:
+                self.module.fail_json(msg="Unable to find recourse pool with name %s" % module.params['parent_resource_pool'])
+
+
     def select_resource_pool(self):
         pool_obj = None
 
-        resource_pools = get_all_objs(self.content, [vim.ResourcePool])
+        resource_pools = get_all_objs(self.content, [vim.ResourcePool], folder=self.compute_resource_obj)
 
         pool_selections = self.get_obj(
             [vim.ResourcePool],
@@ -254,6 +266,7 @@ class VMwareResourcePool(PyVmomi):
                 if p in resource_pools:
                     pool_obj = p
                     break
+
         return pool_obj
 
     def get_obj(self, vimtype, name, return_all=False):
@@ -417,7 +430,11 @@ class VMwareResourcePool(PyVmomi):
 
         rp_spec = self.generate_rp_config()
 
-        rootResourcePool = self.compute_resource_obj.resourcePool
+        if self.parent_resource_pool:
+            rootResourcePool = self.compute_resource_obj
+        else:
+            rootResourcePool = self.compute_resource_obj.resourcePool
+        
         rootResourcePool.CreateResourcePool(self.resource_pool, rp_spec)
 
         resource_pool_config = self.generate_rp_config_return_value(True)
@@ -436,6 +453,7 @@ def main():
     argument_spec.update(dict(datacenter=dict(required=True, type='str'),
                               cluster=dict(type='str', required=False),
                               esxi_hostname=dict(type='str', required=False),
+                              parent_resource_pool=dict(type='str', required=False),
                               resource_pool=dict(required=True, type='str'),
                               mem_shares=dict(type='str', default="normal", choices=[
                                               'high', 'custom', 'normal', 'low']),
@@ -459,10 +477,10 @@ def main():
                                ['cpu_shares', 'custom', ['cpu_allocation_shares']]
                            ],
                            required_one_of=[
-                               ['cluster', 'esxi_hostname'],
+                               ['cluster', 'esxi_hostname', 'parent_resource_pool'],
                            ],
                            mutually_exclusive=[
-                               ['cluster', 'esxi_hostname'],
+                               ['cluster', 'esxi_hostname', 'parent_resource_pool'],
                            ],
                            supports_check_mode=True)
 

--- a/plugins/modules/vmware_resource_pool.py
+++ b/plugins/modules/vmware_resource_pool.py
@@ -222,7 +222,7 @@ class VMwareResourcePool(PyVmomi):
         self.mem_limit = module.params['mem_limit']
         self.mem_reservation = module.params['mem_reservation']
         self.mem_expandable_reservations = module.params[
-            'mem_expandable_reservations']ules/vmware_resource_pool.py#L255
+            'mem_expandable_reservations']
         self.cpu_shares = module.params['cpu_shares']
         self.cpu_allocation_shares = module.params['cpu_allocation_shares']
         self.cpu_limit = module.params['cpu_limit']

--- a/plugins/modules/vmware_resource_pool.py
+++ b/plugins/modules/vmware_resource_pool.py
@@ -222,7 +222,7 @@ class VMwareResourcePool(PyVmomi):
         self.mem_limit = module.params['mem_limit']
         self.mem_reservation = module.params['mem_reservation']
         self.mem_expandable_reservations = module.params[
-            'mem_expandable_reservations']
+            'mem_expandable_reservations']ules/vmware_resource_pool.py#L255
         self.cpu_shares = module.params['cpu_shares']
         self.cpu_allocation_shares = module.params['cpu_allocation_shares']
         self.cpu_limit = module.params['cpu_limit']
@@ -250,7 +250,6 @@ class VMwareResourcePool(PyVmomi):
             self.compute_resource_obj = find_resource_pool_by_name(self.content, module.params['parent_resource_pool'])
             if self.compute_resource_obj is None:
                 self.module.fail_json(msg="Unable to find resource pool with name %s" % module.params['parent_resource_pool'])
-
 
     def select_resource_pool(self):
         pool_obj = None
@@ -435,7 +434,7 @@ class VMwareResourcePool(PyVmomi):
             rootResourcePool = self.compute_resource_obj
         else:
             rootResourcePool = self.compute_resource_obj.resourcePool
-        
+
         rootResourcePool.CreateResourcePool(self.resource_pool, rp_spec)
 
         resource_pool_config = self.generate_rp_config_return_value(True)

--- a/tests/integration/targets/vmware_resource_pool/tasks/main.yml
+++ b/tests/integration/targets/vmware_resource_pool/tasks/main.yml
@@ -7,6 +7,7 @@
   vars:
     setup_attach_host: true
     setup_datastore: true
+    setup_resource_pool: true
     move_host_out_of_cluster: true
 
 - name: set the vmware_resource_pool module default values
@@ -314,3 +315,101 @@
     - assert:
         that:
           - resource_result_023.changed is sameas false
+
+- name: set the vmware_resource_pool module default values without cluster and esxi_hostnamme parameter
+  module_defaults:
+    vmware_resource_pool:
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      validate_certs: false
+      datacenter: "{{ dc1 }}"
+      parent_resource_pool: DC0_C0_RP1
+
+  block:
+    - name: add resource pool to Parent Resource Pool with check_mode
+      vmware_resource_pool:
+        resource_pool: test_resource_024
+      check_mode: true
+      register: resource_result_024
+
+    - assert:
+        that:
+          - resource_result_024.changed is sameas true
+
+    - name: add resource pool to Parent Resource Pool
+      vmware_resource_pool:
+        resource_pool: test_resource_024
+      register: resource_result_025
+
+    - assert:
+        that:
+          - resource_result_025.changed is sameas true
+
+    - name: add resource pool to Parent Resource Pool(idempotency check)
+      vmware_resource_pool:
+        resource_pool: test_resource_024
+      register: resource_result_026
+
+    - assert:
+        that:
+          - resource_result_026.changed is sameas false
+
+    - name: change resource pool config with the custom default value and check_mode
+      vmware_resource_pool:
+        resource_pool: test_resource_024
+        mem_shares: custom
+        cpu_shares: custom
+      check_mode: true
+      register: resource_result_027
+
+    - assert:
+        that:
+          - resource_result_027.changed is sameas true
+
+    - name: change resource pool config with the custom default value
+      vmware_resource_pool:
+        resource_pool: test_resource_024
+        mem_shares: custom
+        cpu_shares: custom
+      register: resource_result_028
+
+    - assert:
+        that:
+          - resource_result_028.changed is sameas true
+          - resource_result_028.resource_pool_config is defined
+          - resource_result_028.resource_pool_config.cpuAllocation.shares.level == 'custom'
+          - resource_result_028.resource_pool_config.cpuAllocation.shares.shares == 4000
+          - resource_result_028.resource_pool_config.memoryAllocation.shares.level == 'custom'
+          - resource_result_028.resource_pool_config.memoryAllocation.shares.shares == 163840
+
+    - name: remove resource pool from Parent Resource Pool with check_mode
+      vmware_resource_pool:
+        resource_pool: test_resource_024
+        state: absent
+      check_mode: true
+      register: resource_result_029
+
+    - assert:
+        that:
+          - resource_result_029.changed is sameas true
+
+    - name: remove resource pool from Parent Resource Pool
+      vmware_resource_pool:
+        resource_pool: test_resource_024
+        state: absent
+      register: resource_result_030
+
+    - assert:
+        that:
+          - resource_result_030.changed is sameas true
+
+    - name: remove resource pool from Parent Resource Pool(idempotency check)
+      vmware_resource_pool:
+        resource_pool: test_resource_024
+        state: absent
+      register: resource_result_031
+
+    - assert:
+        that:
+          - resource_result_031.changed is sameas false


### PR DESCRIPTION
Add `parent_resource_pool` parameter which is mutually exclusive with `cluster`
and `esxi_hostname` #717

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`plugins/modules/vmware_resource_pool`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Tested on a vCenter 6.7
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
