### PR TITLE
vmware_guest: Improve virtualization based security

### DIFF
--- a/changelogs/fragments/816-vmware_guest.yml
+++ b/changelogs/fragments/816-vmware_guest.yml
@@ -1,0 +1,4 @@
+minor_changes:
+- vmware_guest - New parameter ``secure_boot`` to manage (U)EFI secure boot on VMs (https://github.com/ansible-collections/community.vmware/pull/816).
+- vmware_guest - New parameter ``vvtd`` to manage Intel Virtualization Technology for Directed I/O on VMs (https://github.com/ansible-collections/community.vmware/pull/816).
+- vmware_guest - Make the requirements for Virtualization Based Security explicit (https://github.com/ansible-collections/community.vmware/pull/816).

--- a/docs/community.vmware.vmware_guest_module.rst
+++ b/docs/community.vmware.vmware_guest_module.rst
@@ -1181,6 +1181,27 @@ Parameters
                     <td class="elbow-placeholder"></td>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>iommu</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.11.0</div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>no</li>
+                                    <li>yes</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Flag to specify if I/O MMU is enabled for this virtual machine.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>max_connections</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
@@ -1344,6 +1365,27 @@ Parameters
                     <td class="elbow-placeholder"></td>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>secure_boot</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.11.0</div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>no</li>
+                                    <li>yes</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Whether to enable or disable (U)EFI secure boot.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>version</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
@@ -1380,7 +1422,8 @@ Parameters
                 <td>
                         <div>Enable Virtualization Based Security feature for Windows on ESXi 6.7 and later, from hardware version 14.</div>
                         <div>Supported Guest OS are Windows 10 64 bit, Windows Server 2016, Windows Server 2019 and later.</div>
-                        <div>The firmware of virtual machine must be EFI.</div>
+                        <div>The firmware of virtual machine must be EFI and secure boot must be enabled.</div>
+                        <div>Virtualization Based Security depends on nested virtualization and Intel Virtualization Technology for Directed I/O.</div>
                         <div>Deploy on unsupported ESXi, hardware version or firmware may lead to failure or deployed VM with unexpected configurations.</div>
                 </td>
             </tr>

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -157,6 +157,10 @@ options:
             - Valid values are C(buslogic), C(lsilogic), C(lsilogicsas) and C(paravirtual).
             - C(paravirtual) is default.
             choices: [ 'buslogic', 'lsilogic', 'lsilogicsas', 'paravirtual' ]
+        secure_boot:
+            type: bool
+            description: Whether to enable or disable (U)EFI secure boot.
+            version_added: '1.10.0'
         memory_reservation_lock:
             type: bool
             description:
@@ -204,8 +208,13 @@ options:
             description:
             - Enable Virtualization Based Security feature for Windows on ESXi 6.7 and later, from hardware version 14.
             - Supported Guest OS are Windows 10 64 bit, Windows Server 2016, Windows Server 2019 and later.
-            - The firmware of virtual machine must be EFI.
+            - The firmware of virtual machine must be EFI and secure boot must be enabled.
+            - Virtualization Based Security depends on nested virtualization and Intel Virtualization Technology for Directed I/O.
             - Deploy on unsupported ESXi, hardware version or firmware may lead to failure or deployed VM with unexpected configurations.
+        vvtd:
+            type: bool
+            description: Flag to specify if Intel Virtualization Technology for Directed I/O is enabled for this virtual machine.
+            version_added: '1.10.0'
   guest_id:
     type: str
     description:
@@ -1801,16 +1810,27 @@ class PyVmomiHelper(PyVmomi):
                         # Don't fail if VM is already upgraded.
                         pass
 
+        secure_boot = self.params['hardware']['secure_boot']
+        if secure_boot is not None:
+            self.configspec.bootOptions = vim.vm.BootOptions()
+            self.configspec.bootOptions.efiSecureBootEnabled = True
+            if vm_obj is None or self.configspec.bootOptions.efiSecureBootEnabled != vm_obj.config.bootOptions.efiSecureBootEnabled:
+                self.change_detected = True
+
+        vvtd = self.params['hardware']['vvtd']
+        if vvtd is not None:
+            if self.configspec.flags is None:
+                self.configspec.flags = vim.vm.FlagInfo()
+            self.configspec.flags.vvtdEnabled = vvtd
+            if vm_obj is None or self.configspec.flags.vvtdEnabled != vm_obj.config.flags.vvtdEnabled:
+                self.change_detected = True
+
         virt_based_security = self.params['hardware']['virt_based_security']
         if virt_based_security is not None:
-            if vm_obj is None or vm_obj.config.flags.vbsEnabled != virt_based_security:
+            if self.configspec.flags is None:
                 self.configspec.flags = vim.vm.FlagInfo()
-                self.configspec.flags.vbsEnabled = virt_based_security
-                if virt_based_security:
-                    self.configspec.flags.vvtdEnabled = True
-                    self.configspec.nestedHVEnabled = True
-                    self.configspec.bootOptions = vim.vm.BootOptions()
-                    self.configspec.bootOptions.efiSecureBootEnabled = True
+            self.configspec.flags.vbsEnabled = virt_based_security
+            if vm_obj is None or vm_obj.config.flags.vbsEnabled != self.configspec.flags.vbsEnabled:
                 self.change_detected = True
 
     def get_device_by_type(self, vm=None, type=None):
@@ -3416,8 +3436,10 @@ def main():
                 num_cpu_cores_per_socket=dict(type='int'),
                 num_cpus=dict(type='int'),
                 scsi=dict(type='str', choices=['buslogic', 'lsilogic', 'lsilogicsas', 'paravirtual']),
+                secure_boot=dict(type='bool'),
                 version=dict(type='str'),
-                virt_based_security=dict(type='bool')
+                virt_based_security=dict(type='bool'),
+                vvtd=dict(type='bool')
             )),
         force=dict(type='bool', default=False),
         datacenter=dict(type='str', default='ha-datacenter'),
@@ -3475,6 +3497,24 @@ def main():
     result = {'failed': False, 'changed': False}
 
     pyv = PyVmomiHelper(module)
+
+    # Check requirements for virtualization based security
+    if pyv.params['hardware']['virt_based_security']:
+        if not pyv.params['hardware']['nested_virt']:
+            pyv.module.warn("Virtualization based security requires nested virtualization. At the moment, this modules enables this implicitly. "
+                            "Please consider enabling this explicitly because this behavior might change in the future.")
+            pyv.params['hardware']['nested_virt'] = True
+
+        if not pyv.params['hardware']['secure_boot']:
+            pyv.module.warn("Virtualization based security requires (U)EFI secure boot. At the moment, this modules enables this implicitly. "
+                            "Please consider enabling this explicitly because this behavior might change in the future.")
+            pyv.params['hardware']['secure_boot'] = True
+
+        if not pyv.params['hardware']['vvtd']:
+            pyv.module.warn("Virtualization based security requires Intel Virtualization Technology for Directed I/O."
+                            "At the moment, this modules enables this implicitly. "
+                            "Please consider enabling vvtd explicitly because this behavior might change in the future.")
+            pyv.params['hardware']['vvtd'] = True
 
     # Check if the VM exists before continuing
     vm = pyv.get_vm()

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -160,7 +160,7 @@ options:
         secure_boot:
             type: bool
             description: Whether to enable or disable (U)EFI secure boot.
-            version_added: '1.10.0'
+            version_added: '1.11.0'
         memory_reservation_lock:
             type: bool
             description:
@@ -214,7 +214,7 @@ options:
         iommu:
             type: bool
             description: Flag to specify if I/O MMU is enabled for this virtual machine.
-            version_added: '1.10.0'
+            version_added: '1.11.0'
   guest_id:
     type: str
     description:

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -211,9 +211,9 @@ options:
             - The firmware of virtual machine must be EFI and secure boot must be enabled.
             - Virtualization Based Security depends on nested virtualization and Intel Virtualization Technology for Directed I/O.
             - Deploy on unsupported ESXi, hardware version or firmware may lead to failure or deployed VM with unexpected configurations.
-        vvtd:
+        iommu:
             type: bool
-            description: Flag to specify if Intel Virtualization Technology for Directed I/O is enabled for this virtual machine.
+            description: Flag to specify if I/O MMU is enabled for this virtual machine.
             version_added: '1.10.0'
   guest_id:
     type: str
@@ -1817,11 +1817,11 @@ class PyVmomiHelper(PyVmomi):
             if vm_obj is None or self.configspec.bootOptions.efiSecureBootEnabled != vm_obj.config.bootOptions.efiSecureBootEnabled:
                 self.change_detected = True
 
-        vvtd = self.params['hardware']['vvtd']
-        if vvtd is not None:
+        iommu = self.params['hardware']['iommu']
+        if iommu is not None:
             if self.configspec.flags is None:
                 self.configspec.flags = vim.vm.FlagInfo()
-            self.configspec.flags.vvtdEnabled = vvtd
+            self.configspec.flags.vvtdEnabled = iommu
             if vm_obj is None or self.configspec.flags.vvtdEnabled != vm_obj.config.flags.vvtdEnabled:
                 self.change_detected = True
 
@@ -3439,7 +3439,7 @@ def main():
                 secure_boot=dict(type='bool'),
                 version=dict(type='str'),
                 virt_based_security=dict(type='bool'),
-                vvtd=dict(type='bool')
+                iommu=dict(type='bool')
             )),
         force=dict(type='bool', default=False),
         datacenter=dict(type='str', default='ha-datacenter'),
@@ -3510,11 +3510,10 @@ def main():
                             "Please consider enabling this explicitly because this behavior might change in the future.")
             pyv.params['hardware']['secure_boot'] = True
 
-        if not pyv.params['hardware']['vvtd']:
-            pyv.module.warn("Virtualization based security requires Intel Virtualization Technology for Directed I/O."
-                            "At the moment, this modules enables this implicitly. "
-                            "Please consider enabling vvtd explicitly because this behavior might change in the future.")
-            pyv.params['hardware']['vvtd'] = True
+        if not pyv.params['hardware']['iommu']:
+            pyv.module.warn("Virtualization based security requires I/O MMU. At the moment, this modules enables this implicitly. "
+                            "Please consider enabling iommu explicitly because this behavior might change in the future.")
+            pyv.params['hardware']['iommu'] = True
 
     # Check if the VM exists before continuing
     vm = pyv.get_vm()


### PR DESCRIPTION
##### SUMMARY
When enabling visualization based security, `vmware_guest` silently configures some stuff like secure boot. I think we should make this explicit.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_guest

##### ADDITIONAL INFORMATION
#351 made me think about how we handle visualization based security and I don't like it. I really don't think it's a good idea if modules silently configure something, I think it should always be explicit. Or, at least, they should issue a warning that they are doing some things implicitly.