### PR TITLE
CI: ensure vmware_guest tests only run on nested capable host

### DIFF
--- a/tests/integration/targets/vmware_guest/aliases
+++ b/tests/integration/targets/vmware_guest/aliases
@@ -1,5 +1,4 @@
 cloud/vcenter
 needs/target/prepare_vmware_tests
-zuul/vmware/vcenter_1esxi
 zuul/vmware/vcenter_1esxi_with_nested
 zuul/vmware/govcsim


### PR DESCRIPTION
These tests start VM, so we need an ESXi able to do that.