### PR TITLE
vmware_vm_inventory - set with_nested_properties as True

### DIFF
--- a/changelogs/fragments/712_vmware_vm_inventory.yml
+++ b/changelogs/fragments/712_vmware_vm_inventory.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- vmware_vm_inventory - set default to ``True`` for ``with_nested_properties`` (https://github.com/ansible-collections/community.vmware/issues/712).

--- a/plugins/inventory/vmware_vm_inventory.py
+++ b/plugins/inventory/vmware_vm_inventory.py
@@ -96,8 +96,9 @@ DOCUMENTATION = r'''
         with_nested_properties:
             description:
             - This option transform flatten properties name to nested dictionary.
+            - From 1.10.0 and onwards, default value is set to C(True).
             type: bool
-            default: False
+            default: True
         keyed_groups:
             description:
             - Add hosts to group based on the values of a variable.


### PR DESCRIPTION
##### SUMMARY

For AWX/Tower, setting the default value for `with_nested_properties`
as True

Fixes: #712

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/712_vmware_vm_inventory.yml
plugins/inventory/vmware_vm_inventory.py
