### PR TITLE
Clarify is_template parameter docs

### DIFF
--- a/docs/community.vmware.vmware_guest_module.rst
+++ b/docs/community.vmware.vmware_guest_module.rst
@@ -1420,6 +1420,9 @@ Parameters
                 <td>
                         <div>Flag the instance as a template.</div>
                         <div>This will mark the given virtual machine as template.</div>
+                        <div>This may need to be done in a dedicated task invocation that is not making</div>
+                        <div>any other changes, e.g. you cannot change the state from powered-on to </div>
+                        <div>powered-off AND save as template in the same task.</div>
                 </td>
             </tr>
             <tr>


### PR DESCRIPTION
##### SUMMARY
It appears to be "tribal knowledge" that one cannot expect for is_template to take effect when also performing other actions in vmware_guest task invocation, e.g. changing power state. Here I attempt to simply make this knowledge explicit in the docs. Please supplement my statement with additional information if you have it.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
vmware_guest

##### ADDITIONAL INFORMATION
I stumbled over this "feature" when trying to simply save an existing VM as a template. In my case the machine had been previously cloned (from a template) and provisioned. In one final step, I tried to power it off and save it as a template. The task was "successful" in that the power state changed, but the machine was NOT saved as a template (and indeed `instance.hw_is_template: false`). 

After doing some reading online (reddit, stack overflow, NOT here in the repo issues) I found people that had suggested that the `is_template` and other params of the vmware_guest module might mysteriously not work when "trying to do too much" and to always try to break individual actions into separate task invocations to troubleshoot problems.

Please, please, help me make the docs for vmware_guest more useful to users. There appears to be a lot of this "tribal knowledge" that is not reflected in the module docs. This PR is but one such instance. 