### PR TITLE
[WIP] vmware_object_role_permission: Add a note for using the module when ESXi only environment

### DIFF
--- a/docs/community.vmware.vmware_object_role_permission_module.rst
+++ b/docs/community.vmware.vmware_object_role_permission_module.rst
@@ -319,6 +319,18 @@ Examples
 
 .. code-block:: yaml
 
+    - name: Assing Admin permission to local user in ESXi without vCenter
+      community.vmware.vmware_object_role_permission:
+        hostname: '{{ esxi_hostname }}'
+        username: '{{ esxi_username }}'
+        password: '{{ esxi_password }}'
+        role: Admin
+        principal: user_bob
+        object_name: rootFolder
+        object_type: Folder
+        state: present
+      delegate_to: localhost
+
     - name: Assign user to VM folder
       community.vmware.vmware_object_role_permission:
         hostname: '{{ esxi_hostname }}'

--- a/docs/community.vmware.vmware_object_role_permission_module.rst
+++ b/docs/community.vmware.vmware_object_role_permission_module.rst
@@ -309,6 +309,7 @@ Notes
 .. note::
    - Tested on ESXi 6.5, vSphere 6.7
    - The ESXi login user must have the appropriate rights to administer permissions.
+   - If you want to assign permission to a user on ESXi without vCenter, you need *object_name* set to ``rootFolder`` and *object_type* set to ``Folder``.
    - Permissions for a distributed switch must be defined and managed on either the datacenter or a folder containing the switch.
 
 

--- a/plugins/modules/vmware_object_role_permission.py
+++ b/plugins/modules/vmware_object_role_permission.py
@@ -22,6 +22,7 @@ author:
 notes:
     - Tested on ESXi 6.5, vSphere 6.7
     - The ESXi login user must have the appropriate rights to administer permissions.
+    - If you want to assign permission to a user on ESXi without vCenter, you need I(object_name) set to C(rootFolder) and I(object_type) set to C(Folder).
     - Permissions for a distributed switch must be defined and managed on either the datacenter or a folder containing the switch.
 requirements:
     - "python >= 2.7"

--- a/plugins/modules/vmware_object_role_permission.py
+++ b/plugins/modules/vmware_object_role_permission.py
@@ -77,6 +77,18 @@ extends_documentation_fragment:
 '''
 
 EXAMPLES = r'''
+- name: Assing Admin permission to local user in ESXi without vCenter
+  community.vmware.vmware_object_role_permission:
+    hostname: '{{ esxi_hostname }}'
+    username: '{{ esxi_username }}'
+    password: '{{ esxi_password }}'
+    role: Admin
+    principal: user_bob
+    object_name: rootFolder
+    object_type: Folder
+    state: present
+  delegate_to: localhost
+
 - name: Assign user to VM folder
   community.vmware.vmware_object_role_permission:
     hostname: '{{ esxi_hostname }}'


### PR DESCRIPTION
##### SUMMARY

The following conditions were necessary that the module works fine in the ESXi environment without vCenter.

```
        object_name: rootFolder
        object_type: Folder
```

I seem that this thing didn't write in the module documentation.  
So, this PR will add a note for using the module when ESXi only environment.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

docs/community.vmware.vmware_object_role_permission_module.rst
plugins/modules/vmware_object_role_permission.py

##### ADDITIONAL INFORMATION

Tested on ESXi 7.0