### PR TITLE
vmware_host_tcpip_stacks: Add a new module to update the tcpip stack configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Name | Description
 [community.vmware.vmware_host_sriov](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_sriov_module.rst)|Manage SR-IOV settings on host
 [community.vmware.vmware_host_ssl_facts](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_ssl_facts_module.rst)|Gather facts of ESXi host system about SSL
 [community.vmware.vmware_host_ssl_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_ssl_info_module.rst)|Gather info of ESXi host system about SSL
+[community.vmware.vmware_host_tcpip_stacks](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_tcpip_stacks_module.rst)|Manage the TCP/IP Stacks configuration of ESXi host
 [community.vmware.vmware_host_vmhba_facts](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_vmhba_facts_module.rst)|Gathers facts about vmhbas available on the given ESXi host
 [community.vmware.vmware_host_vmhba_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_vmhba_info_module.rst)|Gathers info about vmhbas available on the given ESXi host
 [community.vmware.vmware_host_vmnic_facts](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_vmnic_facts_module.rst)|Gathers facts about vmnics available on the given ESXi host

--- a/docs/community.vmware.vmware_host_tcpip_stacks_module.rst
+++ b/docs/community.vmware.vmware_host_tcpip_stacks_module.rst
@@ -554,8 +554,8 @@ Examples
 
 .. code-block:: yaml
 
-    - name: Modify the TCP/IP stack configuration of the default
-      vmware_host_tcpip_stacks:
+    - name: Update the TCP/IP stack configuration of the default
+      community.vmware.vmware_host_tcpip_stacks:
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
@@ -573,8 +573,8 @@ Examples
           congestion_algorithm: cubic
           max_num_connections: 12000
 
-    - name: Modify the TCP/IP stack configuration of the provisioning
-      vmware_host_tcpip_stacks:
+    - name: Update the TCP/IP stack configuration of the provisioning
+      community.vmware.vmware_host_tcpip_stacks:
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
@@ -585,8 +585,8 @@ Examples
           max_num_connections: 12000
           gateway: 10.10.10.254
 
-    - name: Modify the TCP/IP stack configuration of the default and provisioning
-      vmware_host_tcpip_stacks:
+    - name: Update the TCP/IP stack configuration of the default and provisioning
+      community.vmware.vmware_host_tcpip_stacks:
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"

--- a/docs/community.vmware.vmware_host_tcpip_stacks_module.rst
+++ b/docs/community.vmware.vmware_host_tcpip_stacks_module.rst
@@ -1,0 +1,728 @@
+.. _community.vmware.vmware_host_tcpip_stacks_module:
+
+
+*****************************************
+community.vmware.vmware_host_tcpip_stacks
+*****************************************
+
+**Manage the TCP/IP Stacks configuration of ESXi host**
+
+
+Version added: 1.10.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- This module can be used to modify the TCP/IP stacks configuration.
+
+
+
+Requirements
+------------
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.7
+- PyVmomi
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+            <th width="100%">Comments</th>
+        </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>default</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The TCP/IP stacks configuration of the <em>default</em>.</div>
+                </td>
+            </tr>
+                                <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>alternate_dns</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The IP address of the alternate dns server.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>congestion_algorithm</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li><div style="color: blue"><b>newreno</b>&nbsp;&larr;</div></li>
+                                    <li>cubic</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>The TCP congest control algorithm.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>domain</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The domain name portion of the DNS name.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>gateway</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The gateway address.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>hostname</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The host name of the ESXi host.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>max_num_connections</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">11000</div>
+                </td>
+                <td>
+                        <div>The maximum number of socket connection that are requested.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>preferred_dns</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The IP address of the preferred dns server.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>search_domains</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=string</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">[]</div>
+                </td>
+                <td>
+                        <div>The domain in which to search for hosts, placed in order of preference.</div>
+                </td>
+            </tr>
+
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>esxi_hostname</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Name of the ESXi host.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>hostname</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The hostname or IP address of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_HOST</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The password of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PASSWORD</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: pass, pwd</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">443</div>
+                </td>
+                <td>
+                        <div>The port number of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PORT</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>provisioning</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The TCP/IP stacks configuration of the <em>provisioning</em>.</div>
+                </td>
+            </tr>
+                                <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>congestion_algorithm</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li><div style="color: blue"><b>newreno</b>&nbsp;&larr;</div></li>
+                                    <li>cubic</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>The TCP congest control algorithm.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>gateway</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The gateway address.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>max_num_connections</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">11000</div>
+                </td>
+                <td>
+                        <div>The maximum number of socket connection that are requested.</div>
+                </td>
+            </tr>
+
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>proxy_host</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Address of a proxy that will receive all HTTPS requests and relay them.</div>
+                        <div>The format is a hostname or a IP.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PROXY_HOST</code> will be used instead.</div>
+                        <div>This feature depends on a version of pyvmomi greater than v6.7.1.2018.12</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>proxy_port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Port of the HTTP proxy that will receive all HTTPS requests and relay them.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PROXY_PORT</code> will be used instead.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>username</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The username of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_USER</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: admin, user</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>validate_certs</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>no</li>
+                                    <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Allows connection when SSL certificates are not valid. Set to <code>false</code> when certificates are not trusted.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_VALIDATE_CERTS</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                        <div>If set to <code>true</code>, please make sure Python &gt;= 2.7.9 is installed on the given machine.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>vmotion</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The TCP/IP stacks configuration of the <em>vmotion</em>.</div>
+                </td>
+            </tr>
+                                <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>congestion_algorithm</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li><div style="color: blue"><b>newreno</b>&nbsp;&larr;</div></li>
+                                    <li>cubic</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>The TCP congest control algorithm.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>gateway</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The gateway address.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>max_num_connections</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">11000</div>
+                </td>
+                <td>
+                        <div>The maximum number of socket connection that are requested.</div>
+                </td>
+            </tr>
+
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>vxlan</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The TCP/IP stacks configuration of the <em>vxlan</em>.</div>
+                </td>
+            </tr>
+                                <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>congestion_algorithm</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li><div style="color: blue"><b>newreno</b>&nbsp;&larr;</div></li>
+                                    <li>cubic</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>The TCP congest control algorithm.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>gateway</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The gateway address.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>max_num_connections</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">11000</div>
+                </td>
+                <td>
+                        <div>The maximum number of socket connection that are requested.</div>
+                </td>
+            </tr>
+
+    </table>
+    <br/>
+
+
+
+
+Examples
+--------
+
+.. code-block:: yaml
+
+    - name: Modify the TCP/IP stack configuration of the default
+      vmware_host_tcpip_stacks:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        esxi_hostname: "{{ esxi_hostname }}"
+        default:
+          hostname: "{{ esxi_hostname }}"
+          domain: example.com
+          preferred_dns: 192.168.10.1
+          alternate_dns: 192.168.20.1
+          search_domains:
+            - hoge.com
+            - fuga.com
+          gateway: 192.168.10.1
+          congestion_algorithm: cubic
+          max_num_connections: 12000
+
+    - name: Modify the TCP/IP stack configuration of the provisioning
+      vmware_host_tcpip_stacks:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        esxi_hostname: "{{ esxi_hostname }}"
+        provisioning:
+          congestion_algorithm: newreno
+          max_num_connections: 12000
+          gateway: 10.10.10.254
+
+    - name: Modify the TCP/IP stack configuration of the default and provisioning
+      vmware_host_tcpip_stacks:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        esxi_hostname: "{{ esxi_hostname }}"
+        default:
+          hostname: "{{ esxi_hostname }}"
+          domain: example.com
+          preferred_dns: 192.168.10.1
+          alternate_dns: 192.168.20.1
+          search_domains:
+            - hoge.com
+            - fuga.com
+          gateway: 192.168.10.1
+          congestion_algorithm: cubic
+          max_num_connections: 12000
+        provisioning:
+          congestion_algorithm: newreno
+          max_num_connections: 12000
+          gateway: 10.10.10.254
+
+
+
+Return Values
+-------------
+Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>default</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">dictionary</span>
+                    </div>
+                </td>
+                <td>always</td>
+                <td>
+                            <div>dict of the TCP/IP stack configuration of the default.</div>
+                    <br/>
+                        <div style="font-size: smaller"><b>Sample:</b></div>
+                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{
+        &quot;alternate_dns&quot;: &quot;192.168.20.1&quot;,
+        &quot;congestion_algorithm&quot;: &quot;cubic&quot;,
+        &quot;domain&quot;: &quot;example.com&quot;,
+        &quot;gateway&quot;: &quot;192.168.10.1&quot;,
+        &quot;hostname&quot;: &quot;esxi-test03&quot;,
+        &quot;max_num_connections&quot;: 12000,
+        &quot;preferred_dns&quot;: &quot;192.168.10.1&quot;,
+        &quot;search_domains&quot;: [
+            &quot;hoge.com&quot;,
+            &quot;fuga.com&quot;
+        ]
+    }</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>provisioning</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">dictionary</span>
+                    </div>
+                </td>
+                <td>always</td>
+                <td>
+                            <div>dict of the TCP/IP stack configuration of the provisioning.</div>
+                    <br/>
+                        <div style="font-size: smaller"><b>Sample:</b></div>
+                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{
+        &quot;congestion_algorithm&quot;: &quot;newreno&quot;,
+        &quot;gateway&quot;: &quot;10.10.10.254&quot;,
+        &quot;max_num_connections&quot;: 12000
+    }</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>vmotion</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">dictionary</span>
+                    </div>
+                </td>
+                <td>always</td>
+                <td>
+                            <div>dict of the TCP/IP stack configuration of the vmotion.</div>
+                    <br/>
+                        <div style="font-size: smaller"><b>Sample:</b></div>
+                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{
+        &quot;congestion_algorithm&quot;: &quot;newreno&quot;,
+        &quot;gateway&quot;: null,
+        &quot;max_num_connections&quot;: 11000
+    }</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>vxlan</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">dictionary</span>
+                    </div>
+                </td>
+                <td>always</td>
+                <td>
+                            <div>dict of the TCP/IP stack configuration of the vxlan.</div>
+                    <br/>
+                        <div style="font-size: smaller"><b>Sample:</b></div>
+                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{
+        &quot;congestion_algorithm&quot;: &quot;newreno&quot;,
+        &quot;gateway&quot;: null,
+        &quot;max_num_connections&quot;: 11000
+    }</div>
+                </td>
+            </tr>
+    </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- sky-joker (@sky-joker)

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -111,6 +111,7 @@ action_groups:
   - vmware_host_snmp
   - vmware_host_sriov
   - vmware_host_ssl_info
+  - vmware_host_tcpip_stacks
   - vmware_host_vmhba_info
   - vmware_host_vmnic_info
   - vmware_local_role_info

--- a/plugins/modules/vmware_host_tcpip_stacks.py
+++ b/plugins/modules/vmware_host_tcpip_stacks.py
@@ -263,7 +263,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_text
-from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, vmware_argument_spec, find_host_by_cluster_datacenter
+from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, vmware_argument_spec
 
 
 class VmwareHostTcpipStack(PyVmomi):

--- a/plugins/modules/vmware_host_tcpip_stacks.py
+++ b/plugins/modules/vmware_host_tcpip_stacks.py
@@ -1,0 +1,567 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2021, sky-joker
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: vmware_host_tcpip_stacks
+short_description: Manage the TCP/IP Stacks configuration of ESXi host
+author:
+  - sky-joker (@sky-joker)
+description:
+  - This module can be used to modify the TCP/IP stacks configuration.
+requirements:
+  - python >= 2.7
+  - PyVmomi
+version_added: '1.10.0'
+options:
+  esxi_hostname:
+    description:
+      - Name of the ESXi host.
+    type: str
+    required: true
+  default:
+    description:
+      - The TCP/IP stacks configuration of the I(default).
+    suboptions:
+      hostname:
+        description:
+          - The host name of the ESXi host.
+        type: str
+        required: true
+      domain:
+        description:
+          - The domain name portion of the DNS name.
+        type: str
+        required: true
+      preferred_dns:
+        description:
+          - The IP address of the preferred dns server.
+        type: str
+      alternate_dns:
+        description:
+          - The IP address of the alternate dns server.
+        type: str
+      search_domains:
+        description:
+          - The domain in which to search for hosts, placed in order of preference.
+        default: []
+        elements: str
+        type: list
+      gateway:
+        description:
+          - The gateway address.
+        type: str
+      congestion_algorithm:
+        description:
+          - The TCP congest control algorithm.
+        choices:
+          - newreno
+          - cubic
+        default: newreno
+        type: str
+      max_num_connections:
+        description:
+          - The maximum number of socket connection that are requested.
+        default: 11000
+        type: int
+    type: dict
+  provisioning:
+    description:
+      - The TCP/IP stacks configuration of the I(provisioning).
+    suboptions:
+      gateway:
+        description:
+          - The gateway address.
+        type: str
+      congestion_algorithm:
+        description:
+          - The TCP congest control algorithm.
+        choices:
+          - newreno
+          - cubic
+        default: newreno
+        type: str
+      max_num_connections:
+        description:
+          - The maximum number of socket connection that are requested.
+        default: 11000
+        type: int
+    type: dict
+  vmotion:
+    description:
+      - The TCP/IP stacks configuration of the I(vmotion).
+    suboptions:
+      gateway:
+        description:
+          - The gateway address.
+        type: str
+      congestion_algorithm:
+        description:
+          - The TCP congest control algorithm.
+        choices:
+          - newreno
+          - cubic
+        default: newreno
+        type: str
+      max_num_connections:
+        description:
+          - The maximum number of socket connection that are requested.
+        default: 11000
+        type: int
+    type: dict
+  vxlan:
+    description:
+      - The TCP/IP stacks configuration of the I(vxlan).
+    suboptions:
+      gateway:
+        description:
+          - The gateway address.
+        type: str
+      congestion_algorithm:
+        description:
+          - The TCP congest control algorithm.
+        choices:
+          - newreno
+          - cubic
+        default: newreno
+        type: str
+      max_num_connections:
+        description:
+          - The maximum number of socket connection that are requested.
+        default: 11000
+        type: int
+    type: dict
+extends_documentation_fragment:
+  - community.vmware.vmware.documentation
+'''
+
+EXAMPLES = r'''
+- name: Modify the TCP/IP stack configuration of the default
+  vmware_host_tcpip_stacks:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi_hostname }}"
+    default:
+      hostname: "{{ esxi_hostname }}"
+      domain: example.com
+      preferred_dns: 192.168.10.1
+      alternate_dns: 192.168.20.1
+      search_domains:
+        - hoge.com
+        - fuga.com
+      gateway: 192.168.10.1
+      congestion_algorithm: cubic
+      max_num_connections: 12000
+
+- name: Modify the TCP/IP stack configuration of the provisioning
+  vmware_host_tcpip_stacks:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi_hostname }}"
+    provisioning:
+      congestion_algorithm: newreno
+      max_num_connections: 12000
+      gateway: 10.10.10.254
+
+- name: Modify the TCP/IP stack configuration of the default and provisioning
+  vmware_host_tcpip_stacks:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi_hostname }}"
+    default:
+      hostname: "{{ esxi_hostname }}"
+      domain: example.com
+      preferred_dns: 192.168.10.1
+      alternate_dns: 192.168.20.1
+      search_domains:
+        - hoge.com
+        - fuga.com
+      gateway: 192.168.10.1
+      congestion_algorithm: cubic
+      max_num_connections: 12000
+    provisioning:
+      congestion_algorithm: newreno
+      max_num_connections: 12000
+      gateway: 10.10.10.254
+'''
+
+RETURN = r'''
+default:
+  description: dict of the TCP/IP stack configuration of the default.
+  returned: always
+  type: dict
+  sample: >-
+    {
+        "alternate_dns": "192.168.20.1",
+        "congestion_algorithm": "cubic",
+        "domain": "example.com",
+        "gateway": "192.168.10.1",
+        "hostname": "esxi-test03",
+        "max_num_connections": 12000,
+        "preferred_dns": "192.168.10.1",
+        "search_domains": [
+            "hoge.com",
+            "fuga.com"
+        ]
+    }
+provisioning:
+  description: dict of the TCP/IP stack configuration of the provisioning.
+  returned: always
+  type: dict
+  sample: >-
+    {
+        "congestion_algorithm": "newreno",
+        "gateway": "10.10.10.254",
+        "max_num_connections": 12000
+    }
+vmotion:
+  description: dict of the TCP/IP stack configuration of the vmotion.
+  returned: always
+  type: dict
+  sample: >-
+    {
+        "congestion_algorithm": "newreno",
+        "gateway": null,
+        "max_num_connections": 11000
+    }
+vxlan:
+  description: dict of the TCP/IP stack configuration of the vxlan.
+  returned: always
+  type: dict
+  sample: >-
+    {
+        "congestion_algorithm": "newreno",
+        "gateway": null,
+        "max_num_connections": 11000
+    }
+'''
+
+try:
+    from pyVmomi import vim
+except ImportError:
+    pass
+
+try:
+    from collections import OrderedDict
+except ImportError:
+    try:
+        from ordereddict import OrderedDict
+    except ImportError:
+        pass
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_text
+from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, vmware_argument_spec, find_host_by_cluster_datacenter
+
+
+class VmwareHostTcpipStack(PyVmomi):
+    def __init__(self, module):
+        super(VmwareHostTcpipStack, self).__init__(module)
+        self.esxi_hostname = self.params['esxi_hostname']
+        self.default = self.params['default']
+        self.provisioning = self.params['provisioning']
+        self.vmotion = self.params['vmotion']
+        self.vxlan = self.params['vxlan']
+
+        self.net_stack_instance_keys = {
+            "default": "defaultTcpipStack",
+            "vmotion": "vmotion",
+            "provisioning": "vSphereProvisioning",
+            "vxlan": "vxlan"
+        }
+
+    def check_enabled_net_stack_instance(self):
+        """
+        Make sure if enabled each the tcpip stack item in ESXi host.
+        """
+        self.enabled_net_stack_instance = {
+            "default": False,
+            "vmotion": False,
+            "provisioning": False,
+            "vxlan": False
+        }
+        for net_stack_instance in self.host_obj.runtime.networkRuntimeInfo.netStackInstanceRuntimeInfo:
+            if net_stack_instance.netStackInstanceKey == self.net_stack_instance_keys['default']:
+                self.enabled_net_stack_instance['default'] = True
+
+            if net_stack_instance.netStackInstanceKey == self.net_stack_instance_keys['provisioning']:
+                self.enabled_net_stack_instance['provisioning'] = True
+
+            if net_stack_instance.netStackInstanceKey == self.net_stack_instance_keys['vmotion']:
+                self.enabled_net_stack_instance['vmotion'] = True
+
+            if net_stack_instance.netStackInstanceKey == self.net_stack_instance_keys['vxlan']:
+                self.enabled_net_stack_instance['vxlan'] = True
+
+    def get_net_stack_instance_config(self):
+        """
+        Get a configuration of tcpip stack item if it is enabled.
+        """
+        self.exist_net_stack_instance_config = {}
+        for key, value in self.enabled_net_stack_instance.items():
+            if value is True:
+                for net_stack_instance in self.host_obj.config.network.netStackInstance:
+                    if net_stack_instance.key == self.net_stack_instance_keys[key]:
+                        self.exist_net_stack_instance_config[key] = net_stack_instance
+
+    def diff_net_stack_instance_config(self):
+        """
+        Check the difference between a new and existing config.
+        """
+        self.change_flag = False
+
+        # Make the diff_config variable to check the difference between a new and existing config.
+        self.diff_config = dict(before={}, after={})
+        for key, value in self.enabled_net_stack_instance.items():
+            if value is True:
+                self.diff_config['before'][key] = {}
+                self.diff_config['after'][key] = {}
+
+        if self.enabled_net_stack_instance['default']:
+            exist_dns_servers = self.exist_net_stack_instance_config['default'].dnsConfig.address
+            for key in 'before', 'after':
+                self.diff_config[key]['default'] = dict(
+                    hostname=self.exist_net_stack_instance_config['default'].dnsConfig.hostName,
+                    domain=self.exist_net_stack_instance_config['default'].dnsConfig.domainName,
+                    preferred_dns=exist_dns_servers[0] if [dns for dns in exist_dns_servers if exist_dns_servers.index(dns) == 0] else None,
+                    alternate_dns=exist_dns_servers[1] if [dns for dns in exist_dns_servers if exist_dns_servers.index(dns) == 1] else None,
+                    search_domains=self.exist_net_stack_instance_config['default'].dnsConfig.searchDomain,
+                    gateway=self.exist_net_stack_instance_config['default'].ipRouteConfig.defaultGateway,
+                    congestion_algorithm=self.exist_net_stack_instance_config['default'].congestionControlAlgorithm,
+                    max_num_connections=self.exist_net_stack_instance_config['default'].requestedMaxNumberOfConnections
+                )
+                if self.default:
+                    if self.diff_config['before']['default']['hostname'] != self.default['hostname']:
+                        self.change_flag = True
+                        self.diff_config['after']['default']['hostname'] = self.default['hostname']
+                    if self.diff_config['before']['default']['domain'] != self.default['domain']:
+                        self.change_flag = True
+                        self.diff_config['after']['default']['domain'] = self.default['domain']
+                    if self.diff_config['before']['default']['preferred_dns'] != self.default['preferred_dns']:
+                        self.change_flag = True
+                        self.diff_config['after']['default']['preferred_dns'] = self.default['preferred_dns']
+                    if self.diff_config['before']['default']['alternate_dns'] != self.default['alternate_dns']:
+                        self.change_flag = True
+                        self.diff_config['after']['default']['alternate_dns'] = self.default['alternate_dns']
+                    if self.diff_config['before']['default']['search_domains'] != self.default['search_domains']:
+                        self.change_flag = True
+                        self.diff_config['after']['default']['search_domains'] = self.default['search_domains']
+                    if self.diff_config['before']['default']['gateway'] != self.default['gateway']:
+                        self.change_flag = True
+                        self.diff_config['after']['default']['gateway'] = self.default['gateway']
+                    if self.diff_config['before']['default']['congestion_algorithm'] != self.default['congestion_algorithm']:
+                        self.change_flag = True
+                        self.diff_config['after']['default']['congestion_algorithm'] = self.default['congestion_algorithm']
+                    if self.diff_config['before']['default']['max_num_connections'] != self.default['max_num_connections']:
+                        self.change_flag = True
+                        self.diff_config['after']['default']['max_num_connections'] = self.default['max_num_connections']
+
+        if self.enabled_net_stack_instance['provisioning']:
+            for key in 'before', 'after':
+                self.diff_config[key]['provisioning'] = dict(
+                    gateway=self.exist_net_stack_instance_config['provisioning'].ipRouteConfig.defaultGateway,
+                    congestion_algorithm=self.exist_net_stack_instance_config['provisioning'].congestionControlAlgorithm,
+                    max_num_connections=self.exist_net_stack_instance_config['provisioning'].requestedMaxNumberOfConnections
+                )
+            if self.provisioning:
+                if self.diff_config['before']['provisioning']['gateway'] != self.provisioning['gateway']:
+                    self.change_flag = True
+                    self.diff_config['after']['provisioning']['gateway'] = self.provisioning['gateway']
+                if self.diff_config['before']['provisioning']['max_num_connections'] != self.provisioning['max_num_connections']:
+                    self.change_flag = True
+                    self.diff_config['after']['provisioning']['max_num_connections'] = self.provisioning['max_num_connections']
+                if self.diff_config['before']['provisioning']['congestion_algorithm'] != self.provisioning['congestion_algorithm']:
+                    self.change_flag = True
+                    self.diff_config['after']['provisioning']['congestion_algorithm'] = self.provisioning['congestion_algorithm']
+
+        if self.enabled_net_stack_instance['vmotion']:
+            for key in 'before', 'after':
+                self.diff_config[key]['vmotion'] = dict(
+                    gateway=self.exist_net_stack_instance_config['vmotion'].ipRouteConfig.defaultGateway,
+                    congestion_algorithm=self.exist_net_stack_instance_config['vmotion'].congestionControlAlgorithm,
+                    max_num_connections=self.exist_net_stack_instance_config['vmotion'].requestedMaxNumberOfConnections
+                )
+            if self.vmotion:
+                if self.diff_config['before']['vmotion']['gateway'] != self.vmotion['gateway']:
+                    self.change_flag = True
+                    self.diff_config['after']['vmotion']['gateway'] = self.vmotion['gateway']
+                if self.diff_config['before']['vmotion']['max_num_connections'] != self.vmotion['max_num_connections']:
+                    self.change_flag = True
+                    self.diff_config['after']['vmotion']['max_num_connections'] = self.vmotion['max_num_connections']
+                if self.diff_config['before']['vmotion']['congestion_algorithm'] != self.vmotion['congestion_algorithm']:
+                    self.change_flag = True
+                    self.diff_config['after']['vmotion']['congestion_algorithm'] = self.vmotion['congestion_algorithm']
+
+        if self.enabled_net_stack_instance['vxlan']:
+            for key in 'before', 'after':
+                self.diff_config[key]['vxlan'] = dict(
+                    gateway=self.exist_net_stack_instance_config['vxlan'].ipRouteConfig.defaultGateway,
+                    congestion_algorithm=self.exist_net_stack_instance_config['vxlan'].congestionControlAlgorithm,
+                    max_num_connections=self.exist_net_stack_instance_config['vxlan'].requestedMaxNumberOfConnections
+                )
+            if self.vxlan:
+                if self.diff_config['before']['vxlan']['gateway'] != self.vxlan['gateway']:
+                    self.change_flag = True
+                    self.diff_config['after']['vxlan']['gateway'] = self.vxlan['gateway']
+                if self.diff_config['before']['vxlan']['max_num_connections'] != self.vxlan['max_num_connections']:
+                    self.change_flag = True
+                    self.diff_config['after']['vxlan']['max_num_connections'] = self.vxlan['max_num_connections']
+                if self.diff_config['before']['vxlan']['congestion_algorithm'] != self.vxlan['congestion_algorithm']:
+                    self.change_flag = True
+                    self.diff_config['after']['vxlan']['congestion_algorithm'] = self.vxlan['congestion_algorithm']
+
+    def generate_net_stack_instance_config(self):
+        """
+        Generate a new configuration for tcpip stack to modify the configuration.
+        """
+        self.new_net_stack_instance_configs = vim.host.NetworkConfig()
+        self.new_net_stack_instance_configs.netStackSpec = []
+
+        if self.default and self.enabled_net_stack_instance['default']:
+            default_config = vim.host.NetworkConfig.NetStackSpec()
+            default_config.operation = 'edit'
+            default_config.netStackInstance = vim.host.NetStackInstance()
+            default_config.netStackInstance.key = self.net_stack_instance_keys['default']
+            default_config.netStackInstance.ipRouteConfig = vim.host.IpRouteConfig()
+            default_config.netStackInstance.ipRouteConfig.defaultGateway = self.default['gateway']
+            default_config.netStackInstance.dnsConfig = vim.host.DnsConfig()
+            default_config.netStackInstance.dnsConfig.hostName = self.default['hostname']
+            default_config.netStackInstance.dnsConfig.domainName = self.default['domain']
+            dns_servers = []
+            if self.default['preferred_dns']:
+                dns_servers.append(self.default['preferred_dns'])
+            if self.default['alternate_dns']:
+                dns_servers.append(self.default['alternate_dns'])
+            default_config.netStackInstance.dnsConfig.address = dns_servers
+            default_config.netStackInstance.dnsConfig.searchDomain = self.default['search_domains']
+            default_config.netStackInstance.congestionControlAlgorithm = self.default['congestion_algorithm']
+            default_config.netStackInstance.requestedMaxNumberOfConnections = self.default['max_num_connections']
+            self.new_net_stack_instance_configs.netStackSpec.append(default_config)
+
+        if self.provisioning and self.enabled_net_stack_instance['provisioning']:
+            provisioning_config = vim.host.NetworkConfig.NetStackSpec()
+            provisioning_config.operation = 'edit'
+            provisioning_config.netStackInstance = vim.host.NetStackInstance()
+            provisioning_config.netStackInstance.key = self.net_stack_instance_keys['provisioning']
+            provisioning_config.netStackInstance.ipRouteConfig = vim.host.IpRouteConfig()
+            provisioning_config.netStackInstance.ipRouteConfig.defaultGateway = self.provisioning['gateway']
+            provisioning_config.netStackInstance.congestionControlAlgorithm = self.provisioning['congestion_algorithm']
+            provisioning_config.netStackInstance.requestedMaxNumberOfConnections = self.provisioning['max_num_connections']
+            self.new_net_stack_instance_configs.netStackSpec.append(provisioning_config)
+
+        if self.vmotion and self.enabled_net_stack_instance['vmotion']:
+            vmotion_config = vim.host.NetworkConfig.NetStackSpec()
+            vmotion_config.operation = 'edit'
+            vmotion_config.netStackInstance = vim.host.NetStackInstance()
+            vmotion_config.netStackInstance.key = self.net_stack_instance_keys['vmotion']
+            vmotion_config.netStackInstance.ipRouteConfig = vim.host.IpRouteConfig()
+            vmotion_config.netStackInstance.ipRouteConfig.defaultGateway = self.vmotion['gateway']
+            vmotion_config.netStackInstance.congestionControlAlgorithm = self.vmotion['congestion_algorithm']
+            vmotion_config.netStackInstance.requestedMaxNumberOfConnections = self.vmotion['max_num_connections']
+            self.new_net_stack_instance_configs.netStackSpec.append(vmotion_config)
+
+        if self.vxlan and self.enabled_net_stack_instance['vxlan']:
+            vxlan_config = vim.host.NetworkConfig.NetStackSpec()
+            vxlan_config.operation = 'edit'
+            vxlan_config.netStackInstance = vim.host.NetStackInstance()
+            vxlan_config.netStackInstance.key = self.net_stack_instance_keys['vxlan']
+            vxlan_config.netStackInstance.ipRouteConfig = vim.host.IpRouteConfig()
+            vxlan_config.netStackInstance.ipRouteConfig.defaultGateway = self.vxlan['gateway']
+            vxlan_config.netStackInstance.congestionControlAlgorithm = self.vxlan['congestion_algorithm']
+            vxlan_config.netStackInstance.requestedMaxNumberOfConnections = self.vxlan['max_num_connections']
+            self.new_net_stack_instance_configs.netStackSpec.append(vxlan_config)
+
+    def execute(self):
+        # The host name is unique in vCenter, so find the host from the whole.
+        self.host_obj = self.find_hostsystem_by_name(self.esxi_hostname)
+        if self.host_obj is None:
+            self.module.fail_json(msg="Cannot find the specified ESXi host: %s" % self.params['esxi_hostname'])
+
+        self.check_enabled_net_stack_instance()
+        self.get_net_stack_instance_config()
+        self.diff_net_stack_instance_config()
+        if self.change_flag:
+            if self.module.check_mode is False:
+                self.generate_net_stack_instance_config()
+                try:
+                    self.host_obj.configManager.networkSystem.UpdateNetworkConfig(self.new_net_stack_instance_configs, 'modify')
+                except Exception as e:
+                    self.module.fail_json(msg="cannot modify tcpip stack config: %s" % to_text(e.msg))
+
+        # Make a warning for the item if it isn't supported by ESXi when specified item.
+        for key, value in self.enabled_net_stack_instance.items():
+            if self.params[key] and value is False:
+                self.module.warn("%s isn't supported in %s" % (key, self.params['esxi_hostname']))
+
+        # Make the return value for the result.
+        result = dict(
+            changed=self.change_flag,
+            diff=dict(
+                before=OrderedDict(sorted(self.diff_config['before'].items())),
+                after=OrderedDict(sorted(self.diff_config['after'].items()))
+            )
+        )
+        for key, value in self.enabled_net_stack_instance.items():
+            if value:
+                result[key] = self.diff_config['after'][key]
+            else:
+                result[key] = {}
+        self.module.exit_json(**result)
+
+
+def main():
+    argument_spec = vmware_argument_spec()
+    argument_spec.update(
+        esxi_hostname=dict(type='str', required=True),
+        default=dict(type='dict',
+                     options=dict(
+                         hostname=dict(type='str', required=True),
+                         domain=dict(type='str', required=True),
+                         preferred_dns=dict(type='str'),
+                         alternate_dns=dict(type='str'),
+                         search_domains=dict(type='list', elements='str', default=[]),
+                         gateway=dict(type='str'),
+                         congestion_algorithm=dict(type='str', choices=['newreno', 'cubic'], default='newreno'),
+                         max_num_connections=dict(type='int', default=11000)
+
+                     )),
+        provisioning=dict(type='dict',
+                          options=dict(
+                              gateway=dict(type='str'),
+                              congestion_algorithm=dict(type='str', choices=['newreno', 'cubic'], default='newreno'),
+                              max_num_connections=dict(type='int', default=11000)
+                          )),
+        vmotion=dict(type='dict',
+                     options=dict(
+                         gateway=dict(type='str'),
+                         congestion_algorithm=dict(type='str', choices=['newreno', 'cubic'], default='newreno'),
+                         max_num_connections=dict(type='int', default=11000)
+                     )),
+        vxlan=dict(type='dict',
+                   options=dict(
+                       gateway=dict(type='str'),
+                       congestion_algorithm=dict(type='str', choices=['newreno', 'cubic'], default='newreno'),
+                       max_num_connections=dict(type='int', default=11000)
+                   ))
+    )
+
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+
+    vmware_host_tcpip_stack = VmwareHostTcpipStack(module)
+    vmware_host_tcpip_stack.execute()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/vmware_host_tcpip_stacks.py
+++ b/plugins/modules/vmware_host_tcpip_stacks.py
@@ -142,7 +142,7 @@ extends_documentation_fragment:
 '''
 
 EXAMPLES = r'''
-- name: Modify the TCP/IP stack configuration of the default
+- name: Update the TCP/IP stack configuration of the default
   vmware_host_tcpip_stacks:
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
@@ -161,7 +161,7 @@ EXAMPLES = r'''
       congestion_algorithm: cubic
       max_num_connections: 12000
 
-- name: Modify the TCP/IP stack configuration of the provisioning
+- name: Update the TCP/IP stack configuration of the provisioning
   vmware_host_tcpip_stacks:
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
@@ -173,7 +173,7 @@ EXAMPLES = r'''
       max_num_connections: 12000
       gateway: 10.10.10.254
 
-- name: Modify the TCP/IP stack configuration of the default and provisioning
+- name: Update the TCP/IP stack configuration of the default and provisioning
   vmware_host_tcpip_stacks:
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"

--- a/plugins/modules/vmware_host_tcpip_stacks.py
+++ b/plugins/modules/vmware_host_tcpip_stacks.py
@@ -143,7 +143,7 @@ extends_documentation_fragment:
 
 EXAMPLES = r'''
 - name: Update the TCP/IP stack configuration of the default
-  vmware_host_tcpip_stacks:
+  community.vmware.vmware_host_tcpip_stacks:
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
@@ -162,7 +162,7 @@ EXAMPLES = r'''
       max_num_connections: 12000
 
 - name: Update the TCP/IP stack configuration of the provisioning
-  vmware_host_tcpip_stacks:
+  community.vmware.vmware_host_tcpip_stacks:
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
@@ -174,7 +174,7 @@ EXAMPLES = r'''
       gateway: 10.10.10.254
 
 - name: Update the TCP/IP stack configuration of the default and provisioning
-  vmware_host_tcpip_stacks:
+  community.vmware.vmware_host_tcpip_stacks:
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"

--- a/tests/integration/targets/vmware_host_tcpip_stacks/aliases
+++ b/tests/integration/targets/vmware_host_tcpip_stacks/aliases
@@ -1,0 +1,3 @@
+cloud/vcenter
+needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_host_tcpip_stacks/tasks/destroy.yml
+++ b/tests/integration/targets/vmware_host_tcpip_stacks/tasks/destroy.yml
@@ -1,0 +1,69 @@
+# Test code for the vmware_host_tcpip_stacks module.
+# Copyright: (c) 2021, sky-joker <sky.jokerxx@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: destroy vmkernel for provisioning
+  vmware_vmkernel:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi_hosts[0] }}"
+    vswitch_name: "{{ switch1 }}"
+    portgroup_name: provisioning
+    device: "{{ provisioning_vmk }}"
+    network:
+      type: static
+      ip_address: 100.64.0.1
+      subnet_mask: 255.255.255.0
+      tcpip_stack: provisioning
+    state: absent
+  register: vmkernel_provisioning_result
+
+- name: Make sure if the provisioning vmkernel is destroyed
+  assert:
+    that:
+      - vmkernel_provisioning_result.changed is sameas true
+
+- name: destroy vmkernel for vmotion
+  vmware_vmkernel:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi_hosts[0] }}"
+    vswitch_name: "{{ switch1 }}"
+    portgroup_name: vmotion
+    device: "{{ vmotion_vmk }}"
+    network:
+      type: static
+      ip_address: 100.64.1.1
+      subnet_mask: 255.255.255.0
+      tcpip_stack: vmotion
+    state: absent
+  register: vmkernel_vmotion_result
+
+- name: Make sure if the vmotion vmkernel is destroyed
+  assert:
+    that:
+      - vmkernel_vmotion_result.changed is sameas true
+
+- name: destroy portgroups for the test
+  vmware_portgroup:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    hosts: "{{ esxi_hosts }}"
+    switch: "{{ switch1 }}"
+    portgroup: "{{ item }}"
+    state: absent
+  register: portgroups_result
+  loop:
+    - provisioning
+    - vmotion
+
+- name: Make sure if the portgroups are destroyed
+  assert:
+    that:
+      - portgroups_result.changed is sameas true

--- a/tests/integration/targets/vmware_host_tcpip_stacks/tasks/main.yml
+++ b/tests/integration/targets/vmware_host_tcpip_stacks/tasks/main.yml
@@ -1,0 +1,17 @@
+# Test code for the vmware_host_tcpip_stacks module.
+# Copyright: (c) 2021, sky-joker <sky.jokerxx@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_attach_host: true
+
+- name: include tasks pre.yml
+  include_tasks: pre.yml
+
+- name: include tasks vmware_host_tcpip_stacks_tests.yml
+  include_tasks: vmware_host_tcpip_stacks_tests.yml
+
+- name: include tasks destroy.
+  include_tasks: destroy.yml

--- a/tests/integration/targets/vmware_host_tcpip_stacks/tasks/pre.yml
+++ b/tests/integration/targets/vmware_host_tcpip_stacks/tasks/pre.yml
@@ -1,0 +1,95 @@
+# Test code for the vmware_host_tcpip_stacks module.
+# Copyright: (c) 2021, sky-joker <sky.jokerxx@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: add portgroups for the test
+  vmware_portgroup:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    hosts: "{{ esxi_hosts }}"
+    switch: "{{ switch1 }}"
+    portgroup: "{{ item }}"
+    state: present
+  register: portgroups_result
+  loop:
+    - provisioning
+    - vmotion
+
+- name: Make sure if the portgroups are created
+  assert:
+    that:
+      - portgroups_result.changed is sameas true
+
+- name: add vmkernel for provisioning
+  vmware_vmkernel:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi_hosts[0] }}"
+    vswitch_name: "{{ switch1 }}"
+    portgroup_name: provisioning
+    network:
+      type: static
+      ip_address: 100.64.0.1
+      subnet_mask: 255.255.255.0
+      tcpip_stack: provisioning
+    state: present
+  register: vmkernel_provisioning_result
+
+- name: Make sure if the vmkernel is created for provisioning
+  assert:
+    that:
+      - vmkernel_provisioning_result.changed is sameas true
+
+- name: add vmkernel for vmotion
+  vmware_vmkernel:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi_hosts[0] }}"
+    vswitch_name: "{{ switch1 }}"
+    portgroup_name: vmotion
+    network:
+      type: static
+      ip_address: 100.64.1.1
+      subnet_mask: 255.255.255.0
+      tcpip_stack: vmotion
+    state: present
+  register: vmkernel_vmotion_result
+
+- name: Make sure if the vmkernel is created for vmotion
+  assert:
+    that:
+      - vmkernel_vmotion_result.changed is sameas true
+
+- name: Gather vmk info
+  vmware_vmkernel_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi_hosts[0] }}"
+  register: vmk0_info_result
+
+- name: set the variable of vmk0 ipaddr
+  set_fact:
+    vmk0_ipaddr: "{{ item.ipv4_address }}"
+  loop: "{{ vmk0_info_result.host_vmk_info[esxi_hosts[0]] }}"
+  when:
+    - item.device == "vmk0"
+
+- name: set the variable for each vmk
+  set_fact:
+    provisioning_vmk: "{{ vmkernel_provisioning_result.device }}"
+    vmotion_vmk: "{{ vmkernel_vmotion_result.device }}"
+
+- name: Make sure if defined the variables
+  assert:
+    that:
+      - vmk0_ipaddr is defined
+      - provisioning_vmk is defined
+      - vmotion_vmk is defined

--- a/tests/integration/targets/vmware_host_tcpip_stacks/tasks/vmware_host_tcpip_stacks_tests.yml
+++ b/tests/integration/targets/vmware_host_tcpip_stacks/tasks/vmware_host_tcpip_stacks_tests.yml
@@ -1,0 +1,327 @@
+# Test code for the vmware_host_tcpip_stacks module.
+# Copyright: (c) 2021, sky-joker <sky.jokerxx@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Update the default tcpip stack config with check_mode and diff
+  vmware_host_tcpip_stacks:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi_hosts[0] }}"
+    default:
+      hostname: examplehost
+      domain: example.com
+      preferred_dns: 8.8.8.8
+      alternate_dns: 9.9.9.9
+      search_domains:
+        - example.com
+      gateway: "{{ vmk0_ipaddr }}"
+      congestion_algorithm: cubic
+      max_num_connections: 12000
+  check_mode: true
+  diff: true
+  register: update_default_config_check_mode_diff_result
+
+- name: Make sure if changes will occur
+  assert:
+    that:
+      - update_default_config_check_mode_diff_result.changed is sameas true
+      - update_default_config_check_mode_diff_result.diff is defined
+
+- name: Update the default tcpip stack config
+  vmware_host_tcpip_stacks:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi_hosts[0] }}"
+    default:
+      hostname: examplehost
+      domain: example.com
+      preferred_dns: 8.8.8.8
+      alternate_dns: 9.9.9.9
+      search_domains:
+        - example.com
+      gateway: "{{ vmk0_ipaddr }}"
+      congestion_algorithm: cubic
+      max_num_connections: 12000
+  register: update_default_config_result
+
+- name: Make sure if the default tcpip stack config is updated
+  assert:
+    that:
+      - update_default_config_result.changed is sameas true
+      - update_default_config_result.default is defined
+      - update_default_config_result.default.hostname == "examplehost"
+      - update_default_config_result.default.domain == "example.com"
+      - update_default_config_result.default.preferred_dns == "8.8.8.8"
+      - update_default_config_result.default.alternate_dns == "9.9.9.9"
+      - update_default_config_result.default.search_domains.0 == "example.com"
+      - update_default_config_result.default.gateway == vmk0_ipaddr
+      - update_default_config_result.default.congestion_algorithm == "cubic"
+      - update_default_config_result.default.max_num_connections == 12000
+
+- name: Update the default tcpip stack config (idempotency)
+  vmware_host_tcpip_stacks:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi_hosts[0] }}"
+    default:
+      hostname: examplehost
+      domain: example.com
+      preferred_dns: 8.8.8.8
+      alternate_dns: 9.9.9.9
+      search_domains:
+        - example.com
+      gateway: "{{ vmk0_ipaddr }}"
+      congestion_algorithm: cubic
+      max_num_connections: 12000
+  register: update_default_config_idempotency_result
+
+- name: Make sure if the default tcpip stack config isn't updated
+  assert:
+    that:
+      - update_default_config_idempotency_result.changed is sameas false
+
+- name: Update the provisioning tcpip stack config with check_mode and diff
+  vmware_host_tcpip_stacks:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi_hosts[0] }}"
+    provisioning:
+      gateway: 100.64.0.1
+      congestion_algorithm: cubic
+      max_num_connections: 12000
+  check_mode: true
+  diff: true
+  register: update_provisioning_config_check_mode_diff_result
+
+- name: Make sure if changes will occur
+  assert:
+    that:
+      - update_provisioning_config_check_mode_diff_result.changed is sameas true
+      - update_provisioning_config_check_mode_diff_result.diff is defined
+
+- name: Update the provisioning tcpip stack config
+  vmware_host_tcpip_stacks:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi_hosts[0] }}"
+    provisioning:
+      gateway: 100.64.0.1
+      congestion_algorithm: cubic
+      max_num_connections: 12000
+  register: update_provisioning_config
+
+- debug: var=update_provisioning_config
+
+- name: Make sure if the provisioning tcpip stack config is updated
+  assert:
+    that:
+      - update_provisioning_config.changed is sameas true
+      - update_provisioning_config.provisioning.gateway == "100.64.0.1"
+      - update_provisioning_config.provisioning.congestion_algorithm == "cubic"
+      - update_provisioning_config.provisioning.max_num_connections == 12000
+
+- name: Update the provisioning tcpip stack config (idempotency)
+  vmware_host_tcpip_stacks:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi_hosts[0] }}"
+    provisioning:
+      gateway: 100.64.0.1
+      congestion_algorithm: cubic
+      max_num_connections: 12000
+  register: update_provisioning_idempotency_config
+
+- name: Make sure if the provisioning tcpip stack config isn't updated
+  assert:
+    that:
+      - update_provisioning_idempotency_config.changed is sameas false
+
+- name: Update the vmotion tcpip stack config with check_mode and diff
+  vmware_host_tcpip_stacks:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi_hosts[0] }}"
+    vmotion:
+      gateway: 100.64.1.1
+      congestion_algorithm: cubic
+      max_num_connections: 12000
+  check_mode: true
+  diff: true
+  register: update_vmotion_config_check_mode_diff_result
+
+- name: Make sure if changes will occur
+  assert:
+    that:
+      - update_vmotion_config_check_mode_diff_result.changed is sameas true
+      - update_vmotion_config_check_mode_diff_result.diff is defined
+
+- name: Update the vmotion tcpip stack config
+  vmware_host_tcpip_stacks:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi_hosts[0] }}"
+    vmotion:
+      gateway: 100.64.1.1
+      congestion_algorithm: cubic
+      max_num_connections: 12000
+  register: update_vmotion_config
+
+- name: Make sure if the vmotion tcpip stack config is updated
+  assert:
+    that:
+      - update_vmotion_config.changed is sameas true
+      - update_vmotion_config.vmotion.gateway == "100.64.1.1"
+      - update_vmotion_config.vmotion.congestion_algorithm == "cubic"
+      - update_vmotion_config.vmotion.max_num_connections == 12000
+
+- name: Update the vmotion tcpip stack config (idempotency)
+  vmware_host_tcpip_stacks:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi_hosts[0] }}"
+    vmotion:
+      gateway: 100.64.1.1
+      congestion_algorithm: cubic
+      max_num_connections: 12000
+  register: update_vmotion_idempotency_config
+
+- name: Make sure if the vmotion tcpip stack config isn't updated
+  assert:
+    that:
+      - update_vmotion_idempotency_config.changed is sameas false
+
+- name: Update all tcpip stack config with check_mode and diff
+  vmware_host_tcpip_stacks:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi_hosts[0] }}"
+    default:
+      hostname: examplehost
+      domain: example.com
+      preferred_dns: 9.9.9.9
+      alternate_dns: 8.8.8.8
+      search_domains:
+        - example.com
+        - hoge.com
+      gateway: "{{ vmk0_ipaddr }}"
+      congestion_algorithm: newreno
+      max_num_connections: 11000
+    provisioning:
+      gateway: 100.64.0.2
+      congestion_algorithm: newreno
+      max_num_connections: 11000
+    vmotion:
+      gateway: 100.64.1.2
+      congestion_algorithm: newreno
+      max_num_connections: 11000
+  check_mode: true
+  diff: true
+  register: update_all_config_check_mode_diff_result
+
+- name: Make sure if changes will occur
+  assert:
+    that:
+      - update_all_config_check_mode_diff_result.changed is sameas true
+      - update_all_config_check_mode_diff_result.diff is defined
+
+- name: Update all tcpip stack config
+  vmware_host_tcpip_stacks:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi_hosts[0] }}"
+    default:
+      hostname: examplehost
+      domain: example.com
+      preferred_dns: 9.9.9.9
+      alternate_dns: 8.8.8.8
+      search_domains:
+        - example.com
+        - hoge.com
+      gateway: "{{ vmk0_ipaddr }}"
+      congestion_algorithm: newreno
+      max_num_connections: 11000
+    provisioning:
+      gateway: 100.64.0.2
+      congestion_algorithm: newreno
+      max_num_connections: 11000
+    vmotion:
+      gateway: 100.64.1.2
+      congestion_algorithm: newreno
+      max_num_connections: 11000
+  register: update_all_config_result
+
+- name: Make sure if all tcpip stack config is updated
+  assert:
+    that:
+      - update_all_config_result.changed is sameas true
+      - update_all_config_result.default is defined
+      - update_all_config_result.default.hostname == "examplehost"
+      - update_all_config_result.default.domain == "example.com"
+      - update_all_config_result.default.preferred_dns == "9.9.9.9"
+      - update_all_config_result.default.alternate_dns == "8.8.8.8"
+      - update_all_config_result.default.search_domains.0 == "example.com"
+      - update_all_config_result.default.search_domains.1 == "hoge.com"
+      - update_all_config_result.default.gateway == vmk0_ipaddr
+      - update_all_config_result.default.congestion_algorithm == "newreno"
+      - update_all_config_result.default.max_num_connections == 11000
+      - update_all_config_result.provisioning.gateway == "100.64.0.2"
+      - update_all_config_result.provisioning.congestion_algorithm == "newreno"
+      - update_all_config_result.provisioning.max_num_connections == 11000
+      - update_all_config_result.vmotion.gateway == "100.64.1.2"
+      - update_all_config_result.vmotion.congestion_algorithm == "newreno"
+      - update_all_config_result.vmotion.max_num_connections == 11000
+
+- name: Update all tcpip stack config (idempotency)
+  vmware_host_tcpip_stacks:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi_hosts[0] }}"
+    default:
+      hostname: examplehost
+      domain: example.com
+      preferred_dns: 9.9.9.9
+      alternate_dns: 8.8.8.8
+      search_domains:
+        - example.com
+        - hoge.com
+      gateway: "{{ vmk0_ipaddr }}"
+      congestion_algorithm: newreno
+      max_num_connections: 11000
+    provisioning:
+      gateway: 100.64.0.2
+      congestion_algorithm: newreno
+      max_num_connections: 11000
+    vmotion:
+      gateway: 100.64.1.2
+      congestion_algorithm: newreno
+      max_num_connections: 11000
+  register: update_all_config_idempotency_result
+
+- name: Make sure if all tcpip stack config isn't updated
+  assert:
+    that:
+      - update_all_config_idempotency_result.changed is sameas false

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -287,6 +287,8 @@ plugins/modules/vmware_host_ssl_facts.py compile-2.6!skip
 plugins/modules/vmware_host_ssl_facts.py import-2.6!skip
 plugins/modules/vmware_host_ssl_info.py compile-2.6!skip
 plugins/modules/vmware_host_ssl_info.py import-2.6!skip
+plugins/modules/vmware_host_tcpip_stacks.py compile-2.6!skip
+plugins/modules/vmware_host_tcpip_stacks.py import-2.6!skip
 plugins/modules/vmware_host_vmhba_facts.py compile-2.6!skip
 plugins/modules/vmware_host_vmhba_facts.py import-2.6!skip
 plugins/modules/vmware_host_vmhba_info.py compile-2.6!skip

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -297,6 +297,8 @@ plugins/modules/vmware_host_ssl_facts.py compile-2.6!skip
 plugins/modules/vmware_host_ssl_facts.py import-2.6!skip
 plugins/modules/vmware_host_ssl_info.py compile-2.6!skip
 plugins/modules/vmware_host_ssl_info.py import-2.6!skip
+plugins/modules/vmware_host_tcpip_stacks.py compile-2.6!skip
+plugins/modules/vmware_host_tcpip_stacks.py import-2.6!skip
 plugins/modules/vmware_host_vmhba_facts.py compile-2.6!skip
 plugins/modules/vmware_host_vmhba_facts.py import-2.6!skip
 plugins/modules/vmware_host_vmhba_info.py compile-2.6!skip

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -297,6 +297,8 @@ plugins/modules/vmware_host_ssl_facts.py compile-2.6!skip
 plugins/modules/vmware_host_ssl_facts.py import-2.6!skip
 plugins/modules/vmware_host_ssl_info.py compile-2.6!skip
 plugins/modules/vmware_host_ssl_info.py import-2.6!skip
+plugins/modules/vmware_host_tcpip_stacks.py compile-2.6!skip
+plugins/modules/vmware_host_tcpip_stacks.py import-2.6!skip
 plugins/modules/vmware_host_vmhba_facts.py compile-2.6!skip
 plugins/modules/vmware_host_vmhba_facts.py import-2.6!skip
 plugins/modules/vmware_host_vmhba_info.py compile-2.6!skip

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -329,6 +329,8 @@ plugins/modules/vmware_host_ssl_facts.py validate-modules:deprecation-mismatch
 plugins/modules/vmware_host_ssl_facts.py validate-modules:invalid-documentation
 plugins/modules/vmware_host_ssl_info.py compile-2.6!skip
 plugins/modules/vmware_host_ssl_info.py import-2.6!skip
+plugins/modules/vmware_host_tcpip_stacks.py compile-2.6!skip
+plugins/modules/vmware_host_tcpip_stacks.py import-2.6!skip
 plugins/modules/vmware_host_vmhba_facts.py compile-2.6!skip
 plugins/modules/vmware_host_vmhba_facts.py import-2.6!skip
 plugins/modules/vmware_host_vmhba_facts.py validate-modules:deprecation-mismatch


### PR DESCRIPTION
##### SUMMARY

This PR will add a new module to update the tcpip stack configuration.

fixes: https://github.com/ansible-collections/community.vmware/issues/107
fixes: https://github.com/ansible-collections/community.vmware/issues/654

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

README.md
docs/community.vmware.vmware_host_tcpip_stacks_module.rst
meta/runtime.yml
plugins/modules/vmware_host_tcpip_stacks.py
tests/integration/targets/vmware_host_tcpip_stacks/aliases
tests/integration/targets/vmware_host_tcpip_stacks/tasks/destroy.yml
tests/integration/targets/vmware_host_tcpip_stacks/tasks/main.yml
tests/integration/targets/vmware_host_tcpip_stacks/tasks/pre.yml
tests/integration/targets/vmware_host_tcpip_stacks/tasks/vmware_host_tcpip_stacks_tests.yml
tests/sanity/ignore-2.10.txt
tests/sanity/ignore-2.11.txt
tests/sanity/ignore-2.9.txt
tests/sanity/ignore-2.12.txt

##### ADDITIONAL INFORMATION

tested on vCenter/ESXi 7.0