### PR TITLE
ignore objects that are removed during get_all_objs execution

### DIFF
--- a/changelogs/fragments/791_vmware.yml
+++ b/changelogs/fragments/791_vmware.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- vmware - handle exception raised in ``get_all_objs`` which occurs due to multiple parallel operations (https://github.com/ansible-collections/community.vmware/issues/791).

--- a/changelogs/fragments/791_vmware.yml
+++ b/changelogs/fragments/791_vmware.yml
@@ -1,2 +1,2 @@
 bugfixes:
-- vmware - handle exception raised in ``get_all_objs`` which occurs due to multiple parallel operations (https://github.com/ansible-collections/community.vmware/issues/791).
+- vmware - handle exception raised in ``get_all_objs`` and ``find_object_by_name`` which occurs due to multiple parallel operations (https://github.com/ansible-collections/community.vmware/issues/791).

--- a/plugins/module_utils/vmware.py
+++ b/plugins/module_utils/vmware.py
@@ -136,8 +136,11 @@ def find_object_by_name(content, name, obj_type, folder=None, recurse=True):
 
     objects = get_all_objs(content, obj_type, folder=folder, recurse=recurse)
     for obj in objects:
-        if unquote(obj.name) == name:
-            return obj
+        try:
+            if unquote(obj.name) == name:
+                return obj
+        except vmodl.fault.ManagedObjectNotFound:
+            pass
 
     return None
 
@@ -648,7 +651,10 @@ def get_all_objs(content, vimtype, folder=None, recurse=True):
     obj = {}
     container = content.viewManager.CreateContainerView(folder, vimtype, recurse)
     for managed_object_ref in container.view:
-        obj.update({managed_object_ref: managed_object_ref.name})
+        try:
+            obj.update({managed_object_ref: managed_object_ref.name})
+        except vmodl.fault.ManagedObjectNotFound:
+            pass
     return obj
 
 


### PR DESCRIPTION
### FIXES [#791](https://github.com/ansible-collections/community.vmware/issues/791)

Example: a host is removed during the execution of get_all_objs as you are getting all hosts.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When vmhosts are being deleted/removed from inventory and you run get_all_objs, the following failure message appears
"The object 'vim.HostSystem:host-3406' has already been deleted or has not been completely created".
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware.py
