### PR TITLE
vmware_guest: Fix integration test

### DIFF
--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -2525,7 +2525,7 @@ class PyVmomiHelper(PyVmomi):
             disk_spec.device.backing.diskMode = "persistent"
 
         if not reconfigure:
-            disk_type = expected_disk_spec.get('type', 'thin').lower()
+            disk_type = expected_disk_spec.get('type', 'thin')
             if disk_type == 'thin':
                 disk_spec.device.backing.thinProvisioned = True
             elif disk_type == 'eagerzeroedthick':

--- a/tests/integration/targets/vmware_guest/tasks/multiple_disk_controllers_d1_c1_f0.yml
+++ b/tests/integration/targets/vmware_guest/tasks/multiple_disk_controllers_d1_c1_f0.yml
@@ -56,6 +56,7 @@
         - controller_type: lsilogicsas
           controller_number: 0
           unit_number: 0
+          size_mb: 512
           disk_mode: independent_persistent
         - controller_type: paravirtual
           controller_number: 1


### PR DESCRIPTION
##### SUMMARY
I have enabled some additional integration tests (`multiple_disk_controllers_d1_c1_f0.yml`) for `vmware_guest` in PR #705 that were already defined but not included in `tests/integration/targets/vmware_guest/defaults/main.yml`. Since this PR wasn't tested against a real vSphere environment in CI, we didn't see that one of them was buggy.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_guest

##### ADDITIONAL INFORMATION
At first, I thought two tests were buggy. But it turned out that only one was, the other test that failed was due to a bug in the module.