### PR TITLE
vmware_vm_info: Handle vApp parent logic

### DIFF
--- a/changelogs/fragments/777_vapp_info.yml
+++ b/changelogs/fragments/777_vapp_info.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- vmware_vm_info - handle vApp parent logic (https://github.com/ansible-collections/community.vmware/issues/777).

--- a/plugins/module_utils/vmware.py
+++ b/plugins/module_utils/vmware.py
@@ -164,7 +164,7 @@ def get_parent_datacenter(obj):
     while True:
         if not hasattr(obj, 'parent'):
             break
-        obj = obj.parent
+        obj = obj.parent or obj.parentVApp
         if isinstance(obj, vim.Datacenter):
             datacenter = obj
             break


### PR DESCRIPTION
##### SUMMARY

vmware_vm_info uses get_parent_datacenter API, which fails for
vApp.

Fixes: #777

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/module_utils/vmware.py
