### PR TITLE
vmware_vm_inventory: Skip VMs in disconnected state

### DIFF
--- a/changelogs/fragments/disconnect_inventory.yml
+++ b/changelogs/fragments/disconnect_inventory.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- vmware_vm_inventory - skip disconnected VMs.

--- a/plugins/inventory/vmware_vm_inventory.py
+++ b/plugins/inventory/vmware_vm_inventory.py
@@ -788,7 +788,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             for vm_obj_property in vm_obj.propSet:
                 properties[vm_obj_property.name] = vm_obj_property.val
 
-            if (properties.get('runtime.connectionState') or properties['runtime'].connectionState) in ('orphaned', 'inaccessible'):
+            if (properties.get('runtime.connectionState') or properties['runtime'].connectionState) in ('orphaned', 'inaccessible', 'disconnected'):
                 continue
 
             # Custom values


### PR DESCRIPTION
##### SUMMARY

VMs which are in disconnected state will not return any information
leading to failure of inventory plugin.
We skip such VMs altogether.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/disconnect_inventory.yml
plugins/inventory/vmware_vm_inventory.py
