### PR TITLE
vmware_guest_instant_clone: CI test starts VM

### DIFF
--- a/tests/integration/targets/vmware_guest_instant_clone/aliases
+++ b/tests/integration/targets/vmware_guest_instant_clone/aliases
@@ -1,4 +1,4 @@
 cloud/vcenter
 needs/target/prepare_vmware_tests
-zuul/vmware/vcenter_1esxi
+zuul/vmware/vcenter_1esxi_with_nested
 zuul/vmware/govcsim


### PR DESCRIPTION
Ensure the CI uses an ESXi host that can actually start VM.