### PR TITLE
vmware_guest_instant_clone: Tweak the module adding esxi_hostname alias and removing duplicated hostname paramete

### DIFF
--- a/changelogs/fragments/745-vmware_guest_instant_clone.yml
+++ b/changelogs/fragments/745-vmware_guest_instant_clone.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - vmware_guest_instant_clone: - supported esxi_hostname parameter as an alias (https://github.com/ansible-collections/community.vmware/pull/745).
+  - vmware_guest_instant_clone - supported esxi_hostname parameter as an alias (https://github.com/ansible-collections/community.vmware/pull/745).

--- a/changelogs/fragments/745-vmware_guest_instant_clone.yml
+++ b/changelogs/fragments/745-vmware_guest_instant_clone.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_guest_instant_clone: - supported esxi_hostname parameter as an alias (https://github.com/ansible-collections/community.vmware/pull/745).

--- a/docs/community.vmware.vmware_guest_instant_clone_module.rst
+++ b/docs/community.vmware.vmware_guest_instant_clone_module.rst
@@ -106,6 +106,7 @@ Parameters
                         <div>Name of the ESX Host in datacenter in which to place cloned VM.</div>
                         <div>The host has to be a member of the cluster that contains the resource pool.</div>
                         <div>Required with <em>resource_pool</em> to find resource pool details. This will be used as additional information when there are resource pools with same name.</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: esxi_hostname</div>
                 </td>
             </tr>
             <tr>

--- a/plugins/modules/vmware_guest_instant_clone.py
+++ b/plugins/modules/vmware_guest_instant_clone.py
@@ -55,6 +55,7 @@ options:
       - The host has to be a member of the cluster that contains the resource pool.
       - Required with I(resource_pool) to find resource pool details. This will be used as additional information when there are resource pools with same name.
     type: str
+    aliases: ['esxi_hostname']
     required: True
   datastore:
     description:
@@ -350,8 +351,7 @@ def main():
         datacenter=dict(type='str', required=True),
         datastore=dict(type='str', required=True),
         use_instance_uuid=dict(type='bool', default=False),
-        hostname=dict(type='str', aliases=['admin', 'user']),
-        host=dict(type='str', required=True),
+        host=dict(type='str', required=True, aliases=['esxi_hostname']),
         folder=dict(type='str', required=False),
         resource_pool=dict(type='str', required=False),
         parent_vm=dict(type='str')


### PR DESCRIPTION
##### SUMMARY

This PR will add esxi_hostname alias to the module.  
Also, remove the hostname parameter because covering by the parameter of vmware_argument_spec(module_utils/vmware)

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

changelogs/fragments/745-vmware_guest_instant_clone.yml
docs/community.vmware.vmware_guest_instant_clone_module.rst
plugins/modules/vmware_guest_instant_clone.py

##### ADDITIONAL INFORMATION

tested on vCenter/ESXi 7.0