### PR TITLE
vmware_guest_storage_policy: test need datastore

### DIFF
--- a/tests/integration/targets/vmware_guest_storage_policy/tasks/main.yml
+++ b/tests/integration/targets/vmware_guest_storage_policy/tasks/main.yml
@@ -8,6 +8,7 @@
         name: prepare_vmware_tests
       vars:
         setup_attach_host: true
+        setup_datastore: true
         setup_virtualmachines: true
 
     - name: "Setup: find existing storage profile(s) for later rollback"


### PR DESCRIPTION
The tests need a datastore to host the VM.