### PR TITLE
Skip customvalues while deploying VM on a standalone ESXi

### DIFF
--- a/changelogs/fragments/721_vmware_guest.yml
+++ b/changelogs/fragments/721_vmware_guest.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- vmware_guest - skip customvalues while deploying VM on a standalone ESXi (https://github.com/ansible-collections/community.vmware/issues/721).

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -2214,6 +2214,11 @@ class PyVmomiHelper(PyVmomi):
         if not self.params['customvalues']:
             return
 
+        if not self.is_vcenter():
+            self.module.warn("Currently connected to ESXi. "
+                             "customvalues are a vCenter feature, this parameter will be ignored.")
+            return
+
         facts = self.gather_facts(vm_obj)
         for kv in self.params['customvalues']:
             if 'key' not in kv or 'value' not in kv:


### PR DESCRIPTION
##### SUMMARY

CustomValues are supported by vCenter and not by standalone
ESXi. While deploying VM on a standalone ESXi, skip customvalues.

Fixes: #721

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/721_vmware_guest.yml
plugins/modules/vmware_guest.py
