### PR TITLE
vmware_guest_instant_clone: properly initialize the env before the tests

### DIFF
--- a/tests/integration/targets/vmware_guest_instant_clone/tasks/main.yml
+++ b/tests/integration/targets/vmware_guest_instant_clone/tasks/main.yml
@@ -5,7 +5,9 @@
 - import_role:
     name: prepare_vmware_tests
   vars:
+    setup_attach_host: true
     setup_datacenter: true
+    setup_datastore: true
     setup_resource_pool: true
 
 - name: Create VM


### PR DESCRIPTION
The tests require a host and a datastore.