### PR TITLE
vmware_guest_storage_policy: test: don't clean up the test VM

### DIFF
--- a/tests/integration/targets/vmware_guest_storage_policy/tasks/main.yml
+++ b/tests/integration/targets/vmware_guest_storage_policy/tasks/main.yml
@@ -166,24 +166,6 @@
           - disk_sp_idp.changed_policies.disk == []
 
   always:
-    - name: "007: Cleanup: Rollback storage policy profile"
-      vmware_guest_storage_policy:
-        hostname: "{{ vcenter_hostname }}"
-        username: "{{ vcenter_username }}"
-        password: "{{ vcenter_password }}"
-        validate_certs: false
-        name: "{{ virtual_machines[0].name }}"
-        vm_home: "{{ existing_profiles.spbm_profiles[0].name }}"
-        disk:
-          - unit_number: "{{ unit_number }}"
-            policy: "{{ existing_profiles.spbm_profiles[0].name }}"
-      register: rollback_storage_policy
-
-    - name: "007: assert that changes were made"
-      assert:
-        that:
-          - rollback_storage_policy is changed
-
     - name: "Cleanup: Delete Tag"
       vmware_tag:
         hostname: "{{ vcenter_hostname }}"


### PR DESCRIPTION
The test VM will be removed later anyway. By doing this, we avoid the
following error:

"msg": "Unable to find the datastore with given parameters. This could mean, DC0_H0_VM1 is a non-existent virtual machine and module tried to deploy it as new virtual machine with no disk. Please specify disks parameter or specify template to clone from."