### PR TITLE
vmware_evc_mode: Fix an issue that evc_mode is required when the state parameter set to absent

### DIFF
--- a/changelogs/fragments/764-vmware_evc_mode.yml
+++ b/changelogs/fragments/764-vmware_evc_mode.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_evc_mode - fixed an issue that evc_mode is required when the state parameter set to absent (https://github.com/ansible-collections/community.vmware/pull/764).

--- a/docs/community.vmware.vmware_evc_mode_module.rst
+++ b/docs/community.vmware.vmware_evc_mode_module.rst
@@ -53,6 +53,7 @@ Parameters
                 </td>
                 <td>
                         <div>The name of the cluster to enable or disable EVC mode on.</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: cluster</div>
                 </td>
             </tr>
             <tr>
@@ -69,6 +70,7 @@ Parameters
                 </td>
                 <td>
                         <div>The name of the datacenter the cluster belongs to that you want to enable or disable EVC mode on.</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: datacenter</div>
                 </td>
             </tr>
             <tr>
@@ -78,7 +80,6 @@ Parameters
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
-                         / <span style="color: red">required</span>
                     </div>
                 </td>
                 <td>

--- a/plugins/modules/vmware_evc_mode.py
+++ b/plugins/modules/vmware_evc_mode.py
@@ -27,16 +27,19 @@ options:
     - The name of the datacenter the cluster belongs to that you want to enable or disable EVC mode on.
     required: True
     type: str
+    aliases:
+      - datacenter
   cluster_name:
     description:
     - The name of the cluster to enable or disable EVC mode on.
     required: True
     type: str
+    aliases:
+      - cluster
   evc_mode:
     description:
     - Required for C(state=present).
     - The EVC mode to enable or disable on the cluster. (intel-broadwell, intel-nehalem, intel-merom, etc.).
-    required: True
     type: str
   state:
     description:
@@ -207,9 +210,9 @@ class VMwareEVC(PyVmomi):
 def main():
     argument_spec = vmware_argument_spec()
     argument_spec.update(dict(
-        cluster_name=dict(type='str', required=True),
-        datacenter_name=dict(type='str', required=True),
-        evc_mode=dict(type='str', required=True),
+        cluster_name=dict(type='str', required=True, aliases=['cluster']),
+        datacenter_name=dict(type='str', required=True, aliases=['datacenter']),
+        evc_mode=dict(type='str'),
         state=dict(type='str', default='present', choices=['absent', 'present']),
     ))
 

--- a/plugins/modules/vmware_evc_mode.py
+++ b/plugins/modules/vmware_evc_mode.py
@@ -220,7 +220,7 @@ def main():
         argument_spec=argument_spec,
         supports_check_mode=True,
         required_if=[
-            ['state', 'present', ['cluster_name', 'datacenter_name', 'evc_mode']]
+            ['state', 'present', ['evc_mode']]
         ]
     )
 


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/community.vmware/pull/770

##### SUMMARY

According to the module documentation, evc_mode is unnecessary when the state set to absent.  
But actually, the option is required in executing the module.  
This PR will fix the bug and add the aliases for the datacenter and cluster.

fixes: https://github.com/ansible-collections/community.vmware/issues/702

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

changelogs/fragments/764-vmware_evc_mode.yml
docs/community.vmware.vmware_evc_mode_module.rst
plugins/modules/vmware_evc_mode.py

##### ADDITIONAL INFORMATION

tested on vCenter/ESXi 7.0
