### PR TITLE
Adding GuestOs Customization for Instant Clone feature

### DIFF
--- a/changelogs/fragments/796-vmware_guest_instant_clone.yml
+++ b/changelogs/fragments/796-vmware_guest_instant_clone.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - vmware_guest_instant_clone - added the the guestinfo_vars parameter to provide GuestOS Customization functionality in instant cloned VM (https://github.com/ansible-collections/community.vmware/pull/796).
+ 

--- a/plugins/modules/vmware_guest_instant_clone.py
+++ b/plugins/modules/vmware_guest_instant_clone.py
@@ -21,7 +21,9 @@ description:
 - M(community.vmware.vmware_guest_powerstate) module is also needed to poweroff the instant cloned module.
 - The powered off VM would in turn be deleted by again using M(community.vmware.vmware_guest) module.
 - Thus M(community.vmware.vmware_guest) module is necessary for removing Instant Cloned VM when VMs being created in testing environment.
-
+- Also GuestOS Customization has now been added with guestinfo_vars parameter.
+- The Parent VM must have The Guest customization Engine for instant Clone to customize Guest OS.
+- Only Linux Os in Parent VM enable support for native vSphere Guest Customization for Instant Clone in vSphere 7.
 options:
   name:
     description:
@@ -84,7 +86,52 @@ options:
       - C(Resources) is the default name of resource pool.
     type: str
     required: False
-
+  vm_username:
+    description:
+      - The user to login-in to the virtual machine.
+      - Only required when using guest customization feature.
+    required: False
+    type: str
+  vm_password:
+    description:
+      - The password used to login-in to the virtual machine.
+      - Only required when using guest customization feature.
+    required: False
+    type: str
+  guestinfo_vars:
+    description:
+      - Provides GuestOS Customization functionality in instant cloned VM.
+      - A list of key value pairs that will be passed to the destination VM.
+      - These pairs should be used to provide user-defined customization to differentiate the destination VM from the source VM.
+    suboptions:
+      hostname:
+        description:
+          - hostname is used to obtain the DNS(Domain Name System) name and set the Guest system's hostname.
+        type: str
+      ipaddress:
+        description:
+          - ipaddress is used to set the ipaddress in Instant Cloned Guest Operating System.
+        type: str
+      netmask:
+        description:
+          - netmask is used to set the netmask in Instant Cloned Guest Operating System.
+        type: str
+      gateway:
+        description:
+          - netmask is used to set the netmask in Instant Cloned Guest Operating System.
+        type: str
+      dns:
+        description:
+          - dns is used to set the dns in Instant Cloned Guest Operating System..
+        type: str
+      domain:
+        description:
+          - domain is used to set A fully qualified domain name (FQDN) or complete domain name for Instant Cloned Guest operating System.
+        type: str
+    version_added: '1.11.0'
+    default: []
+    type: list
+    elements: dict
 extends_documentation_fragment:
 - community.vmware.vmware.documentation
 
@@ -134,6 +181,31 @@ EXAMPLES = r'''
     state: absent
   register: delete_instant_clone_from_vm_when_cluster
   ignore_errors: true
+  delegate_to: localhost
+
+- name: Instant Clone a VM with guest_customization
+  community.vmware.vmware_guest_instant_clone:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    vm_username: "root"
+    vm_password: "SuperSecret"
+    validate_certs: False
+    folder: "{{ f0 }}"
+    datastore: "{{ rw_datastore }}"
+    datacenter: "{{ dc1 }}"
+    host: "{{ esxi1 }}"
+    guestinfo_vars:
+      - hostname: "{{ guestinfo.ic.hostname }}"
+        ipaddress: "{{ guestinfo.ic.ipaddress }}"
+        netmask: "{{ guestinfo.ic.netmask }}"
+        gateway: "{{ guestinfo.ic.gateway }}"
+        dns: "{{ guestinfo.ic.dns }}"
+        domain: "{{ guestinfo.ic.domain }}"
+    name: "Instant_clone_guest_customize"
+    parent_vm: "test_vm1"
+    resource_pool: DC0_C0_RP1
+  register: Instant_cloned_guest_customize
   delegate_to: localhost
 
 - name: Instant Clone a VM when skipping optional params
@@ -225,6 +297,7 @@ class VmwareGuestInstantClone(PyVmomi):
         self.uuid = self.params.get('uuid')
         self.port = self.params.get('port')
         self.use_instance_uuid = self.params.get('use_instance_uuid')
+        self.guestinfo_vars = self.params.get('guestinfo_vars')
 
     def get_new_vm_info(self, vm):
         # to check if vm has been cloned in the destination vc
@@ -255,6 +328,56 @@ class VmwareGuestInstantClone(PyVmomi):
             result = {'changed': True, 'failed': False, 'vm_info': vm_info}
         except TaskError as task_e:
             self.module.fail_json(msg=to_native(task_e))
+
+        self.destination_content = connect_to_api(
+            self.module,
+            hostname=self.hostname,
+            username=self.username,
+            password=self.password,
+            port=self.port,
+            validate_certs=self.validate_certs)
+
+        vm_IC = find_vm_by_name(content=self.destination_content, vm_name=self.params['name'])
+        if vm_IC and self.params.get('guestinfo_vars'):
+            guest_custom_mng = self.destination_content.guestCustomizationManager
+            # Make an object for authentication in a guest OS
+            auth_obj = vim.vm.guest.NamePasswordAuthentication()
+
+            guest_user = self.params.get('vm_username')
+            guest_password = self.params.get('vm_password')
+            auth_obj.username = guest_user
+            auth_obj.password = guest_password
+
+            guestinfo_vars = self.params.get('guestinfo_vars')
+            # Make a spec object to customize Guest OS
+            customization_spec = vim.vm.customization.Specification()
+            customization_spec.globalIPSettings = vim.vm.customization.GlobalIPSettings()
+            customization_spec.globalIPSettings.dnsServerList = [guestinfo_vars[0]['dns']]
+            # Make an identity object to do linux prep
+            # The params are reflected the specified following after rebooting OS
+            customization_spec.identity = vim.vm.customization.LinuxPrep()
+            customization_spec.identity.domain = guestinfo_vars[0]['domain']
+            customization_spec.identity.hostName = vim.vm.customization.FixedName()
+            customization_spec.identity.hostName.name = guestinfo_vars[0]['hostname']
+
+            customization_spec.nicSettingMap = []
+            adapter_mapping_obj = vim.vm.customization.AdapterMapping()
+            adapter_mapping_obj.adapter = vim.vm.customization.IPSettings()
+            adapter_mapping_obj.adapter.ip = vim.vm.customization.FixedIp()
+            adapter_mapping_obj.adapter.ip.ipAddress = guestinfo_vars[0]['ipaddress']
+            adapter_mapping_obj.adapter.subnetMask = guestinfo_vars[0]['netmask']
+            adapter_mapping_obj.adapter.gateway = [guestinfo_vars[0]['gateway']]
+
+            customization_spec.nicSettingMap.append(adapter_mapping_obj)
+
+            task_guest = guest_custom_mng.CustomizeGuest_Task(vm_IC, auth_obj, customization_spec)
+            try:
+                wait_for_task(task_guest)
+                vm_info = self.get_new_vm_info(self.vm_name)
+                result = {'changed': True, 'failed': False, 'vm_info': vm_info}
+            except TaskError as task_e:
+                self.module.fail_json(msg=to_native(task_e))
+
         return result
 
     def sanitize_params(self):
@@ -331,6 +454,21 @@ class VmwareGuestInstantClone(PyVmomi):
         else:
             self.resource_pool = self.host.parent.resourcePool
 
+        if self.params['guestinfo_vars']:
+            self.guestinfo_vars = self.dict_to_optionvalues()
+        else:
+            self.guestinfo_vars = None
+
+    def dict_to_optionvalues(self):
+        optionvalues = []
+        for dictionary in self.params['guestinfo_vars']:
+            for key, value in dictionary.items():
+                opt = vim.option.OptionValue()
+                (opt.key, opt.value) = ("guestinfo.ic." + key, value)
+                optionvalues.append(opt)
+
+        return optionvalues
+
     def populate_specs(self):
 
         # populate relocate spec
@@ -340,6 +478,7 @@ class VmwareGuestInstantClone(PyVmomi):
         # populate Instant clone spec
         self.instant_clone_spec.name = self.vm_name
         self.instant_clone_spec.location = self.relocate_spec
+        self.instant_clone_spec.config = self.guestinfo_vars
 
 
 def main():
@@ -348,13 +487,28 @@ def main():
         name=dict(type='str', required=True, aliases=['vm_name']),
         uuid=dict(type='str'),
         moid=dict(type='str'),
+        vm_username=dict(type='str', required=False),
+        vm_password=dict(type='str', no_log=True, required=False),
         datacenter=dict(type='str', required=True),
         datastore=dict(type='str', required=True),
         use_instance_uuid=dict(type='bool', default=False),
         host=dict(type='str', required=True, aliases=['esxi_hostname']),
         folder=dict(type='str', required=False),
         resource_pool=dict(type='str', required=False),
-        parent_vm=dict(type='str')
+        parent_vm=dict(type='str'),
+        guestinfo_vars=dict(
+            type='list',
+            default=[],
+            elements='dict',
+            options=dict(
+                ipaddress=dict(type='str'),
+                netmask=dict(type='str'),
+                gateway=dict(type='str'),
+                dns=dict(type='str'),
+                domain=dict(type='str'),
+                hostname=dict(type='str'),
+            ),
+        ),
     )
     module = AnsibleModule(
         argument_spec=argument_spec,

--- a/tests/integration/targets/vmware_guest_instant_clone/tasks/main.yml
+++ b/tests/integration/targets/vmware_guest_instant_clone/tasks/main.yml
@@ -11,7 +11,7 @@
     setup_resource_pool: true
 
 - name: Create VM
-  vmware_guest:
+  community.vmware.vmware_guest:
     validate_certs: false
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
@@ -35,7 +35,7 @@
 - when: vcsim is not defined
   block:
   - name: Instant Clone a VM with parent VM
-    vmware_guest_instant_clone:
+    community.vmware.vmware_guest_instant_clone:
       hostname: "{{ vcenter_hostname }}"
       username: "{{ vcenter_username }}"
       password: "{{ vcenter_password }}"
@@ -55,7 +55,7 @@
           - instant_clone_from_vm_parent is changed
 
   - name: Instant Clone a VM when datastore cluster is specified
-    vmware_guest_instant_clone:
+    community.vmware.vmware_guest_instant_clone:
       hostname: "{{ vcenter_hostname }}"
       username: "{{ vcenter_username }}"
       password: "{{ vcenter_password }}"
@@ -75,7 +75,7 @@
           - instant_clone_from_vm_when_cluster_is_specified is changed
 
   - name: set state to poweroff the Cloned VM
-    vmware_guest_powerstate:
+    community.vmware.vmware_guest_powerstate:
       validate_certs: false
       hostname: "{{ vcenter_hostname }}"
       username: "{{ vcenter_username }}"
@@ -89,7 +89,7 @@
       var: poweroff_instant_clone_from_vm_when_cluster
 
   - name: Clean VM
-    vmware_guest:
+    community.vmware.vmware_guest:
       validate_certs: false
       hostname: "{{ vcenter_hostname }}"
       username: "{{ vcenter_username }}"
@@ -104,7 +104,7 @@
 
 
   - name: Instant Clone a VM when skipping optional params
-    vmware_guest_instant_clone:
+    community.vmware.vmware_guest_instant_clone:
       hostname: "{{ vcenter_hostname }}"
       username: "{{ vcenter_username }}"
       password: "{{ vcenter_password }}"
@@ -122,7 +122,7 @@
           - instant_clone_from_vm_optional_arguments is changed
 
   - name: set state to poweroff the Cloned VM
-    vmware_guest_powerstate:
+    community.vmware.vmware_guest_powerstate:
       validate_certs: false
       hostname: "{{ vcenter_hostname }}"
       username: "{{ vcenter_username }}"
@@ -135,7 +135,7 @@
       var: poweroff_instant_clone_from_vm_optional_arguments
 
   - name: Clean VM
-    vmware_guest:
+    community.vmware.vmware_guest:
       validate_certs: false
       hostname: "{{ vcenter_hostname }}"
       username: "{{ vcenter_username }}"
@@ -149,7 +149,7 @@
   - debug: var=delete_instant_clone_from_vm_optional_arguments
 
   - name: Instant Clone a VM with moid
-    vmware_guest_instant_clone:
+    community.vmware.vmware_guest_instant_clone:
       hostname: "{{ vcenter_hostname }}"
       username: "{{ vcenter_username }}"
       password: "{{ vcenter_password }}"
@@ -169,7 +169,7 @@
           - instant_clone_from_vm_moid is changed
 
   - name: set state to poweroff the Cloned VM
-    vmware_guest_powerstate:
+    community.vmware.vmware_guest_powerstate:
       validate_certs: false
       hostname: "{{ vcenter_hostname }}"
       username: "{{ vcenter_username }}"
@@ -183,7 +183,7 @@
       var: poweroff_instant_clone_from_vm_moid
 
   - name: Clean VM
-    vmware_guest:
+    community.vmware.vmware_guest:
       validate_certs: false
       hostname: "{{ vcenter_hostname }}"
       username: "{{ vcenter_username }}"
@@ -197,7 +197,7 @@
   - debug: var=delete_instant_clone_from_vm_moid
 
   - name: Instant Clone a VM with instance_uuid
-    vmware_guest_instant_clone:
+    community.vmware.vmware_guest_instant_clone:
       hostname: "{{ vcenter_hostname }}"
       username: "{{ vcenter_username }}"
       password: "{{ vcenter_password }}"
@@ -218,7 +218,7 @@
           - instant_clone_from_vm_instance_uuid is changed
 
   - name: set state to poweroff the Cloned VM
-    vmware_guest_powerstate:
+    community.vmware.vmware_guest_powerstate:
       validate_certs: false
       hostname: "{{ vcenter_hostname }}"
       username: "{{ vcenter_username }}"
@@ -232,7 +232,7 @@
       var: poweroff_instant_clone_from_vm_instance_uuid
 
   - name: Clean VM
-    vmware_guest:
+    community.vmware.vmware_guest:
       validate_certs: false
       hostname: "{{ vcenter_hostname }}"
       username: "{{ vcenter_username }}"
@@ -246,7 +246,7 @@
   - debug: var=delete_instant_clone_from_vm_instance_uuid
 
   - name: Instant Clone a VM with uuid
-    vmware_guest_instant_clone:
+    community.vmware.vmware_guest_instant_clone:
       hostname: "{{ vcenter_hostname }}"
       username: "{{ vcenter_username }}"
       password: "{{ vcenter_password }}"
@@ -266,7 +266,7 @@
           - instant_clone_from_vm_uuid is changed
 
   - name: set state to poweroff the VM
-    vmware_guest_powerstate:
+    community.vmware.vmware_guest_powerstate:
       validate_certs: false
       hostname: "{{ vcenter_hostname }}"
       username: "{{ vcenter_username }}"
@@ -280,7 +280,7 @@
       var: poweroff_instant_clone_from_vm_uuid
 
   - name: Clean VM
-    vmware_guest:
+    community.vmware.vmware_guest:
       validate_certs: false
       hostname: "{{ vcenter_hostname }}"
       username: "{{ vcenter_username }}"
@@ -294,7 +294,7 @@
   - debug: var=delete_instant_clone_from_vm_uuid
 
   - name: Instant clone in check mode
-    vmware_guest_instant_clone:
+    community.vmware.vmware_guest_instant_clone:
       hostname: "{{ vcenter_hostname }}"
       username: "{{ vcenter_username }}"
       password: "{{ vcenter_password }}"
@@ -313,7 +313,7 @@
       var: check_mode_instant_clone
 
   - name:  idempotency check - VM name already exists
-    vmware_guest_instant_clone:
+    community.vmware.vmware_guest_instant_clone:
       hostname: "{{ vcenter_hostname }}"
       username: "{{ vcenter_username }}"
       password: "{{ vcenter_password }}"
@@ -331,7 +331,7 @@
       var: idempotency_check
 
   - name: set state to poweroff the Cloned VM
-    vmware_guest_powerstate:
+    community.vmware.vmware_guest_powerstate:
       validate_certs: false
       hostname: "{{ vcenter_hostname }}"
       username: "{{ vcenter_username }}"
@@ -345,7 +345,7 @@
       var: poweroff_instant_clone_from_vm_parent
 
   - name: Clean VM
-    vmware_guest:
+    community.vmware.vmware_guest:
       validate_certs: false
       hostname: "{{ vcenter_hostname }}"
       username: "{{ vcenter_username }}"
@@ -359,7 +359,7 @@
   - debug: var=delete_instant_clone_from_vm_parent
 
   - name: set state to poweroff the parent VM
-    vmware_guest_powerstate:
+    community.vmware.vmware_guest_powerstate:
       validate_certs: false
       hostname: "{{ vcenter_hostname }}"
       username: "{{ vcenter_username }}"
@@ -373,7 +373,7 @@
       var: poweroff_instant_clone_from_vm_parent
 
   - name: Clean parent VM
-    vmware_guest:
+    community.vmware.vmware_guest:
       validate_certs: false
       hostname: "{{ vcenter_hostname }}"
       username: "{{ vcenter_username }}"


### PR DESCRIPTION
##### SUMMARY
Adding GuestOS Customization feature for Instant Cloned VM

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_guest_instant_clone module

##### ADDITIONAL INFORMATION
- Provides GuestOS Customization functionality in instant cloned VM.
- A list of key-value pairs will be passed to the destination VM.
- These pairs should be used to provide user-defined customization to differentiate the destination VM from the source VM.

