### PR TITLE
vmware_host_iscsi_info: Add detected_iscsi_drives value to return and fix the issue736

### DIFF
--- a/changelogs/fragments/729-vmware_host_iscsi_info.yml
+++ b/changelogs/fragments/729-vmware_host_iscsi_info.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_host_iscsi_info - added a list(detected_iscsi_drives) of detected iscsi drives to the return value after set an iscsi config (https://github.com/ansible-collections/community.vmware/pull/729).

--- a/changelogs/fragments/729-vmware_host_iscsi_info.yml
+++ b/changelogs/fragments/729-vmware_host_iscsi_info.yml
@@ -1,2 +1,4 @@
 minor_changes:
   - vmware_host_iscsi_info - added a list(detected_iscsi_drives) of detected iscsi drives to the return value after set an iscsi config (https://github.com/ansible-collections/community.vmware/pull/729).
+bugfixes:
+  - vmware_host_iscsi_info - fixed an issue that an error occurs gathering iSCSI information against an ESXi Host with iSCSI disabled (https://github.com/ansible-collections/community.vmware/pull/729).

--- a/docs/community.vmware.vmware_host_iscsi_info_module.rst
+++ b/docs/community.vmware.vmware_host_iscsi_info_module.rst
@@ -218,6 +218,32 @@ Common return values are documented `here <https://docs.ansible.com/ansible/late
             <tr>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>detected_iscsi_drives</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">dictionary</span>
+                    </div>
+                </td>
+                <td>always</td>
+                <td>
+                            <div>list of detected iSCSI drive</div>
+                            <div>added from version 1.9.0</div>
+                    <br/>
+                        <div style="font-size: smaller"><b>Sample:</b></div>
+                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[
+        {
+            &quot;address&quot;: [
+                &quot;192.168.0.57:3260&quot;
+            ],
+            &quot;canonical_name&quot;: &quot;naa.60014055f198fb3d0cb4bd7ae1f802e1&quot;,
+            &quot;iscsi_name&quot;: &quot;iqn.2021-03.local.iscsi-target:iscsi-storage.target0&quot;
+        }
+    ]</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
                     <b>iscsi_properties</b>
                     <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
                     <div style="font-size: small">

--- a/docs/community.vmware.vmware_host_iscsi_info_module.rst
+++ b/docs/community.vmware.vmware_host_iscsi_info_module.rst
@@ -221,7 +221,7 @@ Common return values are documented `here <https://docs.ansible.com/ansible/late
                     <b>detected_iscsi_drives</b>
                     <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
                     <div style="font-size: small">
-                      <span style="color: purple">dictionary</span>
+                      <span style="color: purple">list</span>
                     </div>
                 </td>
                 <td>always</td>

--- a/plugins/modules/vmware_host_iscsi_info.py
+++ b/plugins/modules/vmware_host_iscsi_info.py
@@ -133,65 +133,67 @@ class VMwareHostiScsiInfo(PyVmomi):
         self.esxi_hostname = self.params['esxi_hostname']
 
     def get_iscsi_config(self):
-        self.existing_system_iscsi_config = {}
-        for hba in self.host_obj.config.storageDevice.hostBusAdapter:
-            if isinstance(hba, vim.host.InternetScsiHba):
-                self.existing_system_iscsi_config.update(
-                    {
-                        'vmhba_name': hba.device,
-                        'iscsi_name': hba.iScsiName,
-                        'iscsi_alias': hba.iScsiAlias,
-                        'iscsi_authentication_properties': self.to_json(hba.authenticationProperties)
-                    }
-                )
-
-                iscsi_send_targets = []
-                for iscsi_send_target in self.to_json(hba.configuredSendTarget):
-                    iscsi_send_targets.append({
-                        'address': iscsi_send_target['address'],
-                        'authenticationProperties': iscsi_send_target['authenticationProperties'],
-                        'port': iscsi_send_target['port']
-                    })
-                self.existing_system_iscsi_config['iscsi_send_targets'] = iscsi_send_targets
-
-                iscsi_static_targets = []
-                for iscsi_static_target in self.to_json(hba.configuredStaticTarget):
-                    iscsi_static_targets.append({
-                        'iscsi_name': iscsi_static_target['iScsiName'],
-                        'address': iscsi_static_target['address'],
-                        'authenticationProperties': iscsi_static_target['authenticationProperties'],
-                        'port': iscsi_static_target['port']
-                    })
-                self.existing_system_iscsi_config['iscsi_static_targets'] = iscsi_static_targets
-
-        detected_iscsi_drives_information = []
-        for lun in self.host_obj.config.storageDevice.scsiLun:
-            if isinstance(lun, vim.host.ScsiDisk):
-                detected_iscsi_drives_information.append({
-                    'key': lun.key,
-                    'canonical_name': lun.canonicalName
-                })
-
+        iscsi_enabled = self.host_obj.config.storageDevice.softwareInternetScsiEnabled
+        self.existing_system_iscsi_config = {
+            'iscsi_enabled': iscsi_enabled
+        }
         self.detected_iscsi_drives = []
-        for scsi_adapter in self.host_obj.config.storageDevice.scsiTopology.adapter:
-            if isinstance(scsi_adapter, vim.host.ScsiTopology.Interface):
-                if re.search(self.existing_system_iscsi_config['vmhba_name'], scsi_adapter.key):
-                    for target in scsi_adapter.target:
-                        scsi_lun = target.lun[0].scsiLun
-                        for scsi_info in detected_iscsi_drives_information:
-                            if scsi_info['key'] == scsi_lun:
-                                self.detected_iscsi_drives.append({
-                                    'iscsi_name': target.transport.iScsiName,
-                                    'canonical_name': scsi_info['canonical_name'],
-                                    'address': target.transport.address
-                                })
+        if iscsi_enabled is True:
+            for hba in self.host_obj.config.storageDevice.hostBusAdapter:
+                if isinstance(hba, vim.host.InternetScsiHba):
+                    self.existing_system_iscsi_config.update(
+                        {
+                            'vmhba_name': hba.device,
+                            'iscsi_name': hba.iScsiName,
+                            'iscsi_alias': hba.iScsiAlias,
+                            'iscsi_authentication_properties': self.to_json(hba.authenticationProperties)
+                        }
+                    )
 
-        self.existing_system_iscsi_config['iscsi_enabled'] = self.to_json(self.host_obj.config.storageDevice.softwareInternetScsiEnabled)
+                    iscsi_send_targets = []
+                    for iscsi_send_target in self.to_json(hba.configuredSendTarget):
+                        iscsi_send_targets.append({
+                            'address': iscsi_send_target['address'],
+                            'authenticationProperties': iscsi_send_target['authenticationProperties'],
+                            'port': iscsi_send_target['port']
+                        })
+                    self.existing_system_iscsi_config['iscsi_send_targets'] = iscsi_send_targets
 
-        vnic_devices = []
-        for vnic in self.host_obj.configManager.iscsiManager.QueryBoundVnics(iScsiHbaName=self.existing_system_iscsi_config['vmhba_name']):
-            vnic_devices.append(vnic.vnicDevice)
-        self.existing_system_iscsi_config['port_bind'] = vnic_devices
+                    iscsi_static_targets = []
+                    for iscsi_static_target in self.to_json(hba.configuredStaticTarget):
+                        iscsi_static_targets.append({
+                            'iscsi_name': iscsi_static_target['iScsiName'],
+                            'address': iscsi_static_target['address'],
+                            'authenticationProperties': iscsi_static_target['authenticationProperties'],
+                            'port': iscsi_static_target['port']
+                        })
+                    self.existing_system_iscsi_config['iscsi_static_targets'] = iscsi_static_targets
+
+            detected_iscsi_drives_information = []
+            for lun in self.host_obj.config.storageDevice.scsiLun:
+                if isinstance(lun, vim.host.ScsiDisk):
+                    detected_iscsi_drives_information.append({
+                        'key': lun.key,
+                        'canonical_name': lun.canonicalName
+                    })
+
+            for scsi_adapter in self.host_obj.config.storageDevice.scsiTopology.adapter:
+                if isinstance(scsi_adapter, vim.host.ScsiTopology.Interface):
+                    if re.search(self.existing_system_iscsi_config['vmhba_name'], scsi_adapter.key):
+                        for target in scsi_adapter.target:
+                            scsi_lun = target.lun[0].scsiLun
+                            for scsi_info in detected_iscsi_drives_information:
+                                if scsi_info['key'] == scsi_lun:
+                                    self.detected_iscsi_drives.append({
+                                        'iscsi_name': target.transport.iScsiName,
+                                        'canonical_name': scsi_info['canonical_name'],
+                                        'address': target.transport.address
+                                    })
+
+            vnic_devices = []
+            for vnic in self.host_obj.configManager.iscsiManager.QueryBoundVnics(iScsiHbaName=self.existing_system_iscsi_config['vmhba_name']):
+                vnic_devices.append(vnic.vnicDevice)
+            self.existing_system_iscsi_config['port_bind'] = vnic_devices
 
     def execute(self):
         self.host_obj = self.find_hostsystem_by_name(self.esxi_hostname)

--- a/plugins/modules/vmware_host_iscsi_info.py
+++ b/plugins/modules/vmware_host_iscsi_info.py
@@ -104,7 +104,7 @@ detected_iscsi_drives:
     - list of detected iSCSI drive
     - added from version 1.9.0
   returned: always
-  type: dict
+  type: list
   sample: >-
     [
         {

--- a/tests/integration/targets/vmware_host_iscsi_info/tasks/iscsi_info_module_test_tasks.yml
+++ b/tests/integration/targets/vmware_host_iscsi_info/tasks/iscsi_info_module_test_tasks.yml
@@ -110,3 +110,17 @@
 - assert:
     that:
       - disable_iscsi_result.changed is sameas true
+
+- name: Gather iSCSI configuration when ESXi host with iSCSI disabled
+  vmware_host_iscsi_info:
+    hostname: "{{ hostname }}"
+    username: "{{ username }}"
+    password: "{{ password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+  register: dsabled_iscsi_info_result
+
+- assert:
+    that:
+      - dsabled_iscsi_info_result.iscsi_properties.iscsi_enabled is sameas false
+      - dsabled_iscsi_info_result.detected_iscsi_drives is defined

--- a/tests/integration/targets/vmware_host_iscsi_info/tasks/iscsi_info_module_test_tasks.yml
+++ b/tests/integration/targets/vmware_host_iscsi_info/tasks/iscsi_info_module_test_tasks.yml
@@ -71,6 +71,7 @@
       - iscsi_info_result.iscsi_properties.iscsi_static_targets[0].iscsi_name == 'iqn.2011-08.com.xxxxxxx:as6104t-8c3e9d.target001'
       - iscsi_info_result.iscsi_properties.port_bind[0] == 'vmk0'
       - iscsi_info_result.iscsi_properties.vmhba_name is defined
+      - iscsi_info_result.detected_iscsi_drives is defined
 
 - name: Remove dynamic and static targets iSCSI config from ESXi
   vmware_host_iscsi:


### PR DESCRIPTION
##### SUMMARY

I wanted to know a canonical name related to a static iscsi name, but the module hasn't returned it.  
It is useful when mounting a datastore if a canonical name is known.  
So this PR will add it to the return value.

And fix the following issue.

fixes: https://github.com/ansible-collections/community.vmware/issues/736

##### ISSUE TYPE

- Feature Pull Request
- Bugfix Pull Request

##### COMPONENT NAME

changelogs/fragments/729-vmware_host_iscsi_info.yml
docs/community.vmware.vmware_host_iscsi_info_module.rst
plugins/modules/vmware_host_iscsi_info.py
tests/integration/targets/vmware_host_iscsi_info/tasks/iscsi_info_module_test_tasks.yml

##### ADDITIONAL INFORMATION

tested on vCenter/ESXi 7.0