### PR TITLE
vmware_cluster_drs/ha/vsan: Announce change of enable parameter default for the future

### DIFF
--- a/changelogs/fragments/739-vmware_cluster_drs.yml
+++ b/changelogs/fragments/739-vmware_cluster_drs.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - vmware_cluster_drs - Make enable_drs an alias of enable and remove the default value making it a required parameter (https://github.com/ansible-collections/community.vmware/issues/739)
+  - vmware_cluster_ha - Make enable_ha an alias of enable and remove the default value making it a required parameter (https://github.com/ansible-collections/community.vmware/issues/739)
+  - vmware_cluster_vsan - Make enable_vsan an alias of enable and remove the default value making it a required parameter (https://github.com/ansible-collections/community.vmware/issues/739)

--- a/changelogs/fragments/739-vmware_cluster_drs.yml
+++ b/changelogs/fragments/739-vmware_cluster_drs.yml
@@ -1,4 +1,4 @@
 minor_changes:
-  - vmware_cluster_drs - Make enable_drs an alias of enable and remove the default value making it a required parameter (https://github.com/ansible-collections/community.vmware/issues/739)
-  - vmware_cluster_ha - Make enable_ha an alias of enable and remove the default value making it a required parameter (https://github.com/ansible-collections/community.vmware/issues/739)
-  - vmware_cluster_vsan - Make enable_vsan an alias of enable and remove the default value making it a required parameter (https://github.com/ansible-collections/community.vmware/issues/739)
+  - vmware_cluster_drs - Make enable_drs an alias of enable and add a warning that the default will change from false to true in a future version (https://github.com/ansible-collections/community.vmware/pull/766)
+  - vmware_cluster_ha - Make enable_ha an alias of enable and add a warning that the default will change from false to true in a future version (https://github.com/ansible-collections/community.vmware/pull/766)
+  - vmware_cluster_vsan - Make enable_vsan an alias of enable and add a warning that the default will change from false to true in a future version (https://github.com/ansible-collections/community.vmware/pull/766)

--- a/plugins/modules/vmware_cluster_drs.py
+++ b/plugins/modules/vmware_cluster_drs.py
@@ -153,7 +153,8 @@ class VMwareCluster(PyVmomi):
         else:
             self.changed_advanced_settings = None
 
-        self.module.warn("The default value for enable will change from false to true in a future version in order to make the behavior more consistent with other modules. Please make sure your playbooks don't rely on the default being false so you don't run into problems.")
+        self.module.warn("The default value for enable will change from false to true in a future version in order to make the behavior more consistent with other modules."
+                         "Please make sure your playbooks don't rely on the default being false so you don't run into problems.")
 
     def check_drs_config_diff(self):
         """

--- a/plugins/modules/vmware_cluster_drs.py
+++ b/plugins/modules/vmware_cluster_drs.py
@@ -35,11 +35,12 @@ options:
       type: str
       required: true
       aliases: [ datacenter_name ]
-    enable_drs:
+    enable:
       description:
       - Whether to enable DRS.
       type: bool
-      default: false
+      required: true
+      aliases: [ enable_drs ]
     drs_enable_vm_behavior_overrides:
       description:
       - Whether DRS Behavior overrides for individual virtual machines are enabled.
@@ -82,7 +83,7 @@ EXAMPLES = r'''
     password: '{{ vcenter_password }}'
     datacenter_name: datacenter
     cluster_name: cluster
-    enable_drs: true
+    enable: true
   delegate_to: localhost
 
 - name: Enable DRS and distribute a more even number of virtual machines across hosts for availability
@@ -92,7 +93,7 @@ EXAMPLES = r'''
     password: '{{ vcenter_password }}'
     datacenter_name: datacenter
     cluster_name: cluster
-    enable_drs: true
+    enable: true
     advanced_settings:
       'TryBalanceVmsPerHost': '1'
   delegate_to: localhost
@@ -104,7 +105,7 @@ EXAMPLES = r'''
     password: "{{ vcenter_password }}"
     datacenter_name: DC0
     cluster_name: "{{ cluster_name }}"
-    enable_drs: True
+    enable: True
     drs_default_vm_behavior: partiallyAutomated
   delegate_to: localhost
 '''
@@ -134,7 +135,7 @@ class VMwareCluster(PyVmomi):
         super(VMwareCluster, self).__init__(module)
         self.cluster_name = module.params['cluster_name']
         self.datacenter_name = module.params['datacenter']
-        self.enable_drs = module.params['enable_drs']
+        self.enable_drs = module.params['enable']
         self.datacenter = None
         self.cluster = None
 
@@ -214,7 +215,7 @@ def main():
         cluster_name=dict(type='str', required=True),
         datacenter=dict(type='str', required=True, aliases=['datacenter_name']),
         # DRS
-        enable_drs=dict(type='bool', default=False),
+        enable=dict(type='bool', required=True, aliases=['enable_drs']),
         drs_enable_vm_behavior_overrides=dict(type='bool', default=True),
         drs_default_vm_behavior=dict(type='str',
                                      choices=['fullyAutomated', 'manual', 'partiallyAutomated'],

--- a/plugins/modules/vmware_cluster_drs.py
+++ b/plugins/modules/vmware_cluster_drs.py
@@ -39,7 +39,7 @@ options:
       description:
       - Whether to enable DRS.
       type: bool
-      required: true
+      default: false
       aliases: [ enable_drs ]
     drs_enable_vm_behavior_overrides:
       description:
@@ -153,6 +153,8 @@ class VMwareCluster(PyVmomi):
         else:
             self.changed_advanced_settings = None
 
+        self.module.warn("The default value for enable will change from false to true in a future version in order to make the behavior more consistent with other modules. Please make sure your playbooks don't rely on the default being false so you don't run into problems.")
+
     def check_drs_config_diff(self):
         """
         Check DRS configuration diff
@@ -215,7 +217,7 @@ def main():
         cluster_name=dict(type='str', required=True),
         datacenter=dict(type='str', required=True, aliases=['datacenter_name']),
         # DRS
-        enable=dict(type='bool', required=True, aliases=['enable_drs']),
+        enable=dict(type='bool', default=False, aliases=['enable_drs']),
         drs_enable_vm_behavior_overrides=dict(type='bool', default=True),
         drs_default_vm_behavior=dict(type='str',
                                      choices=['fullyAutomated', 'manual', 'partiallyAutomated'],

--- a/plugins/modules/vmware_cluster_drs.py
+++ b/plugins/modules/vmware_cluster_drs.py
@@ -153,7 +153,7 @@ class VMwareCluster(PyVmomi):
         else:
             self.changed_advanced_settings = None
 
-        self.module.warn("The default value for enable will change from false to true in a future version in order to make the behavior more consistent with other modules."
+        self.module.warn("The default for enable will change from false to true in a future version to make the behavior more consistent with other modules."
                          "Please make sure your playbooks don't rely on the default being false so you don't run into problems.")
 
     def check_drs_config_diff(self):

--- a/plugins/modules/vmware_cluster_ha.py
+++ b/plugins/modules/vmware_cluster_ha.py
@@ -284,7 +284,8 @@ class VMwareCluster(PyVmomi):
         else:
             self.changed_advanced_settings = None
 
-        self.module.warn("The default value for enable will change from false to true in a future version in order to make the behavior more consistent with other modules. Please make sure your playbooks don't rely on the default being false so you don't run into problems.")
+        self.module.warn("The default value for enable will change from false to true in a future version in order to make the behavior more consistent with other modules."
+                         "Please make sure your playbooks don't rely on the default being false so you don't run into problems.")
 
     def get_failover_hosts(self):
         """

--- a/plugins/modules/vmware_cluster_ha.py
+++ b/plugins/modules/vmware_cluster_ha.py
@@ -36,17 +36,18 @@ options:
       type: str
       required: true
       aliases: [ datacenter_name ]
-    enable_ha:
+    enable:
       description:
       - Whether to enable HA.
       type: bool
-      default: false
+      required: true
+      aliases: [ enable_ha ]
     ha_host_monitoring:
       description:
       - Whether HA restarts virtual machines after a host fails.
       - If set to C(enabled), HA restarts virtual machines after a host fails.
       - If set to C(disabled), HA does not restart virtual machines after a host fails.
-      - If C(enable_ha) is set to C(False), then this value is ignored.
+      - If C(enable) is set to C(False), then this value is ignored.
       type: str
       choices: [ 'enabled', 'disabled' ]
       default: 'enabled'
@@ -56,7 +57,7 @@ options:
       - If set to C(vmAndAppMonitoring), HA response to both virtual machine and application heartbeat failure.
       - If set to C(vmMonitoringDisabled), virtual machine health monitoring is disabled.
       - If set to C(vmMonitoringOnly), HA response to virtual machine heartbeat failure.
-      - If C(enable_ha) is set to C(False), then this value is ignored.
+      - If C(enable) is set to C(False), then this value is ignored.
       type: str
       choices: ['vmAndAppMonitoring', 'vmMonitoringOnly', 'vmMonitoringDisabled']
       default: 'vmMonitoringDisabled'
@@ -200,7 +201,7 @@ EXAMPLES = r'''
     password: '{{ vcenter_password }}'
     datacenter_name: datacenter
     cluster_name: cluster
-    enable_ha: true
+    enable: true
   delegate_to: localhost
 
 - name: Enable HA and VM monitoring without admission control
@@ -210,7 +211,7 @@ EXAMPLES = r'''
     password: "{{ vcenter_password }}"
     datacenter_name: DC0
     cluster_name: "{{ cluster_name }}"
-    enable_ha: True
+    enable: True
     ha_vm_monitoring: vmMonitoringOnly
   delegate_to: localhost
 
@@ -221,7 +222,7 @@ EXAMPLES = r'''
     password: '{{ vcenter_password }}'
     datacenter_name: datacenter
     cluster_name: cluster
-    enable_ha: true
+    enable: true
     reservation_based_admission_control:
       auto_compute_percentages: False
       failover_level: 1
@@ -255,7 +256,7 @@ class VMwareCluster(PyVmomi):
         super(VMwareCluster, self).__init__(module)
         self.cluster_name = module.params['cluster_name']
         self.datacenter_name = module.params['datacenter']
-        self.enable_ha = module.params['enable_ha']
+        self.enable_ha = module.params['enable']
         self.datacenter = None
         self.cluster = None
         self.host_isolation_response = getattr(vim.cluster.DasVmSettings.IsolationResponse, self.params.get('host_isolation_response'))
@@ -455,7 +456,7 @@ def main():
         cluster_name=dict(type='str', required=True),
         datacenter=dict(type='str', required=True, aliases=['datacenter_name']),
         # HA
-        enable_ha=dict(type='bool', default=False),
+        enable=dict(type='bool', required=True, aliases=['enable_ha']),
         ha_host_monitoring=dict(type='str',
                                 default='enabled',
                                 choices=['enabled', 'disabled']),

--- a/plugins/modules/vmware_cluster_ha.py
+++ b/plugins/modules/vmware_cluster_ha.py
@@ -40,7 +40,7 @@ options:
       description:
       - Whether to enable HA.
       type: bool
-      required: true
+      default: false
       aliases: [ enable_ha ]
     ha_host_monitoring:
       description:
@@ -284,6 +284,8 @@ class VMwareCluster(PyVmomi):
         else:
             self.changed_advanced_settings = None
 
+        self.module.warn("The default value for enable will change from false to true in a future version in order to make the behavior more consistent with other modules. Please make sure your playbooks don't rely on the default being false so you don't run into problems.")
+
     def get_failover_hosts(self):
         """
         Get failover hosts for failover_host_admission_control policy
@@ -456,7 +458,7 @@ def main():
         cluster_name=dict(type='str', required=True),
         datacenter=dict(type='str', required=True, aliases=['datacenter_name']),
         # HA
-        enable=dict(type='bool', required=True, aliases=['enable_ha']),
+        enable=dict(type='bool', default=False, aliases=['enable_ha']),
         ha_host_monitoring=dict(type='str',
                                 default='enabled',
                                 choices=['enabled', 'disabled']),

--- a/plugins/modules/vmware_cluster_ha.py
+++ b/plugins/modules/vmware_cluster_ha.py
@@ -284,7 +284,7 @@ class VMwareCluster(PyVmomi):
         else:
             self.changed_advanced_settings = None
 
-        self.module.warn("The default value for enable will change from false to true in a future version in order to make the behavior more consistent with other modules."
+        self.module.warn("The default for enable will change from false to true in a future version to make the behavior more consistent with other modules."
                          "Please make sure your playbooks don't rely on the default being false so you don't run into problems.")
 
     def get_failover_hosts(self):

--- a/plugins/modules/vmware_cluster_vsan.py
+++ b/plugins/modules/vmware_cluster_vsan.py
@@ -41,7 +41,7 @@ options:
       description:
       - Whether to enable vSAN.
       type: bool
-      required: true
+      default: false
       aliases: [ enable_vsan ]
     vsan_auto_claim_storage:
       description:
@@ -170,6 +170,8 @@ class VMwareCluster(PyVmomi):
         vcMos = vsanapiutils.GetVsanVcMos(client_stub, context=ssl_context, version=apiVersion)
         self.vsanClusterConfigSystem = vcMos['vsan-cluster-config-system']
 
+        self.module.warn("The default value for enable will change from false to true in a future version in order to make the behavior more consistent with other modules. Please make sure your playbooks don't rely on the default being false so you don't run into problems.")
+
     def check_vsan_config_diff(self):
         """
         Check VSAN configuration diff
@@ -258,7 +260,7 @@ def main():
         cluster_name=dict(type='str', required=True),
         datacenter=dict(type='str', required=True, aliases=['datacenter_name']),
         # VSAN
-        enable=dict(type='bool', required=True, aliases=['enable_vsan']),
+        enable=dict(type='bool', default=False, aliases=['enable_vsan']),
         vsan_auto_claim_storage=dict(type='bool', default=False),
         advanced_options=dict(type='dict', options=dict(
             automatic_rebalance=dict(type='bool', required=False),

--- a/plugins/modules/vmware_cluster_vsan.py
+++ b/plugins/modules/vmware_cluster_vsan.py
@@ -170,7 +170,7 @@ class VMwareCluster(PyVmomi):
         vcMos = vsanapiutils.GetVsanVcMos(client_stub, context=ssl_context, version=apiVersion)
         self.vsanClusterConfigSystem = vcMos['vsan-cluster-config-system']
 
-        self.module.warn("The default value for enable will change from false to true in a future version in order to make the behavior more consistent with other modules."
+        self.module.warn("The default for enable will change from false to true in a future version to make the behavior more consistent with other modules."
                          "Please make sure your playbooks don't rely on the default being false so you don't run into problems.")
 
     def check_vsan_config_diff(self):

--- a/plugins/modules/vmware_cluster_vsan.py
+++ b/plugins/modules/vmware_cluster_vsan.py
@@ -170,7 +170,8 @@ class VMwareCluster(PyVmomi):
         vcMos = vsanapiutils.GetVsanVcMos(client_stub, context=ssl_context, version=apiVersion)
         self.vsanClusterConfigSystem = vcMos['vsan-cluster-config-system']
 
-        self.module.warn("The default value for enable will change from false to true in a future version in order to make the behavior more consistent with other modules. Please make sure your playbooks don't rely on the default being false so you don't run into problems.")
+        self.module.warn("The default value for enable will change from false to true in a future version in order to make the behavior more consistent with other modules."
+                         "Please make sure your playbooks don't rely on the default being false so you don't run into problems.")
 
     def check_vsan_config_diff(self):
         """

--- a/plugins/modules/vmware_cluster_vsan.py
+++ b/plugins/modules/vmware_cluster_vsan.py
@@ -37,11 +37,12 @@ options:
       type: str
       required: true
       aliases: [ datacenter_name ]
-    enable_vsan:
+    enable:
       description:
       - Whether to enable vSAN.
       type: bool
-      default: false
+      required: true
+      aliases: [ enable_vsan ]
     vsan_auto_claim_storage:
       description:
       - Whether the VSAN service is configured to automatically claim local storage
@@ -88,7 +89,7 @@ EXAMPLES = r'''
     password: '{{ vcenter_password }}'
     datacenter_name: datacenter
     cluster_name: cluster
-    enable_vsan: true
+    enable: true
   delegate_to: localhost
 
 - name: Enable vSAN and automatic rebalancing
@@ -98,7 +99,7 @@ EXAMPLES = r'''
     password: '{{ vcenter_password }}'
     datacenter_name: datacenter
     cluster_name: cluster
-    enable_vsan: true
+    enable: true
     advanced_options:
       automatic_rebalance: True
   delegate_to: localhost
@@ -110,7 +111,7 @@ EXAMPLES = r'''
     password: "{{ vcenter_password }}"
     datacenter_name: DC0
     cluster_name: "{{ cluster_name }}"
-    enable_vsan: True
+    enable: True
     vsan_auto_claim_storage: True
   delegate_to: localhost
 '''
@@ -147,7 +148,7 @@ class VMwareCluster(PyVmomi):
         super(VMwareCluster, self).__init__(module)
         self.cluster_name = module.params['cluster_name']
         self.datacenter_name = module.params['datacenter']
-        self.enable_vsan = module.params['enable_vsan']
+        self.enable_vsan = module.params['enable']
         self.datacenter = None
         self.cluster = None
         self.advanced_options = None
@@ -257,7 +258,7 @@ def main():
         cluster_name=dict(type='str', required=True),
         datacenter=dict(type='str', required=True, aliases=['datacenter_name']),
         # VSAN
-        enable_vsan=dict(type='bool', default=False),
+        enable=dict(type='bool', required=True, aliases=['enable_vsan']),
         vsan_auto_claim_storage=dict(type='bool', default=False),
         advanced_options=dict(type='dict', options=dict(
             automatic_rebalance=dict(type='bool', required=False),

--- a/tests/integration/targets/prepare_vmware_tests/tasks/setup_cluster.yml
+++ b/tests/integration/targets/prepare_vmware_tests/tasks/setup_cluster.yml
@@ -7,4 +7,4 @@
   vmware_cluster_drs:
     datacenter_name: '{{ dc1 }}'
     cluster_name: '{{ ccr1 }}'
-    enable_drs: true
+    enable: true

--- a/tests/integration/targets/vmware_cluster_drs/tasks/main.yml
+++ b/tests/integration/targets/vmware_cluster_drs/tasks/main.yml
@@ -42,7 +42,7 @@
     password: "{{ vcenter_password }}"
     datacenter_name: "{{ dc1 }}"
     cluster_name: test_cluster_drs
-    enable: false
+    enable_drs: false
   register: cluster_drs_result_0002
 
 - name: Ensure DRS is disabled

--- a/tests/integration/targets/vmware_cluster_drs/tasks/main.yml
+++ b/tests/integration/targets/vmware_cluster_drs/tasks/main.yml
@@ -25,7 +25,7 @@
     password: "{{ vcenter_password }}"
     datacenter_name: "{{ dc1 }}"
     cluster_name: test_cluster_drs
-    enable_drs: true
+    enable: true
   register: cluster_drs_result_0001
 
 - name: Ensure DRS is enabled
@@ -42,7 +42,7 @@
     password: "{{ vcenter_password }}"
     datacenter_name: "{{ dc1 }}"
     cluster_name: test_cluster_drs
-    enable_drs: false
+    enable: false
   register: cluster_drs_result_0002
 
 - name: Ensure DRS is disabled
@@ -52,6 +52,17 @@
 
 - when: vcsim is not defined
   block:
+  - name: Enable DRS for the following tests
+    vmware_cluster_drs:
+      validate_certs: false
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      datacenter_name: "{{ dc1 }}"
+      cluster_name: test_cluster_drs
+      enable: true
+    register: cluster_drs_result_0001
+
   - name: Change advanced setting "TryBalanceVmsPerHost" (check-mode)
     vmware_cluster_drs: &change_balance_vms
       validate_certs: false
@@ -60,6 +71,7 @@
       password: "{{ vcenter_password }}"
       datacenter_name: "{{ dc1 }}"
       cluster_name: test_cluster_drs
+      enable: true
       advanced_settings:
           'TryBalanceVmsPerHost': '1'
     check_mode: true
@@ -77,7 +89,7 @@
       that:
         - change_balance_vms.changed
 
-  - name: Change advanced setting "TryBalanceVmsPerHost" again
+  - name: Change advanced setting "TryBalanceVmsPerHost" again (idempotency)
     vmware_cluster_drs: *change_balance_vms
     register: change_balance_vms_again
 

--- a/tests/integration/targets/vmware_cluster_ha/tasks/main.yml
+++ b/tests/integration/targets/vmware_cluster_ha/tasks/main.yml
@@ -24,7 +24,7 @@
     password: "{{ vcenter_password }}"
     datacenter_name: "{{ dc1 }}"
     cluster_name: test_cluster_ha
-    enable_ha: true
+    enable: true
   register: enable_ha_result
 
 - name: Ensure HA is enabled
@@ -42,7 +42,7 @@
       password: "{{ vcenter_password }}"
       datacenter_name: "{{ dc1 }}"
       cluster_name: test_cluster_ha
-      enable_ha: true
+      enable: true
       apd_response: 'restartAggressive'
     check_mode: true
     register: change_apd_response_check
@@ -59,7 +59,7 @@
       that:
         - change_apd_response.changed
 
-  - name: Change APD response to "restartAggressive" again
+  - name: Change APD response to "restartAggressive" again (idempotency)
     vmware_cluster_ha: *change_apd_response
     register: change_apd_response_again
 
@@ -75,7 +75,7 @@
       password: "{{ vcenter_password }}"
       datacenter_name: "{{ dc1 }}"
       cluster_name: test_cluster_ha
-      enable_ha: true
+      enable: true
 
   - name: Change PDL response to "restartAggressive" (check-mode)
     vmware_cluster_ha: &change_pdl_response
@@ -85,7 +85,7 @@
       password: "{{ vcenter_password }}"
       datacenter_name: "{{ dc1 }}"
       cluster_name: test_cluster_ha
-      enable_ha: true
+      enable: true
       pdl_response: 'restartAggressive'
     check_mode: true
     register: change_pdl_response_check
@@ -118,7 +118,7 @@
       password: "{{ vcenter_password }}"
       datacenter_name: "{{ dc1 }}"
       cluster_name: test_cluster_ha
-      enable_ha: true
+      enable: true
 
   - name: Enable Slot based Admission Control
     vmware_cluster_ha:
@@ -128,7 +128,7 @@
       password: "{{ vcenter_password }}"
       datacenter_name: "{{ dc1 }}"
       cluster_name: test_cluster_ha
-      enable_ha: true
+      enable: true
       slot_based_admission_control:
         failover_level: 1
     register: enable_slot_based_admission_control_result
@@ -146,7 +146,7 @@
       password: "{{ vcenter_password }}"
       datacenter_name: "{{ dc1 }}"
       cluster_name: test_cluster_ha
-      enable_ha: true
+      enable: true
       reservation_based_admission_control:
         auto_compute_percentages: false
         failover_level: 1
@@ -167,7 +167,7 @@
       password: "{{ vcenter_password }}"
       datacenter_name: "{{ dc1 }}"
       cluster_name: test_cluster_ha
-      enable_ha: true
+      enable: true
       host_isolation_response: 'powerOff'
     register: isolation_response_poweroff_result
 
@@ -184,7 +184,7 @@
       password: "{{ vcenter_password }}"
       datacenter_name: "{{ dc1 }}"
       cluster_name: test_cluster_ha
-      enable_ha: true
+      enable: true
       host_isolation_response: 'shutdown'
     register: isolation_response_shutdown_result
 
@@ -201,7 +201,7 @@
       password: "{{ vcenter_password }}"
       datacenter_name: "{{ dc1 }}"
       cluster_name: test_cluster_ha
-      enable_ha: true
+      enable: true
       advanced_settings:
           'das.heartbeatDsPerHost': '4'
     check_mode: true
@@ -235,7 +235,7 @@
       password: "{{ vcenter_password }}"
       datacenter_name: "{{ dc1 }}"
       cluster_name: test_cluster_ha
-      enable_ha: true
+      enable: true
       advanced_settings:
           'das.includeFTcomplianceChecks': 'False'
     check_mode: true
@@ -269,7 +269,7 @@
       password: "{{ vcenter_password }}"
       datacenter_name: "{{ dc1 }}"
       cluster_name: test_cluster_ha
-      enable_ha: false
+      enable: false
     register: disable_ha_result
 
   - name: Ensure HA is disabled

--- a/tests/integration/targets/vmware_cluster_ha/tasks/main.yml
+++ b/tests/integration/targets/vmware_cluster_ha/tasks/main.yml
@@ -32,6 +32,22 @@
     that:
       - enable_ha_result.changed
 
+- name: Disable HA
+  vmware_cluster_ha:
+    validate_certs: false
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter_name: "{{ dc1 }}"
+    cluster_name: test_cluster_ha
+    enable_ha: false
+  register: disable_ha_result
+
+- name: Ensure HA is disabled
+  assert:
+    that:
+      - disable_ha_result.changed
+
 - when: vcsim is not defined
   block:
   - name: Change APD response to "restartAggressive" (check-mode)

--- a/tests/integration/targets/vmware_cluster_vsan/tasks/main.yml
+++ b/tests/integration/targets/vmware_cluster_vsan/tasks/main.yml
@@ -27,7 +27,7 @@
         password: "{{ vcenter_password }}"
         datacenter_name: "{{ dc1 }}"
         cluster_name: test_cluster_vsan
-        enable_vsan: true
+        enable: true
       register: cluster_vsan_result_0001
 
     - name: Ensure vSAN is enabled
@@ -44,7 +44,7 @@
         password: "{{ vcenter_password }}"
         datacenter_name: "{{ dc1 }}"
         cluster_name: test_cluster_vsan
-        enable_vsan: true
+        enable: true
       register: cluster_vsan_result_0002
 
     - name: Ensure vSAN is not enabled again
@@ -61,7 +61,7 @@
         password: "{{ vcenter_password }}"
         datacenter_name: "{{ dc1 }}"
         cluster_name: test_cluster_vsan
-        enable_vsan: true
+        enable: true
         advanced_options:
           object_repair_timer: 67
       register: cluster_vsan_result_0003
@@ -80,7 +80,7 @@
         password: "{{ vcenter_password }}"
         datacenter_name: "{{ dc1 }}"
         cluster_name: test_cluster_vsan
-        enable_vsan: true
+        enable: true
         advanced_options:
           object_repair_timer: 67
       register: cluster_vsan_result_0004
@@ -99,7 +99,7 @@
         password: "{{ vcenter_password }}"
         datacenter_name: "{{ dc1 }}"
         cluster_name: test_cluster_vsan
-        enable_vsan: false
+        enable: false
       register: cluster_vsan_result_0005
 
     - name: Ensure vSAN is disabled
@@ -116,7 +116,7 @@
         password: "{{ vcenter_password }}"
         datacenter_name: "{{ dc1 }}"
         cluster_name: test_cluster_vsan
-        enable_vsan: false
+        enable: false
       register: cluster_vsan_result_0006
 
     - name: Ensure vSAN is not disabled again

--- a/tests/integration/targets/vmware_cluster_vsan/tasks/main.yml
+++ b/tests/integration/targets/vmware_cluster_vsan/tasks/main.yml
@@ -44,7 +44,7 @@
         password: "{{ vcenter_password }}"
         datacenter_name: "{{ dc1 }}"
         cluster_name: test_cluster_vsan
-        enable: true
+        enable_vsan: true
       register: cluster_vsan_result_0002
 
     - name: Ensure vSAN is not enabled again


### PR DESCRIPTION
Depends-On: ansible/ansible-zuul-jobs#869

##### SUMMARY
If the user does not specify this parameter explicitly by setting it to Yes (True), then the consequences for the cluster can be destructive, because disabling DRS destroys the entire Resourse Pools tree. For some environments (eg VCD, VRA) the consequences will be disastrous.

~~I don't want to just change the default from `false` to `true` because this will lead to playbooks behaving differently after updating the collection; making this a required parameter might make playbooks fail but I think this is still better than changing the default behavior.~~

Since this is a breaking change, I'll only announce that the default will change in the future.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_cluster_drs
vmware_cluster_ha
vmware_cluster_vsan

##### ADDITIONAL INFORMATION
See issue #739 

I'm not really sure about HA and VSAN but in order to get a consistent user experience when configuring DRS / HA / VSAN I'd like to ~~make this a required parameter~~ change the default in `vmware_cluster_ha` and `vmware_cluster_vsan`, too.

Additionally, `enable_drs/ha/vsan` seems a bit redundant to me in modules configuring DRS / HA / VSAN so I've aliased them to a new parameter `enable`.