### PR TITLE
vmware: Propose implementing a function for finding a hostsystem by datacenter

### DIFF
--- a/changelogs/fragments/808-vmware.yml
+++ b/changelogs/fragments/808-vmware.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware - added a new function for finding a hostsystem by datacenter (https://github.com/ansible-collections/community.vmware/pull/808).

--- a/plugins/module_utils/vmware.py
+++ b/plugins/module_utils/vmware.py
@@ -1254,11 +1254,10 @@ class PyVmomi(object):
             self.module.fail_json(msg="Unable to find datacenter with name %s" % datacenter_name)
 
         hosts = self._find_recursively_hostsytem_by_datacenter(dc.hostFolder.childEntity)
-        flatten_hosts = list(self._flatten_list(hosts))
-        if not flatten_hosts:
+        if not hosts:
             self.module.fail_json(msg="ESXi hosts not found in %s" % datacenter_name)
 
-        for host in flatten_hosts:
+        for host in hosts:
             if host.name == host_name:
                 return host
 
@@ -1277,21 +1276,10 @@ class PyVmomi(object):
             if isinstance(obj, vim.Folder):
                 self._find_recursively_hostsytem_by_datacenter(obj.childEntity, hosts)
             if isinstance(obj, vim.ComputeResource) or isinstance(obj, vim.ClusterComputeResource):
-                hosts.append(obj.host)
+                for host in obj.host:
+                    hosts.append(host)
 
         return hosts
-
-    def _flatten_list(self, objs):
-        """
-        Flatten List
-        Args:
-            objs: List of Management Object
-        """
-        for obj in objs:
-            if isinstance(obj, list):
-                yield from self._flatten_list(obj)
-            else:
-                yield obj
 
     def get_all_host_objs(self, cluster_name=None, esxi_host_name=None):
         """


### PR DESCRIPTION
##### SUMMARY

I noticed in making a new host module that I seem that there isn't a function in vmware.py for finding a hostsystem by datacenter.  
By the way, there is find_host_by_cluster_datacenter to find a hostsystem specifying a datacenter and cluster.  
https://github.com/ansible-collections/community.vmware/blob/2782d08e0fece820c70a90b8b0a9c4b5ea412868/plugins/module_utils/vmware.py#L761

But the function needs a datacenter and cluster to use.  
Also, it is possible that specify a datacenter in vmwre_host module, but I seem that search a hostsystem from whole if a datacenter only.

https://github.com/ansible-collections/community.vmware/blob/2782d08e0fece820c70a90b8b0a9c4b5ea412868/plugins/modules/vmware_host.py#L284-L290

This I'm thinking that it's not the intended behavior.  
So, this PR will add a new function for finding a hostsystem by datacenter.  
What do you think?

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

changelogs/fragments/808-vmware.yml
plugins/module_utils/vmware.py

##### ADDITIONAL INFORMATION

The following is an example of using the function.

```python
class VmwareXxxxxxxx(Pyvmomi):
(snip)
    def execute(self):
        if self.cluster and self.datacenter:
            host_obj = find_host_by_cluster_datacenter(self.module, self.content, self.datacenter, self.cluster, self.esxi_hostname)
        elif(self.datacenter):
            host_obj = self.find_hostsystem_by_datacenter(self.datacenter, self.esxi_hostname)
        else:
            host_obj = self.find_hostsystem_by_name(self.esxi_hostname)

        if host_obj is None:
            self.module.fail_json(msg="xxxxxx")
(snip)
def main():
    argument_spec = vmware_argument_spec()
    argument_spec.update(
        datacenter=dict(type='str'),
        cluster=dict(type='str'),
        esxi_hostname=dict(type='str', required=True)
    )
(snip)
```