### PR TITLE
vmware_cluster_vsan: Fix a bug when advanced_options is not set

### DIFF
--- a/changelogs/fragments/728-vmware_cluster_vsan.yml
+++ b/changelogs/fragments/728-vmware_cluster_vsan.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_cluster_vsan - fixed a bug that made the module fail when advanced_options is not set (https://github.com/ansible-collections/community.vmware/issues/728).

--- a/plugins/modules/vmware_cluster_vsan.py
+++ b/plugins/modules/vmware_cluster_vsan.py
@@ -162,11 +162,12 @@ class VMwareCluster(PyVmomi):
 
         if module.params['advanced_options'] is not None:
             self.advanced_options = module.params['advanced_options']
-            client_stub = self.si._GetStub()
-            ssl_context = client_stub.schemeArgs.get('context')
-            apiVersion = vsanapiutils.GetLatestVmodlVersion(module.params['hostname'])
-            vcMos = vsanapiutils.GetVsanVcMos(client_stub, context=ssl_context, version=apiVersion)
-            self.vsanClusterConfigSystem = vcMos['vsan-cluster-config-system']
+
+        client_stub = self.si._GetStub()
+        ssl_context = client_stub.schemeArgs.get('context')
+        apiVersion = vsanapiutils.GetLatestVmodlVersion(module.params['hostname'])
+        vcMos = vsanapiutils.GetVsanVcMos(client_stub, context=ssl_context, version=apiVersion)
+        self.vsanClusterConfigSystem = vcMos['vsan-cluster-config-system']
 
     def check_vsan_config_diff(self):
         """


### PR DESCRIPTION
##### SUMMARY
The module breaks if `advanced_options` is not set.

Fixes #728 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_cluster_vsan

##### ADDITIONAL INFORMATION
`self.vsanClusterConfigSystem` is needed to configure VSAN but isn't set when no `advanced_options` are given.
