### PR TITLE
vmware_vm_inventory: skip over ghost tags attached to VMs

### DIFF
--- a/changelogs/fragments/681_vmware_inventory.yml
+++ b/changelogs/fragments/681_vmware_inventory.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- vmware_vm_inventory - Skip over ghost tags attached to virtual machines (https://github.com/ansible-collections/community.vmware/issues/681).

--- a/plugins/inventory/vmware_vm_inventory.py
+++ b/plugins/inventory/vmware_vm_inventory.py
@@ -809,6 +809,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 properties['categories'] = []
                 properties['tag_category'] = {}
                 for tag_id in tag_association.list_attached_tags(vm_dynamic_id):
+                    if tag_id not in tags_info:
+                        # Ghost Tags - community.vmware#681
+                        continue
                     # Add tags related to VM
                     properties['tags'].append(tags_info[tag_id][0])
                     # Add categories related to VM


### PR DESCRIPTION
##### SUMMARY

Skip over the ghost tags attached to VMs instead of failing.

Fixes: #681

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/681_vmware_inventory.yml
plugins/inventory/vmware_vm_inventory.py
