### PR TITLE
vmware_vm_storage_policy_info: Fix an issue that the module can't get the info when the policy has the tag base rules

### DIFF
--- a/changelogs/fragments/788-vmware_vm_storage_policy_info.yml
+++ b/changelogs/fragments/788-vmware_vm_storage_policy_info.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_vm_storage_policy_info - fixed an issue that the module can't get storage policy info when the policy has the tag base rules (https://github.com/ansible-collections/community.vmware/pull/788).

--- a/plugins/modules/vmware_vm_storage_policy_info.py
+++ b/plugins/modules/vmware_vm_storage_policy_info.py
@@ -135,9 +135,15 @@ class SPBMClient(SPBM):
                 subprofiles = profile.constraints.subProfiles
                 temp_sub_profiles = []
                 for subprofile in subprofiles:
+                    rule_set_info = self.show_capabilities(subprofile.capability)
+                    # if a storage policy set tag base placement rules, the tags are set into the value.
+                    # https://github.com/ansible-collections/community.vmware/issues/742
+                    for _rule_set_info in rule_set_info:
+                        if isinstance(_rule_set_info['value'], pbm.capability.types.DiscreteSet):
+                            _rule_set_info['value'] = _rule_set_info['value'].values
                     temp_sub_profiles.append({
                         'rule_set_name': subprofile.name,
-                        'rule_set_info': self.show_capabilities(subprofile.capability),
+                        'rule_set_info': rule_set_info,
                     })
                 temp_profile_info['constraints_sub_profiles'] = temp_sub_profiles
 


### PR DESCRIPTION
Depends-On: ansible/ansible-zuul-jobs#869

##### SUMMARY

The module has a bug that it can't get storage policy info when the policy has the tag base rules.  
This PR will fix the bug.

fixes: https://github.com/ansible-collections/community.vmware/issues/742

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

plugins/modules/vmware_vm_storage_policy_info.py

##### ADDITIONAL INFORMATION

tested on vCenter 7.0