### PR TITLE
vmware_dvs_portgroup: MAC learning, elastic PGs and uplink configuration

### DIFF
--- a/changelogs/fragments/644-vmware_dvs_portgroup.yml
+++ b/changelogs/fragments/644-vmware_dvs_portgroup.yml
@@ -1,0 +1,6 @@
+minor_changes:
+- vmware_dvs_portgroup - Implement MAC learning configuration (https://github.com/ansible-collections/community.vmware/issues/644).
+- vmware_dvs_portgroup - Implement 'elastic' port group configuration (https://github.com/ansible-collections/community.vmware/issues/410).
+- vmware_dvs_portgroup - Implement configuration of active and standby uplinks (https://github.com/ansible-collections/community.vmware/issues/709).
+- vmware_dvs_portgroup_info - Return information about MAC learning configuration (https://github.com/ansible-collections/community.vmware/issues/644).
+- vmware_dvs_portgroup_info - Return information about uplinks (https://github.com/ansible-collections/community.vmware/issues/709).

--- a/changelogs/fragments/644-vmware_dvs_portgroup.yml
+++ b/changelogs/fragments/644-vmware_dvs_portgroup.yml
@@ -2,5 +2,6 @@ minor_changes:
 - vmware_dvs_portgroup - Implement MAC learning configuration (https://github.com/ansible-collections/community.vmware/issues/644).
 - vmware_dvs_portgroup - Implement 'elastic' port group configuration (https://github.com/ansible-collections/community.vmware/issues/410).
 - vmware_dvs_portgroup - Implement configuration of active and standby uplinks (https://github.com/ansible-collections/community.vmware/issues/709).
+- vmware_dvs_portgroup - Remove default for teaming_policy.inbound_policy (https://github.com/ansible-collections/community.vmware/pull/743).
 - vmware_dvs_portgroup_info - Return information about MAC learning configuration (https://github.com/ansible-collections/community.vmware/issues/644).
 - vmware_dvs_portgroup_info - Return information about uplinks (https://github.com/ansible-collections/community.vmware/issues/709).

--- a/plugins/modules/vmware_dvs_portgroup.py
+++ b/plugins/modules/vmware_dvs_portgroup.py
@@ -278,7 +278,7 @@ EXAMPLES = r'''
     switch_name: dvSwitch
     vlan_id: 123
     num_ports: 120
-    portgroup_type: earlyBinding
+    port_binding: static
     state: present
   delegate_to: localhost
 
@@ -292,7 +292,7 @@ EXAMPLES = r'''
     vlan_id: 1-1000, 1005, 1100-1200
     vlan_trunk: True
     num_ports: 120
-    portgroup_type: earlyBinding
+    port_binding: static
     state: present
   delegate_to: localhost
 
@@ -306,7 +306,7 @@ EXAMPLES = r'''
     vlan_id: 1001
     vlan_private: True
     num_ports: 120
-    portgroup_type: earlyBinding
+    port_binding: static
     state: present
   delegate_to: localhost
 
@@ -319,7 +319,7 @@ EXAMPLES = r'''
     switch_name: dvSwitch
     vlan_id: 0
     num_ports: 120
-    portgroup_type: earlyBinding
+    port_binding: static
     state: present
   delegate_to: localhost
 
@@ -332,7 +332,7 @@ EXAMPLES = r'''
     switch_name: dvSwitch
     vlan_id: 123
     num_ports: 120
-    portgroup_type: earlyBinding
+    port_binding: static
     state: present
     network_policy:
       promiscuous: true

--- a/plugins/modules/vmware_dvs_portgroup.py
+++ b/plugins/modules/vmware_dvs_portgroup.py
@@ -45,17 +45,33 @@ options:
     num_ports:
         description:
             - The number of ports the portgroup should contain.
-        required: True
         type: int
     portgroup_type:
         description:
             - See VMware KB 1022312 regarding portgroup types.
-        required: True
+            - Deprecated. Will be removed 2021-12-01.
         choices:
             - 'earlyBinding'
             - 'lateBinding'
             - 'ephemeral'
         type: str
+    port_binding:
+        description:
+            - The type of port binding determines when ports in a port group are assigned to virtual machines.
+            - See VMware KB 1022312 U(https://kb.vmware.com/s/article/1022312) for more details.
+        type: str
+        choices:
+            - 'static'
+            - 'ephemeral'
+    port_allocation:
+        description:
+            - Elastic port groups automatically increase or decrease the number of ports as needed.
+            - Only valid if I(port_binding) is set to C(static).
+            - Will be C(elastic) if not specified and I(port_binding) is set to C(static).
+        type: str
+        choices:
+            - 'elastic'
+            - 'fixed'
     state:
         description:
             - Determines if the portgroup should be present or not.
@@ -78,6 +94,30 @@ options:
         required: False
         default: False
         type: bool
+    mac_learning:
+        description:
+            - Dictionary which configures MAC learning for portgroup.
+        suboptions:
+            allow_unicast_flooding:
+                type: bool
+                description: The flag to allow flooding of unlearned MAC for ingress traffic.
+                required: False
+            enabled:
+                type: bool
+                description: The flag to indicate if source MAC address learning is allowed.
+                required: False
+            limit:
+                type: int
+                description: The maximum number of MAC addresses that can be learned.
+                required: False
+            limit_policy:
+                type: str
+                description: The maximum number of MAC addresses that can be learned.
+                required: False
+                choices:
+                    - 'allow'
+                    - 'drop'
+        type: dict
     network_policy:
         description:
             - Dictionary which configures the different security values for portgroup.
@@ -132,6 +172,16 @@ options:
                 - Indicate whether or not to use a rolling policy when restoring links.
                 default: False
                 type: bool
+            active_uplinks:
+                description:
+                - List of active uplinks used for load balancing.
+                type: list
+                elements: str
+            standby_uplinks:
+                description:
+                - List of standby uplinks used for failover.
+                type: list
+                elements: str
         default: {
             'notify_switches': True,
             'load_balance_policy': 'loadbalance_srcid',
@@ -323,6 +373,21 @@ class VMwareDvsPortgroup(PyVmomi):
         self.dvs_portgroup = None
         self.dv_switch = None
 
+        # Some sanity checks
+        if self.module.params['port_allocation'] == 'elastic':
+            if self.module.params['port_binding'] == 'ephemeral':
+                self.module.fail_json(
+                    msg="'elastic' port allocation is not supported on an 'ephemeral' portgroup."
+                )
+
+            if self.module.params['num_ports']:
+                self.module.fail_json(
+                    msg="The number of ports cannot be configured when port allocation is set to 'elastic'."
+                )
+
+    def supports_mac_learning(self):
+        return hasattr(self.dv_switch.capability.featuresSupported, 'macLearningSupported') and self.dv_switch.capability.featuresSupported.macLearningSupported
+
     def create_vlan_list(self):
         vlan_id_list = []
         for vlan_id_splitted in self.module.params['vlan_id'].split(','):
@@ -357,7 +422,9 @@ class VMwareDvsPortgroup(PyVmomi):
 
         # Basic config
         config.name = self.module.params['portgroup_name']
-        config.numPorts = self.module.params['num_ports']
+
+        if self.module.params['port_allocation'] != 'elastic' and self.module.params['port_binding'] != 'ephemeral':
+            config.numPorts = self.module.params['num_ports']
 
         # Default port config
         config.defaultPortConfig = vim.dvs.VmwareDistributedVirtualSwitch.VmwarePortConfigPolicy()
@@ -377,11 +444,33 @@ class VMwareDvsPortgroup(PyVmomi):
         else:
             config.defaultPortConfig.vlan = vim.dvs.VmwareDistributedVirtualSwitch.VlanIdSpec()
             config.defaultPortConfig.vlan.vlanId = int(self.module.params['vlan_id'])
+
         config.defaultPortConfig.vlan.inherited = False
-        config.defaultPortConfig.securityPolicy = vim.dvs.VmwareDistributedVirtualSwitch.SecurityPolicy()
-        config.defaultPortConfig.securityPolicy.allowPromiscuous = vim.BoolPolicy(value=self.module.params['network_policy']['promiscuous'])
-        config.defaultPortConfig.securityPolicy.forgedTransmits = vim.BoolPolicy(value=self.module.params['network_policy']['forged_transmits'])
-        config.defaultPortConfig.securityPolicy.macChanges = vim.BoolPolicy(value=self.module.params['network_policy']['mac_changes'])
+
+        # If the dvSwitch supports MAC learning, it's a version where securityPolicy is deprecated
+        if self.supports_mac_learning():
+            config.defaultPortConfig.macManagementPolicy = vim.dvs.VmwareDistributedVirtualSwitch.MacManagementPolicy()
+            config.defaultPortConfig.macManagementPolicy.allowPromiscuous = self.module.params['network_policy']['promiscuous']
+            config.defaultPortConfig.macManagementPolicy.forgedTransmits = self.module.params['network_policy']['forged_transmits']
+            config.defaultPortConfig.macManagementPolicy.macChanges = self.module.params['network_policy']['mac_changes']
+
+            macLearning = self.module.params['mac_learning']
+            if macLearning:
+                macLearningPolicy = vim.dvs.VmwareDistributedVirtualSwitch.MacLearningPolicy()
+                if macLearning['allow_unicast_flooding'] is not None:
+                    macLearningPolicy.allowUnicastFlooding = macLearning['allow_unicast_flooding']
+                if macLearning['enabled'] is not None:
+                    macLearningPolicy.enabled = macLearning['enabled']
+                if macLearning['limit'] is not None:
+                    macLearningPolicy.limit = macLearning['limit']
+                if macLearning['limit_policy']:
+                    macLearningPolicy.limitPolicy = macLearning['limit_policy']
+                config.defaultPortConfig.macManagementPolicy.macLearningPolicy = macLearningPolicy
+        else:
+            config.defaultPortConfig.securityPolicy = vim.dvs.VmwareDistributedVirtualSwitch.SecurityPolicy()
+            config.defaultPortConfig.securityPolicy.allowPromiscuous = vim.BoolPolicy(value=self.module.params['network_policy']['promiscuous'])
+            config.defaultPortConfig.securityPolicy.forgedTransmits = vim.BoolPolicy(value=self.module.params['network_policy']['forged_transmits'])
+            config.defaultPortConfig.securityPolicy.macChanges = vim.BoolPolicy(value=self.module.params['network_policy']['mac_changes'])
 
         # Teaming Policy
         teamingPolicy = vim.dvs.VmwareDistributedVirtualSwitch.UplinkPortTeamingPolicy()
@@ -389,6 +478,14 @@ class VMwareDvsPortgroup(PyVmomi):
         teamingPolicy.reversePolicy = vim.BoolPolicy(value=self.module.params['teaming_policy']['inbound_policy'])
         teamingPolicy.notifySwitches = vim.BoolPolicy(value=self.module.params['teaming_policy']['notify_switches'])
         teamingPolicy.rollingOrder = vim.BoolPolicy(value=self.module.params['teaming_policy']['rolling_order'])
+
+        if self.module.params['teaming_policy']['active_uplinks'] or self.module.params['teaming_policy']['standby_uplinks']:
+            teamingPolicy.uplinkPortOrder = vim.dvs.VmwareDistributedVirtualSwitch.UplinkPortOrderPolicy()
+            if self.module.params['teaming_policy']['active_uplinks']:
+                teamingPolicy.uplinkPortOrder.activeUplinkPort = self.module.params['teaming_policy']['active_uplinks']
+            if self.module.params['teaming_policy']['standby_uplinks']:
+                teamingPolicy.uplinkPortOrder.standbyUplinkPort = self.module.params['teaming_policy']['standby_uplinks']
+
         config.defaultPortConfig.uplinkTeamingPolicy = teamingPolicy
 
         # PG policy (advanced_policy)
@@ -406,7 +503,19 @@ class VMwareDvsPortgroup(PyVmomi):
         config.policy.vlanOverrideAllowed = self.module.params['port_policy']['vlan_override']
 
         # PG Type
-        config.type = self.module.params['portgroup_type']
+        # NOTE: 'portgroup_type' is deprecated.
+        if self.module.params['portgroup_type']:
+            config.type = self.module.params['portgroup_type']
+        elif self.module.params['port_binding'] == 'ephemeral':
+            config.type = 'ephemeral'
+        else:
+            config.type = 'earlyBinding'
+
+        if self.module.params['port_allocation']:
+            if self.module.params['port_allocation'] == 'elastic':
+                config.autoExpand = True
+            else:
+                config.autoExpand = False
 
         return config
 
@@ -491,9 +600,9 @@ class VMwareDvsPortgroup(PyVmomi):
             return 'absent'
 
         # Check config
-        # Basic config
-        if self.dvs_portgroup.config.numPorts != self.module.params['num_ports']:
-            return 'update'
+        if self.module.params['port_allocation'] != 'elastic' and self.module.params['port_binding'] != 'ephemeral':
+            if self.dvs_portgroup.config.numPorts != self.module.params['num_ports']:
+                return 'update'
 
         # Default port config
         defaultPortConfig = self.dvs_portgroup.config.defaultPortConfig
@@ -513,10 +622,29 @@ class VMwareDvsPortgroup(PyVmomi):
             if defaultPortConfig.vlan.vlanId != int(self.module.params['vlan_id']):
                 return 'update'
 
-        if defaultPortConfig.securityPolicy.allowPromiscuous.value != self.module.params['network_policy']['promiscuous'] or \
-                defaultPortConfig.securityPolicy.forgedTransmits.value != self.module.params['network_policy']['forged_transmits'] or \
-                defaultPortConfig.securityPolicy.macChanges.value != self.module.params['network_policy']['mac_changes']:
-            return 'update'
+        # If the dvSwitch supports MAC learning, it's a version where securityPolicy is deprecated
+        if self.supports_mac_learning():
+            if defaultPortConfig.macManagementPolicy.allowPromiscuous != self.module.params['network_policy']['promiscuous'] or \
+                    defaultPortConfig.macManagementPolicy.forgedTransmits != self.module.params['network_policy']['forged_transmits'] or \
+                    defaultPortConfig.macManagementPolicy.macChanges != self.module.params['network_policy']['mac_changes']:
+                return 'update'
+
+            macLearning = self.module.params['mac_learning']
+            if macLearning:
+                macLearningPolicy = defaultPortConfig.macManagementPolicy.macLearningPolicy
+                if macLearning['allow_unicast_flooding'] is not None and macLearningPolicy.allowUnicastFlooding != macLearning['allow_unicast_flooding']:
+                    return 'update'
+                if macLearning['enabled'] is not None and macLearningPolicy.enabled != macLearning['enabled']:
+                    return 'update'
+                if macLearning['limit'] is not None and macLearningPolicy.limit != macLearning['limit']:
+                    return 'update'
+                if macLearning['limit_policy'] and macLearningPolicy.limitPolicy != macLearning['limit_policy']:
+                    return 'update'
+        else:
+            if defaultPortConfig.securityPolicy.allowPromiscuous.value != self.module.params['network_policy']['promiscuous'] or \
+                    defaultPortConfig.securityPolicy.forgedTransmits.value != self.module.params['network_policy']['forged_transmits'] or \
+                    defaultPortConfig.securityPolicy.macChanges.value != self.module.params['network_policy']['mac_changes']:
+                return 'update'
 
         # Teaming Policy
         teamingPolicy = self.dvs_portgroup.config.defaultPortConfig.uplinkTeamingPolicy
@@ -524,6 +652,14 @@ class VMwareDvsPortgroup(PyVmomi):
                 teamingPolicy.reversePolicy.value != self.module.params['teaming_policy']['inbound_policy'] or \
                 teamingPolicy.notifySwitches.value != self.module.params['teaming_policy']['notify_switches'] or \
                 teamingPolicy.rollingOrder.value != self.module.params['teaming_policy']['rolling_order']:
+            return 'update'
+
+        if self.module.params['teaming_policy']['active_uplinks'] and \
+                teamingPolicy.uplinkPortOrder.activeUplinkPort != self.module.params['teaming_policy']['active_uplinks']:
+            return 'update'
+
+        if self.module.params['teaming_policy']['standby_uplinks'] and \
+                teamingPolicy.uplinkPortOrder.standbyUplinkPort != self.module.params['teaming_policy']['standby_uplinks']:
             return 'update'
 
         # PG policy (advanced_policy)
@@ -542,8 +678,22 @@ class VMwareDvsPortgroup(PyVmomi):
             return 'update'
 
         # PG Type
-        if self.dvs_portgroup.config.type != self.module.params['portgroup_type']:
+        # NOTE: 'portgroup_type' is deprecated.
+        if self.module.params['portgroup_type']:
+            if self.dvs_portgroup.config.type != self.module.params['portgroup_type']:
+                return 'update'
+        elif self.module.params['port_binding'] == 'ephemeral':
+            if self.dvs_portgroup.config.type != 'ephemeral':
+                return 'update'
+        elif self.dvs_portgroup.config.type != 'earlyBinding':
             return 'update'
+
+        # Check port allocation
+        if self.module.params['port_allocation']:
+            if self.module.params['port_allocation'] == 'elastic' and self.dvs_portgroup.config.autoExpand is False:
+                return 'update'
+            elif self.module.params['port_allocation'] == 'fixed' and self.dvs_portgroup.config.autoExpand is True:
+                return 'update'
 
         return 'present'
 
@@ -555,8 +705,15 @@ def main():
             portgroup_name=dict(required=True, type='str'),
             switch_name=dict(required=True, type='str'),
             vlan_id=dict(required=True, type='str'),
-            num_ports=dict(required=True, type='int'),
-            portgroup_type=dict(required=True, choices=['earlyBinding', 'lateBinding', 'ephemeral'], type='str'),
+            num_ports=dict(type='int'),
+            portgroup_type=dict(
+                type='str',
+                choices=['earlyBinding', 'lateBinding', 'ephemeral'],
+                removed_at_date='2021-12-01',
+                removed_from_collection='community.vmware',
+            ),
+            port_binding=dict(type='str', choices=['static', 'ephemeral']),
+            port_allocation=dict(type='str', choices=['fixed', 'elastic']),
             state=dict(required=True, choices=['present', 'absent'], type='str'),
             vlan_trunk=dict(type='bool', default=False),
             vlan_private=dict(type='bool', default=False),
@@ -588,7 +745,9 @@ def main():
                                                  'loadbalance_loadbased',
                                                  'failover_explicit',
                                              ],
-                                             )
+                                             ),
+                    active_uplinks=dict(type='list', elements='str'),
+                    standby_uplinks=dict(type='list', elements='str'),
                 ),
                 default=dict(
                     inbound_policy=False,
@@ -624,14 +783,28 @@ def main():
                     uplink_teaming_override=False,
                     vendor_config_override=False,
                     vlan_override=False
-                )
+                ),
+            ),
+            mac_learning=dict(
+                type='dict',
+                options=dict(
+                    allow_unicast_flooding=dict(type='bool'),
+                    enabled=dict(type='bool'),
+                    limit=dict(type='int'),
+                    limit_policy=dict(type='str', choices=['allow', 'drop']),
+                ),
             )
         )
     )
 
     module = AnsibleModule(argument_spec=argument_spec,
+                           required_one_of=[
+                               ['portgroup_type', 'port_binding'],
+                           ],
                            mutually_exclusive=[
-                               ['vlan_trunk', 'vlan_private']
+                               ['portgroup_type', 'port_binding'],
+                               ['portgroup_type', 'port_allocation'],
+                               ['vlan_trunk', 'vlan_private'],
                            ],
                            supports_check_mode=True)
 

--- a/plugins/modules/vmware_dvs_portgroup.py
+++ b/plugins/modules/vmware_dvs_portgroup.py
@@ -19,7 +19,7 @@ author:
     - Joseph Callen (@jcpowermac)
     - Philippe Dellaert (@pdellaert) <philippe@dellaert.org>
 notes:
-    - Tested on vSphere 5.5, 6.5
+    - Tested on vSphere 7.0
 requirements:
     - "python >= 2.6"
     - PyVmomi

--- a/plugins/modules/vmware_dvs_portgroup.py
+++ b/plugins/modules/vmware_dvs_portgroup.py
@@ -63,6 +63,7 @@ options:
         choices:
             - 'static'
             - 'ephemeral'
+        version_added: '1.10.0'
     port_allocation:
         description:
             - Elastic port groups automatically increase or decrease the number of ports as needed.
@@ -72,6 +73,7 @@ options:
         choices:
             - 'elastic'
             - 'fixed'
+        version_added: '1.10.0'
     state:
         description:
             - Determines if the portgroup should be present or not.
@@ -118,6 +120,7 @@ options:
                     - 'allow'
                     - 'drop'
         type: dict
+        version_added: '1.10.0'
     network_policy:
         description:
             - Dictionary which configures the different security values for portgroup.
@@ -176,11 +179,13 @@ options:
                 - List of active uplinks used for load balancing.
                 type: list
                 elements: str
+                version_added: '1.10.0'
             standby_uplinks:
                 description:
                 - List of standby uplinks used for failover.
                 type: list
                 elements: str
+                version_added: '1.10.0'
         default: {
             'notify_switches': True,
             'load_balance_policy': 'loadbalance_srcid',

--- a/plugins/modules/vmware_dvs_portgroup.py
+++ b/plugins/modules/vmware_dvs_portgroup.py
@@ -114,7 +114,7 @@ options:
                 required: False
             limit_policy:
                 type: str
-                description: The maximum number of MAC addresses that can be learned.
+                description: The default switching policy after MAC limit is exceeded.
                 required: False
                 choices:
                     - 'allow'

--- a/plugins/modules/vmware_dvs_portgroup_info.py
+++ b/plugins/modules/vmware_dvs_portgroup_info.py
@@ -33,6 +33,11 @@ options:
     - Name of a dvswitch to look for.
     required: false
     type: str
+  show_mac_learning:
+    description:
+    - Show or hide MAC learning information of the DVS portgroup.
+    type: bool
+    default: False
   show_network_policy:
     description:
     - Show or hide network policies of DVS portgroup.
@@ -46,6 +51,11 @@ options:
   show_teaming_policy:
     description:
     - Show or hide teaming policies of DVS portgroup.
+    type: bool
+    default: True
+  show_uplinks:
+    description:
+    - Show or hide uplinks of DVS portgroup.
     type: bool
     default: True
   show_vlan_info:
@@ -153,6 +163,9 @@ class DVSPortgroupInfoManager(PyVmomi):
             # default behaviour, gather information about all dvswitches
             self.dvsls = get_all_objs(self.content, [vim.DistributedVirtualSwitch], folder=datacenter.networkFolder)
 
+    def supports_mac_learning(self, dvs):
+        return hasattr(dvs.capability.featuresSupported, 'macLearningSupported') and self.dv_switch.capability.featuresSupported.macLearningSupported
+
     def get_vlan_info(self, vlan_obj=None):
         """
         Return vlan information from given object
@@ -184,19 +197,51 @@ class DVSPortgroupInfoManager(PyVmomi):
         dvs_lists = self.dvsls
         result = dict()
         for dvs in dvs_lists:
+            switch_supports_mac_learning = self.supports_mac_learning(dvs)
             result[dvs.name] = list()
             for dvs_pg in dvs.portgroup:
+                mac_learning = dict()
                 network_policy = dict()
                 teaming_policy = dict()
                 port_policy = dict()
                 vlan_info = dict()
+                active_uplinks = list()
+                standby_uplinks = list()
 
-                if self.module.params['show_network_policy'] and dvs_pg.config.defaultPortConfig.securityPolicy:
-                    network_policy = dict(
-                        forged_transmits=dvs_pg.config.defaultPortConfig.securityPolicy.forgedTransmits.value,
-                        promiscuous=dvs_pg.config.defaultPortConfig.securityPolicy.allowPromiscuous.value,
-                        mac_changes=dvs_pg.config.defaultPortConfig.securityPolicy.macChanges.value
+                if dvs_pg.config.type == 'ephemeral':
+                    port_binding = 'ephemeral'
+                else:
+                    port_binding = 'static'
+
+                if dvs_pg.config.autoExpand is True:
+                    port_allocation = 'elastic'
+                else:
+                    port_allocation = 'fixed'
+
+                # If the dvSwitch supports MAC learning, it's a version where securityPolicy is deprecated
+                if self.module.params['show_network_policy']:
+                    if switch_supports_mac_learning and dvs_pg.config.defaultPortConfig.macManagementPolicy:
+                        network_policy = dict(
+                            forged_transmits=dvs_pg.config.defaultPortConfig.macManagementPolicy.forgedTransmits,
+                            promiscuous=dvs_pg.config.defaultPortConfig.macManagementPolicy.allowPromiscuous,
+                            mac_changes=dvs_pg.config.defaultPortConfig.macManagementPolicy.macChanges
+                        )
+                    elif dvs_pg.config.defaultPortConfig.securityPolicy:
+                        network_policy = dict(
+                            forged_transmits=dvs_pg.config.defaultPortConfig.securityPolicy.forgedTransmits.value,
+                            promiscuous=dvs_pg.config.defaultPortConfig.securityPolicy.allowPromiscuous.value,
+                            mac_changes=dvs_pg.config.defaultPortConfig.securityPolicy.macChanges.value
+                        )
+
+                if self.module.params['show_mac_learning'] and switch_supports_mac_learning:
+                    macLearningPolicy = dvs_pg.config.defaultPortConfig.macManagementPolicy.macLearningPolicy
+                    mac_learning = dict(
+                        allow_unicast_flooding=macLearningPolicy.allowUnicastFlooding,
+                        enabled=macLearningPolicy.enabled,
+                        limit=macLearningPolicy.limit,
+                        limit_policy=macLearningPolicy.limitPolicy
                     )
+
                 if self.module.params['show_teaming_policy']:
                     # govcsim does not have uplinkTeamingPolicy, remove this check once
                     # PR https://github.com/vmware/govmomi/pull/1524 merged.
@@ -207,6 +252,12 @@ class DVSPortgroupInfoManager(PyVmomi):
                             notify_switches=dvs_pg.config.defaultPortConfig.uplinkTeamingPolicy.notifySwitches.value,
                             rolling_order=dvs_pg.config.defaultPortConfig.uplinkTeamingPolicy.rollingOrder.value,
                         )
+
+                if self.module.params['show_uplinks'] and \
+                        dvs_pg.config.defaultPortConfig.uplinkTeamingPolicy and \
+                        dvs_pg.config.defaultPortConfig.uplinkTeamingPolicy.uplinkPortOrder:
+                    active_uplinks = dvs_pg.config.defaultPortConfig.uplinkTeamingPolicy.uplinkPortOrder.activeUplinkPort
+                    standby_uplinks = dvs_pg.config.defaultPortConfig.uplinkTeamingPolicy.uplinkPortOrder.standbyUplinkPort
 
                 if self.params['show_port_policy']:
                     # govcsim does not have port policy
@@ -234,11 +285,16 @@ class DVSPortgroupInfoManager(PyVmomi):
                     dvswitch_name=dvs_pg.config.distributedVirtualSwitch.name,
                     description=dvs_pg.config.description,
                     type=dvs_pg.config.type,
+                    port_binding=port_binding,
+                    port_allocation=port_allocation,
                     teaming_policy=teaming_policy,
                     port_policy=port_policy,
+                    mac_learning=mac_learning,
                     network_policy=network_policy,
                     vlan_info=vlan_info,
                     key=dvs_pg.key,
+                    active_uplinks=active_uplinks,
+                    standby_uplinks=standby_uplinks,
                 )
                 result[dvs.name].append(dvpg_details)
 
@@ -249,8 +305,10 @@ def main():
     argument_spec = vmware_argument_spec()
     argument_spec.update(
         datacenter=dict(type='str', required=True),
+        show_mac_learning=dict(type='bool', default=False),
         show_network_policy=dict(type='bool', default=True),
         show_teaming_policy=dict(type='bool', default=True),
+        show_uplinks=dict(type='bool', default=True),
         show_port_policy=dict(type='bool', default=True),
         dvswitch=dict(),
         show_vlan_info=dict(type='bool', default=False),

--- a/plugins/modules/vmware_dvs_portgroup_info.py
+++ b/plugins/modules/vmware_dvs_portgroup_info.py
@@ -38,6 +38,7 @@ options:
     - Show or hide MAC learning information of the DVS portgroup.
     type: bool
     default: True
+    version_added: '1.10.0'
   show_network_policy:
     description:
     - Show or hide network policies of DVS portgroup.
@@ -58,6 +59,7 @@ options:
     - Show or hide uplinks of DVS portgroup.
     type: bool
     default: True
+    version_added: '1.10.0'
   show_vlan_info:
     description:
     - Show or hide vlan information of the DVS portgroup.

--- a/plugins/modules/vmware_dvs_portgroup_info.py
+++ b/plugins/modules/vmware_dvs_portgroup_info.py
@@ -164,7 +164,7 @@ class DVSPortgroupInfoManager(PyVmomi):
             self.dvsls = get_all_objs(self.content, [vim.DistributedVirtualSwitch], folder=datacenter.networkFolder)
 
     def supports_mac_learning(self, dvs):
-        return hasattr(dvs.capability.featuresSupported, 'macLearningSupported') and self.dv_switch.capability.featuresSupported.macLearningSupported
+        return hasattr(dvs.capability.featuresSupported, 'macLearningSupported') and dvs.capability.featuresSupported.macLearningSupported
 
     def get_vlan_info(self, vlan_obj=None):
         """

--- a/plugins/modules/vmware_dvs_portgroup_info.py
+++ b/plugins/modules/vmware_dvs_portgroup_info.py
@@ -37,7 +37,7 @@ options:
     description:
     - Show or hide MAC learning information of the DVS portgroup.
     type: bool
-    default: False
+    default: True
   show_network_policy:
     description:
     - Show or hide network policies of DVS portgroup.
@@ -305,7 +305,7 @@ def main():
     argument_spec = vmware_argument_spec()
     argument_spec.update(
         datacenter=dict(type='str', required=True),
-        show_mac_learning=dict(type='bool', default=False),
+        show_mac_learning=dict(type='bool', default=True),
         show_network_policy=dict(type='bool', default=True),
         show_teaming_policy=dict(type='bool', default=True),
         show_uplinks=dict(type='bool', default=True),

--- a/plugins/modules/vmware_dvs_portgroup_info.py
+++ b/plugins/modules/vmware_dvs_portgroup_info.py
@@ -18,7 +18,7 @@ description:
 author:
 - Abhijeet Kasurde (@Akasurde)
 notes:
-- Tested on vSphere 6.5
+- Tested on vSphere 7.0
 requirements:
 - python >= 2.6
 - PyVmomi

--- a/tests/integration/targets/prepare_vmware_tests/tasks/setup_dvswitch.yml
+++ b/tests/integration/targets/prepare_vmware_tests/tasks/setup_dvswitch.yml
@@ -3,7 +3,7 @@
   vmware_dvswitch:
     datacenter_name: '{{ dc1 }}'
     switch_name: '{{ dvswitch1 }}'
-    switch_version: 6.5.0
+    switch_version: 6.6.0
     mtu: 9000
     uplink_quantity: 2
     discovery_proto: lldp

--- a/tests/integration/targets/vmware_dvs_portgroup/tasks/main.yml
+++ b/tests/integration/targets/vmware_dvs_portgroup/tasks/main.yml
@@ -17,7 +17,7 @@
     portgroup_name: "basic"
     vlan_id: 0
     num_ports: 32
-    portgroup_type: earlyBinding
+    port_binding: static
     state: present
   register: dvs_pg_result_0001
 
@@ -29,6 +29,104 @@
     that:
         - dvs_pg_result_0001.changed
 
+- when: vcsim is not defined
+  block:
+    - name: enable MAC learning
+      vmware_dvs_portgroup:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        switch_name: "{{ dvswitch1 }}"
+        portgroup_name: "basic"
+        vlan_id: 0
+        num_ports: 32
+        port_binding: static
+        mac_learning:
+          enabled: true
+        state: present
+      register: enable_mac_learning_result
+
+    - debug:
+        var: enable_mac_learning_result
+
+    - name: ensure MAC learning is enabled
+      assert:
+        that:
+            - enable_mac_learning_result.changed
+
+    - name: enable MAC learning again (idempotency)
+      vmware_dvs_portgroup:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        switch_name: "{{ dvswitch1 }}"
+        portgroup_name: "basic"
+        vlan_id: 0
+        num_ports: 32
+        port_binding: static
+        mac_learning:
+          enabled: true
+        state: present
+      register: enable_mac_learning_again_result
+
+    - debug:
+        var: enable_mac_learning_again_result
+
+    - name: ensure MAC learning is not enabled again
+      assert:
+        that:
+            - not enable_mac_learning_again_result.changed
+
+    - name: disable MAC learning
+      vmware_dvs_portgroup:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        switch_name: "{{ dvswitch1 }}"
+        portgroup_name: "basic"
+        vlan_id: 0
+        num_ports: 32
+        port_binding: static
+        mac_learning:
+          enabled: false
+        state: present
+      register: disable_mac_learning_result
+
+    - debug:
+        var: disable_mac_learning_result
+
+    - name: ensure MAC learning is disabled
+      assert:
+        that:
+            - disable_mac_learning_result.changed
+
+    - name: disable MAC learning again (idempotency)
+      vmware_dvs_portgroup:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        switch_name: "{{ dvswitch1 }}"
+        portgroup_name: "basic"
+        vlan_id: 0
+        num_ports: 32
+        port_binding: static
+        mac_learning:
+          enabled: false
+        state: present
+      register: disable_mac_learning_again_result
+
+    - debug:
+        var: disable_mac_learning_again_result
+
+    - name: ensure MAC learning is not disabled again
+      assert:
+        that:
+            - not disable_mac_learning_again_result.changed
+
 - name: create basic VLAN portgroup
   vmware_dvs_portgroup:
     validate_certs: false
@@ -39,7 +137,7 @@
     portgroup_name: "basic-vlan10"
     vlan_id: 10
     num_ports: 32
-    portgroup_type: earlyBinding
+    port_binding: static
     state: present
   register: dvs_pg_result_0002
 
@@ -59,7 +157,7 @@
     vlan_id: 1-4094
     vlan_trunk: true
     num_ports: 32
-    portgroup_type: earlyBinding
+    port_binding: static
     state: present
   register: dvs_pg_result_0003
 
@@ -78,7 +176,7 @@
     portgroup_name: "basic"
     vlan_id: 0
     num_ports: 32
-    portgroup_type: earlyBinding
+    port_binding: static
     state: present
   register: dvs_pg_result_0004
 
@@ -97,7 +195,7 @@
     portgroup_name: "basic-all-enabled"
     vlan_id: 0
     num_ports: 32
-    portgroup_type: earlyBinding
+    port_binding: static
     state: present
     network_policy:
       promiscuous: true
@@ -132,7 +230,7 @@
     portgroup_name: "basic-some-enabled"
     vlan_id: 0
     num_ports: 32
-    portgroup_type: earlyBinding
+    port_binding: static
     state: present
     network_policy:
       promiscuous: true
@@ -157,7 +255,7 @@
     portgroup_name: "basic-some-enabled"
     vlan_id: 0
     num_ports: 32
-    portgroup_type: earlyBinding
+    port_binding: static
     state: present
     network_policy:
       promiscuous: true
@@ -182,7 +280,7 @@
     portgroup_name: "basic-some-enabled"
     vlan_id: 0
     num_ports: 32
-    portgroup_type: earlyBinding
+    port_binding: static
     state: present
     network_policy:
       promiscuous: true
@@ -207,7 +305,7 @@
     portgroup_name: "basic-some-enabled"
     vlan_id: 0
     num_ports: 16
-    portgroup_type: earlyBinding
+    port_binding: static
     state: present
     network_policy:
       promiscuous: true
@@ -232,7 +330,7 @@
     portgroup_name: "basic-some-enabled"
     vlan_id: 0
     num_ports: 16
-    portgroup_type: ephemeral
+    port_binding: ephemeral
     state: present
     network_policy:
       promiscuous: true
@@ -257,7 +355,7 @@
     portgroup_name: "basic"
     vlan_id: 0
     num_ports: 32
-    portgroup_type: earlyBinding
+    port_binding: static
     state: absent
   register: dvs_pg_result_0011
 
@@ -276,7 +374,7 @@
     portgroup_name: "basic"
     vlan_id: 0
     num_ports: 32
-    portgroup_type: earlyBinding
+    port_binding: static
     state: absent
   register: dvs_pg_result_0012
 
@@ -296,7 +394,7 @@
     vlan_id: 1-4096
     vlan_trunk: true
     num_ports: 32
-    portgroup_type: earlyBinding
+    port_binding: static
     state: present
   register: dvs_pg_result_0013
   ignore_errors: true
@@ -317,7 +415,7 @@
     portgroup_name: "basic-vlan10"
     vlan_id: 20
     num_ports: 32
-    portgroup_type: earlyBinding
+    port_binding: static
     state: present
   register: dvs_pg_result_0014
 
@@ -337,7 +435,7 @@
     vlan_id: 1000-2000
     vlan_trunk: true
     num_ports: 32
-    portgroup_type: earlyBinding
+    port_binding: static
     state: present
   register: dvs_pg_result_0015
 
@@ -357,7 +455,7 @@
     vlan_id: 1-1000, 1005, 1100-1200
     vlan_trunk: true
     num_ports: 32
-    portgroup_type: earlyBinding
+    port_binding: static
     state: present
   register: dvs_pg_result_0016
 
@@ -377,7 +475,7 @@
     vlan_id: 1-1000, 1006, 1100-1200
     vlan_trunk: true
     num_ports: 32
-    portgroup_type: earlyBinding
+    port_binding: static
     state: present
   register: dvs_pg_result_0017
 
@@ -396,7 +494,7 @@
     vlan_id: 10
     vlan_private: true
     num_ports: 12
-    portgroup_type: earlyBinding
+    port_binding: static
     state: present
     validate_certs: false
   register: dvs_pg_result_0018
@@ -460,7 +558,7 @@
         vlan_id: 1
         vlan_private: true
         num_ports: 12
-        portgroup_type: earlyBinding
+        port_binding: static
         state: present
         validate_certs: false
       register: dvs_pg_result_0019
@@ -480,7 +578,7 @@
         vlan_id: 2
         vlan_private: true
         num_ports: 12
-        portgroup_type: earlyBinding
+        port_binding: static
         state: present
         validate_certs: false
       register: dvs_pg_result_0020
@@ -499,7 +597,7 @@
         switch_name: dvswitch_0001
         vlan_id: 5
         num_ports: 12
-        portgroup_type: earlyBinding
+        port_binding: static
         state: present
         validate_certs: false
       register: dvs_pg_result_0021
@@ -550,7 +648,7 @@
             portgroup_name: 'dvportgroup\/%'
             vlan_id: 1
             num_ports: 8
-            portgroup_type: earlyBinding
+            port_binding: static
             state: present
           register: create_dvportgroup_with_special_characters_result
 
@@ -568,7 +666,7 @@
             portgroup_name: 'dvportgroup\/%'
             vlan_id: 1
             num_ports: 8
-            portgroup_type: earlyBinding
+            port_binding: static
             state: present
           register: create_dvportgroup_with_special_characters_idempotency_check_result
 
@@ -586,7 +684,7 @@
             portgroup_name: 'dvportgroup\/%'
             vlan_id: 1
             num_ports: 8
-            portgroup_type: earlyBinding
+            port_binding: static
             state: absent
           register: delete_dvportgroup_with_special_characters_result
 
@@ -604,7 +702,7 @@
             portgroup_name: 'dvportgroup\/%'
             vlan_id: 1
             num_ports: 8
-            portgroup_type: earlyBinding
+            port_binding: static
             state: absent
           register: delete_dvportgroup_with_special_characters_idempotency_check_result
 
@@ -643,7 +741,7 @@
         vlan_id: "1500,1501"
         vlan_trunk: true
         num_ports: 120
-        portgroup_type: earlyBinding
+        port_binding: static
         network_policy:
           promiscuous: false
           forged_transmits: true
@@ -666,7 +764,7 @@
         vlan_id: "1500,1501"
         vlan_trunk: true
         num_ports: 120
-        portgroup_type: earlyBinding
+        port_binding: static
         network_policy:
           promiscuous: false
           forged_transmits: true
@@ -689,7 +787,7 @@
         vlan_id: "1500,1501"
         vlan_trunk: true
         num_ports: 120
-        portgroup_type: earlyBinding
+        port_binding: static
         network_policy:
           promiscuous: false
           forged_transmits: true


### PR DESCRIPTION
Depends-On: ansible/ansible-zuul-jobs#869

##### SUMMARY
Implement MAC learning, elastic PGs and active / standby uplink configuration.

Fixes #644
Fixes #410
Fixes #709 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_dvs_portgroup
vmware_dvs_portgroup_info

##### ADDITIONAL INFORMATION
While working on this I've seen that `securityPolicy` is [deprecated](https://vdc-repo.vmware.com/vmwb-repository/dcr-public/fe08899f-1eec-4d8d-b3bc-a6664c168c2c/7fdf97a1-4c0d-4be0-9d43-2ceebbc174d9/doc/vim.dvs.VmwareDistributedVirtualSwitch.VmwarePortConfigPolicy.html#field_detail) and macManagementPolicy ([DVSMacManagementPolicy](https://vdc-repo.vmware.com/vmwb-repository/dcr-public/fe08899f-1eec-4d8d-b3bc-a6664c168c2c/7fdf97a1-4c0d-4be0-9d43-2ceebbc174d9/doc/vim.dvs.VmwareDistributedVirtualSwitch.MacManagementPolicy.html))  should be used to configure `promiscuous`, `forged_transmits` and `mac_changes`. I've implemented this for newer dvSwitches while I was at it.

_edit:_
A note on introducing `port_binding` and deprecating `portgroup_type`: In the API, a portgroup has a type which can be `ephemeral`, `earlyBinding` or `lateBinding` but the latter is deprecated. In the UI, there is no portgroup type but you can specify port binding (`static` or `ephemeral`). I think we should use the UI wording here, this should make it easier for most people to understand and use the module.