### PR TITLE
vmware_vmotion: Fail when required ESXi host is not found

### DIFF
--- a/changelogs/fragments/803-vmware_vmotion-better-error-msg.yml
+++ b/changelogs/fragments/803-vmware_vmotion-better-error-msg.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - vmware_vmotion - Provide an meaningful error message when providing a bad ESXi node as ``destination_host``
+    (https://github.com/ansible-collections/vmware/pull/804).

--- a/plugins/modules/vmware_vmotion.py
+++ b/plugins/modules/vmware_vmotion.py
@@ -166,6 +166,9 @@ class VmotionManager(PyVmomi):
         if dest_host_name is not None:
             self.host_object = find_hostsystem_by_name(content=self.content,
                                                        hostname=dest_host_name)
+            if self.host_object is None:
+                self.module.fail_json(msg="Unable to find destination host %s" % dest_host_name)
+
 
         # Get Destination Datastore if specified by user
         dest_datastore = self.params.get('destination_datastore', None)
@@ -189,7 +192,7 @@ class VmotionManager(PyVmomi):
             self.resourcepool_object = self.host_object.parent.resourcePool
         # Fail if resourcePool object is not found
         if self.resourcepool_object is None:
-            self.module.fail_json(msg="Unable to destination resource pool object which is required")
+            self.module.fail_json(msg="Unable to find destination resource pool object which is required")
 
         # Check if datastore is required, this check is required if destination
         # and source host system does not share same datastore.

--- a/plugins/modules/vmware_vmotion.py
+++ b/plugins/modules/vmware_vmotion.py
@@ -169,7 +169,6 @@ class VmotionManager(PyVmomi):
             if self.host_object is None:
                 self.module.fail_json(msg="Unable to find destination host %s" % dest_host_name)
 
-
         # Get Destination Datastore if specified by user
         dest_datastore = self.params.get('destination_datastore', None)
         self.datastore_object = None


### PR DESCRIPTION
This is a proposition of fix for #803.
I also added a missing «find» in another error message.

##### SUMMARY
Fixes #803 by adding an explicit error message.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- `vmware_vmotion` module

##### ADDITIONAL INFORMATION
Please, review this PR twice, as I'm testing only one use case:
- `destination_host` defined (correctly and wrongly) and `destination_datastore` defined

According to the code other cases could be valid but not tested (only  `destination_host` or only `destination_datastore` defined, or combined with `destination_resourcepool`…)