### PR TITLE
vmware_local_user_manager: Fix to require local_user_password

### DIFF
--- a/changelogs/fragments/724-vmware_local_user_manager.yml
+++ b/changelogs/fragments/724-vmware_local_user_manager.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_local_user_manager - fixed to require local_user_password when the state is present (https://github.com/ansible-collections/community.vmware/pull/724).

--- a/docs/community.vmware.vmware_local_user_manager_module.rst
+++ b/docs/community.vmware.vmware_local_user_manager_module.rst
@@ -255,6 +255,7 @@ Examples
         username: root
         password: vmware
         local_user_name: foo
+        local_user_password: password
       delegate_to: localhost
 
 

--- a/plugins/modules/vmware_local_user_manager.py
+++ b/plugins/modules/vmware_local_user_manager.py
@@ -58,6 +58,7 @@ EXAMPLES = r'''
     username: root
     password: vmware
     local_user_name: foo
+    local_user_password: password
   delegate_to: localhost
 '''
 
@@ -173,6 +174,9 @@ def main():
                               state=dict(default='present', choices=['present', 'absent'], type='str')))
 
     module = AnsibleModule(argument_spec=argument_spec,
+                           required_if=[
+                               ['state', 'present', ['local_user_password']]
+                           ],
                            supports_check_mode=False)
 
     vmware_local_user_manager = VMwareLocalUserManager(module)


### PR DESCRIPTION
##### SUMMARY

A password error has been occurring in executing the module if the local_user_password doesn't set when the state is present.

**error**

```
fatal: [localhost]: FAILED! => {"changed": false, "msg": "A specified parameter was not correct: password"}
```

So, this PR will fix to require local_user_password when the state is present.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

changelogs/fragments/724-vmware_local_user_manager.yml
docs/community.vmware.vmware_local_user_manager_module.rst
plugins/modules/vmware_local_user_manager.py

##### ADDITIONAL INFORMATION

tested on ESXi 7.0