### PR TITLE
vmware_host_iscsi: Add a new state for rescanning a host bus adapter

### DIFF
--- a/changelogs/730-vmware_host_iscsi.yml
+++ b/changelogs/730-vmware_host_iscsi.yml
@@ -1,0 +1,2 @@
+major_changes:
+  - vmware_host_iscsi - added a new state(rescanned) for rescanning a host bus adapter (https://github.com/ansible-collections/community.vmware/pull/730).

--- a/docs/community.vmware.vmware_host_iscsi_module.rst
+++ b/docs/community.vmware.vmware_host_iscsi_module.rst
@@ -951,6 +951,7 @@ Parameters
                                     <li>absent</li>
                                     <li>enabled</li>
                                     <li>disabled</li>
+                                    <li>rescanned</li>
                         </ul>
                 </td>
                 <td>
@@ -959,6 +960,7 @@ Parameters
                         <div>If set to <code>absent</code>, remove the iSCSI target or the bind ports if they are existing.</div>
                         <div>If set to (enabled), enable the iSCSI of ESXi if the iSCSI is disabled.</div>
                         <div>If set to (disabled), disable the iSCSI of ESXi if the iSCSI is enabled.</div>
+                        <div>If set to (rescanned), rescan a host bus adapter for new storage devices.</div>
                 </td>
             </tr>
             <tr>
@@ -1072,6 +1074,16 @@ Examples
             chap_name: chap_user_name
             chap_secret: secret
         state: present
+
+    - name: Rescan a host bus adapter for new devices
+      community.vmware.vmware_host_iscsi:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        esxi_hostname: "{{ esxi_hostname }}"
+        iscsi_config:
+          vmhba_name: vmhba65
+        state: rescanned
 
     - name: Remove a dynamic target from iSCSI config of ESXi
       community.vmware.vmware_host_iscsi:

--- a/tests/integration/targets/vmware_host_iscsi/tasks/iscsi_module_test_tasks.yml
+++ b/tests/integration/targets/vmware_host_iscsi/tasks/iscsi_module_test_tasks.yml
@@ -46,6 +46,39 @@
     that:
       - enable_iscsi_idempotency_check_result.changed is sameas false
 
+- name: rescan a host bus adapter with check_mode
+  vmware_host_iscsi:
+    hostname: "{{ hostname }}"
+    username: "{{ username }}"
+    password: "{{ password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    iscsi_config:
+      vmhba_name: "{{ vmhba_name }}"
+    state: rescanned
+  check_mode: true
+  register: rescan_host_bus_adapter_check_mode_result
+
+- assert:
+    that:
+      - rescan_host_bus_adapter_check_mode_result.changed is sameas true
+
+- name: rescan a host bus adapter
+  vmware_host_iscsi:
+    hostname: "{{ hostname }}"
+    username: "{{ username }}"
+    password: "{{ password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    iscsi_config:
+      vmhba_name: "{{ vmhba_name }}"
+    state: rescanned
+  register: rescan_host_bus_adapter_result
+
+- assert:
+    that:
+      - rescan_host_bus_adapter_result.changed is sameas true
+
 - name: Set an iqn variable for an iSCSI name changing test
   set_fact:
     iqn: "iqn.1998-01.com.vmware:{{ hostname }}-012345"


### PR DESCRIPTION
##### SUMMARY

If we want to detect a new storage device right away after set an iSCSI config, a host bus adapter needs to rescan.  
So this PR will add a new state for rescanning a host bus adapter.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

changelogs/730-vmware_host_iscsi.yml
docs/community.vmware.vmware_host_iscsi_module.rst
plugins/modules/vmware_host_iscsi.py
tests/integration/targets/vmware_host_iscsi/tasks/iscsi_module_test_tasks.yml

##### ADDITIONAL INFORMATION

tested on vCenter/ESXi 7.0