### PR TITLE
vmware_guest_instance_clone: tests: Unable to set power state

### DIFF
--- a/tests/integration/targets/vmware_guest_instant_clone/tasks/main.yml
+++ b/tests/integration/targets/vmware_guest_instant_clone/tasks/main.yml
@@ -126,7 +126,6 @@
       username: "{{ vcenter_username }}"
       password: "{{ vcenter_password }}"
       name: "cloned_vm_from_vm_optional"
-      folder: "{{ f0 }}"
       state: powered-off
     register: poweroff_instant_clone_from_vm_optional_arguments
 


### PR DESCRIPTION
Ensure `vmware_guest_powerstate` looks for the VM at the default
location.
Closes: #761