### PR TITLE
Do not return enabled_vsan and vsan_auto_claim_storage as a list

### DIFF
--- a/changelogs/fragments/805-vmware_cluster_info.yml
+++ b/changelogs/fragments/805-vmware_cluster_info.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  vmware_cluster_info - Fix a bug that returned enabled_vsan and vsan_auto_claim_storage as lists instead of just true or false (https://github.com/ansible-collections/community.vmware/issues/805).

--- a/changelogs/fragments/805-vmware_cluster_info.yml
+++ b/changelogs/fragments/805-vmware_cluster_info.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  vmware_cluster_info - Fix a bug that returned enabled_vsan and vsan_auto_claim_storage as lists instead of just true or false (https://github.com/ansible-collections/community.vmware/issues/805).
+  - vmware_cluster_info - Fix a bug that returned enabled_vsan and vsan_auto_claim_storage as lists instead of just true or false (https://github.com/ansible-collections/community.vmware/issues/805).

--- a/plugins/modules/vmware_cluster_info.py
+++ b/plugins/modules/vmware_cluster_info.py
@@ -282,8 +282,8 @@ class VmwreClusterInfoManager(PyVmomi):
                 # VSAN
                 if hasattr(cluster.configurationEx, 'vsanConfigInfo'):
                     vsan_config = cluster.configurationEx.vsanConfigInfo
-                    enabled_vsan = vsan_config.enabled,
-                    vsan_auto_claim_storage = vsan_config.defaultConfig.autoClaimStorage,
+                    enabled_vsan = vsan_config.enabled
+                    vsan_auto_claim_storage = vsan_config.defaultConfig.autoClaimStorage
 
                 tag_info = []
                 if self.params.get('show_tag'):


### PR DESCRIPTION
##### SUMMARY
`vmware_cluster_info` returns `enabled_vsan` and `vsan_auto_claim_storage` as a list instead of just `true` or `false`.

Fixes #805 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_cluster_info
