### PR TITLE
README: Add the vSAN Management SDK for Python to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ VMware community collection depends upon following third party libraries:
 
 * [`Pyvmomi`](https://github.com/vmware/pyvmomi) >= 6.7.1.2018.12
 * [`vSphere Automation SDK for Python`](https://github.com/vmware/vsphere-automation-sdk-python/)
-* [`vSAN Management SDK for Python`](https://code.vmware.com/web/sdk/7.0%20U2/vsan-python)
+* [`vSAN Management SDK for Python`](https://code.vmware.com/web/sdk/vsan-python)
 
 ### Installing required libraries and SDK
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ VMware community collection depends upon following third party libraries:
 
 * [`Pyvmomi`](https://github.com/vmware/pyvmomi) >= 6.7.1.2018.12
 * [`vSphere Automation SDK for Python`](https://github.com/vmware/vsphere-automation-sdk-python/)
+* [`vSAN Management SDK for Python`](https://code.vmware.com/web/sdk/7.0%20U2/vsan-python)
 
 ### Installing required libraries and SDK
 


### PR DESCRIPTION
##### SUMMARY

If using vSAN modules, the vSAN Management SDK for Python is necessary, but the README isn't written about it.  
So this PR will add it to README.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

README.md

##### ADDITIONAL INFORMATION