### PR TITLE
vmware_vmkernel_ip_config: Fix module.deprecate

### DIFF
--- a/plugins/modules/vmware_vmkernel_ip_config.py
+++ b/plugins/modules/vmware_vmkernel_ip_config.py
@@ -99,7 +99,7 @@ def main():
 
     module.deprecate(
         msg="The 'vmware_vmkernel_ip_config' is deprecated, please use the 'vmware_vmkernel' module instead.",
-        date="2023-03-01",
+        date="2021-12-01",
         collection_name="community.vmware"
     )
 


### PR DESCRIPTION
##### SUMMARY
This is a follow-up to #667. I forgot to update `module.deprecate`. Sorry for this :-/

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
vmware_vmkernel_ip_config

