### PR TITLE
vmware_dvs_portgroup_info: ensure functional tests pass

### DIFF
--- a/tests/integration/targets/vmware_dvs_portgroup_info/tasks/main.yml
+++ b/tests/integration/targets/vmware_dvs_portgroup_info/tasks/main.yml
@@ -65,7 +65,7 @@
           assert:
             that:
               - >-
-               dvs_results.dvs_portgroup_info.DVSwitch
+               dvs_results.dvs_portgroup_info.{{ dvswitch1 }}
                | map(attribute='portgroup_name')
                | select('==', 'dvportgroup\/%')
                | list


### PR DESCRIPTION
Address a regression introduced by #648.

Close: #750