### PR TITLE
vmware_guest_powerstate: Add the answer option to require in starting the vm

### DIFF
--- a/changelogs/fragments/821-vmware_guest_powerstate.yml
+++ b/changelogs/fragments/821-vmware_guest_powerstate.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - vmware_guest_powerstate - Add an option that answers whether it was copied or moved the vm if the vm is blocked (https://github.com/ansible-collections/community.vmware/pull/821).
+  - vmware - add processing to answer if the answer question is occurred in starting the vm (https://github.com/ansible-collections/community.vmware/pull/821).

--- a/docs/community.vmware.vmware_guest_powerstate_module.rst
+++ b/docs/community.vmware.vmware_guest_powerstate_module.rst
@@ -35,34 +35,66 @@ Parameters
 
     <table  border=0 cellpadding=0 class="documentation-table">
         <tr>
-            <th colspan="1">Parameter</th>
+            <th colspan="2">Parameter</th>
             <th>Choices/<font color="blue">Defaults</font></th>
             <th width="100%">Comments</th>
         </tr>
             <tr>
-                <td colspan="1">
+                <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>answer</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=dictionary</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.11.0</div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>A list of questions to answer, should one or more arise while waiting for the task to complete.</div>
+                        <div>Some common uses are to allow a cdrom to be changed even if locked, or to answer the question as to whether a VM was copied or moved.</div>
+                        <div>The <em>answer</em> can be used if <em>state</em> is <code>powered-on</code>.</div>
+                </td>
+            </tr>
+                                <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>question</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
                         <span style="color: purple">string</span>
+                         / <span style="color: red">required</span>
                     </div>
                 </td>
                 <td>
-                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
-                                    <li>moved</li>
-                                    <li>copied</li>
-                        </ul>
                 </td>
                 <td>
-                        <div>The <em>answer</em> is required in the vm starting process if the vm is blocked after you copied or moved the vm.</div>
-                        <div>The <em>answer</em> can be used if <em>state</em> is <code>powered-on</code>.</div>
-                        <div>If <em>answer</em> is set to <code>moved</code>, answer as a moved vm.</div>
-                        <div>If <em>answer</em> is set to <code>copied</code>, answer as a copied vm.</div>
+                        <div>The message id, for example <code>msg.uuid.altered</code>.</div>
                 </td>
             </tr>
             <tr>
+                    <td class="elbow-placeholder"></td>
                 <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>response</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The choice key, for example <code>button.uuid.copiedTheVM</code>.</div>
+                </td>
+            </tr>
+
+            <tr>
+                <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>folder</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -88,7 +120,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="1">
+                <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>force</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -108,7 +140,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="1">
+                <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>hostname</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -125,7 +157,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="1">
+                <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>moid</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -141,7 +173,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="1">
+                <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>name</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -157,7 +189,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="1">
+                <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>name_match</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -176,7 +208,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="1">
+                <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>password</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -194,7 +226,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="1">
+                <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>port</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -212,7 +244,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="1">
+                <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>proxy_host</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -230,7 +262,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="1">
+                <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>proxy_port</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -246,7 +278,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="1">
+                <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>schedule_task_description</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -262,7 +294,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="1">
+                <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>schedule_task_enabled</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -281,7 +313,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="1">
+                <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>schedule_task_name</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -297,7 +329,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="1">
+                <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>scheduled_at</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -314,7 +346,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="1">
+                <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>state</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -338,7 +370,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="1">
+                <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>state_change_timeout</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -356,7 +388,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="1">
+                <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>use_instance_uuid</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -375,7 +407,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="1">
+                <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>username</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -393,7 +425,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="1">
+                <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>uuid</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -409,7 +441,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td colspan="1">
+                <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>validate_certs</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
@@ -488,6 +520,31 @@ Examples
         state_change_timeout: 200
       delegate_to: localhost
       register: deploy
+
+    - name: Automatically answer if a question locked a virtual machine
+      block:
+        - name: Power on a virtual machine without the answer param
+          vmware_guest_powerstate:
+            hostname: "{{ ansible_host }}"
+            username: "{{ ansible_user }}"
+            password: "{{ ansible_password }}"
+            validate_certs: false
+            folder: "{{ f1 }}"
+            name: "{{ vm_name }}"
+            state: powered-on
+      rescue:
+        - name: Power on a virtual machine with the answer param
+          vmware_guest_powerstate:
+            hostname: "{{ ansible_host }}"
+            username: "{{ ansible_user }}"
+            password: "{{ ansible_password }}"
+            validate_certs: false
+            folder: "{{ f1 }}"
+            name: "{{ vm_name }}"
+            answer:
+              - question: "msg.uuid.altered"
+                response: "button.uuid.copiedTheVM"
+            state: powered-on
 
 
 

--- a/docs/community.vmware.vmware_guest_powerstate_module.rst
+++ b/docs/community.vmware.vmware_guest_powerstate_module.rst
@@ -42,6 +42,28 @@ Parameters
             <tr>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>answer</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>moved</li>
+                                    <li>copied</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>The <em>answer</em> is required in the vm starting process if the vm is blocked after you copied or moved the vm.</div>
+                        <div>The <em>answer</em> can be used if <em>state</em> is <code>powered-on</code>.</div>
+                        <div>If <em>answer</em> is set to <code>moved</code>, answer as a moved vm.</div>
+                        <div>If <em>answer</em> is set to <code>copied</code>, answer as a copied vm.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>folder</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">

--- a/docs/community.vmware.vmware_guest_powerstate_module.rst
+++ b/docs/community.vmware.vmware_guest_powerstate_module.rst
@@ -525,9 +525,9 @@ Examples
       block:
         - name: Power on a virtual machine without the answer param
           vmware_guest_powerstate:
-            hostname: "{{ ansible_host }}"
-            username: "{{ ansible_user }}"
-            password: "{{ ansible_password }}"
+            hostname: "{{ esxi_hostname }}"
+            username: "{{ esxi_username }}"
+            password: "{{ esxi_password }}"
             validate_certs: false
             folder: "{{ f1 }}"
             name: "{{ vm_name }}"
@@ -535,9 +535,9 @@ Examples
       rescue:
         - name: Power on a virtual machine with the answer param
           vmware_guest_powerstate:
-            hostname: "{{ ansible_host }}"
-            username: "{{ ansible_user }}"
-            password: "{{ ansible_password }}"
+            hostname: "{{ esxi_hostname }}"
+            username: "{{ esxi_username }}"
+            password: "{{ esxi_password }}"
             validate_certs: false
             folder: "{{ f1 }}"
             name: "{{ vm_name }}"

--- a/plugins/module_utils/vmware.py
+++ b/plugins/module_utils/vmware.py
@@ -51,7 +51,66 @@ class TaskError(Exception):
         super(TaskError, self).__init__(*args, **kwargs)
 
 
-def wait_for_task(task, max_backoff=64, timeout=3600):
+def check_answer_question_status(vm):
+    """Check whether locked a virtual machine.
+
+    Args:
+        vm: Virtual machine management object
+
+    Returns: bool
+    """
+    if hasattr(vm, "runtime") and vm.runtime.question:
+        return True
+
+    return False
+
+
+def make_answer_response(vm, answers):
+    """Make the response contents to answer against locked a virtual machine.
+
+    Args:
+        vm: Virtual machine management object
+        answers: Answer contents
+
+    Returns: Dict with answer id and number
+    Raises: TaskError on failure
+    """
+    response_list = {}
+    for message in vm.runtime.question.message:
+        response_list[message.id] = {}
+        for choice in vm.runtime.question.choice.choiceInfo:
+            response_list[message.id].update({
+                choice.label: choice.key
+            })
+
+    responses = []
+    try:
+        for answer in answers:
+            responses.append({
+                "id": vm.runtime.question.id,
+                "response_num": response_list[answer["question"]][answer["response"]]
+            })
+    except Exception:
+        raise TaskError("not found %s or %s or both in the response list" % (answer["question"], answer["response"]))
+
+    return responses
+
+
+def answer_question(vm, responses):
+    """Answer against the question for unlocking a virtual machine.
+
+    Args:
+        vm: Virtual machine management object
+        responses: Answer contents to unlock a virtual machine
+    """
+    for response in responses:
+        try:
+            vm.AnswerVM(response["id"], response["response_num"])
+        except Exception as e:
+            raise TaskError("answer failed: %s" % to_text(e))
+
+
+def wait_for_task(task, max_backoff=64, timeout=3600, vm=None, answers=None):
     """Wait for given task using exponential back-off algorithm.
 
     Args:
@@ -66,6 +125,12 @@ def wait_for_task(task, max_backoff=64, timeout=3600):
     start_time = time.time()
 
     while True:
+        if check_answer_question_status(vm):
+            if answers:
+                responses = make_answer_response(vm, answers)
+                answer_question(vm, responses)
+            else:
+                raise TaskError("%s" % to_text(vm.runtime.question.text))
         if time.time() - start_time >= timeout:
             raise TaskError("Timeout")
         if task.info.state == vim.TaskInfo.State.success:
@@ -780,7 +845,7 @@ def find_host_by_cluster_datacenter(module, content, datacenter_name, cluster_na
     return None, cluster
 
 
-def set_vm_power_state(content, vm, state, force, timeout=0, answer=None):
+def set_vm_power_state(content, vm, state, force, timeout=0, answers=None):
     """
     Set the power status for a VM determined by the current and
     requested states. force is forceful
@@ -809,15 +874,6 @@ def set_vm_power_state(content, vm, state, force, timeout=0, answer=None):
 
             elif expected_state == 'poweredon':
                 task = vm.PowerOn()
-                if answer:
-                    answers = {
-                        "moved": "1",
-                        "copied": "2"
-                    }
-                    while task.info.state not in [vim.TaskInfo.State.success, vim.TaskInfo.State.error]:
-                        if vm.runtime.question is not None:
-                            question_id = vm.runtime.question.id
-                            vm.AnswerVM(question_id, answers[answer])
 
             elif expected_state == 'restarted':
                 if current_state in ('poweredon', 'poweringon', 'resetting', 'poweredoff'):
@@ -861,12 +917,17 @@ def set_vm_power_state(content, vm, state, force, timeout=0, answer=None):
             result['msg'] = to_text(e)
 
         if task:
-            wait_for_task(task)
-            if task.info.state == 'error':
+            try:
+                wait_for_task(task, vm=vm, answers=answers)
+            except TaskError as e:
                 result['failed'] = True
-                result['msg'] = task.info.error.msg
-            else:
-                result['changed'] = True
+                result['msg'] = to_text(e)
+            finally:
+                if task.info.state == 'error':
+                    result['failed'] = True
+                    result['msg'] = task.info.error.msg
+                else:
+                    result['changed'] = True
 
     # need to get new metadata if changed
     result['instance'] = gather_vm_facts(content, vm)

--- a/plugins/module_utils/vmware.py
+++ b/plugins/module_utils/vmware.py
@@ -780,7 +780,7 @@ def find_host_by_cluster_datacenter(module, content, datacenter_name, cluster_na
     return None, cluster
 
 
-def set_vm_power_state(content, vm, state, force, timeout=0):
+def set_vm_power_state(content, vm, state, force, timeout=0, answer=None):
     """
     Set the power status for a VM determined by the current and
     requested states. force is forceful
@@ -809,6 +809,15 @@ def set_vm_power_state(content, vm, state, force, timeout=0):
 
             elif expected_state == 'poweredon':
                 task = vm.PowerOn()
+                if answer:
+                    answers = {
+                        "moved": "1",
+                        "copied": "2"
+                    }
+                    while task.info.state not in [vim.TaskInfo.State.success, vim.TaskInfo.State.error]:
+                        if vm.runtime.question is not None:
+                            question_id = vm.runtime.question.id
+                            vm.AnswerVM(question_id, answers[answer])
 
             elif expected_state == 'restarted':
                 if current_state in ('poweredon', 'poweringon', 'resetting', 'poweredoff'):

--- a/plugins/modules/vmware_guest_powerstate.py
+++ b/plugins/modules/vmware_guest_powerstate.py
@@ -180,9 +180,9 @@ EXAMPLES = r"""
   block:
     - name: Power on a virtual machine without the answer param
       vmware_guest_powerstate:
-        hostname: "{{ ansible_host }}"
-        username: "{{ ansible_user }}"
-        password: "{{ ansible_password }}"
+        hostname: "{{ esxi_hostname }}"
+        username: "{{ esxi_username }}"
+        password: "{{ esxi_password }}"
         validate_certs: false
         folder: "{{ f1 }}"
         name: "{{ vm_name }}"
@@ -190,9 +190,9 @@ EXAMPLES = r"""
   rescue:
     - name: Power on a virtual machine with the answer param
       vmware_guest_powerstate:
-        hostname: "{{ ansible_host }}"
-        username: "{{ ansible_user }}"
-        password: "{{ ansible_password }}"
+        hostname: "{{ esxi_hostname }}"
+        username: "{{ esxi_username }}"
+        password: "{{ esxi_password }}"
         validate_certs: false
         folder: "{{ f1 }}"
         name: "{{ vm_name }}"


### PR DESCRIPTION
##### SUMMARY

The answer is required in starting the vm if the vm is blocked after you copied or moved the vm.  
FYI, The following image is shown at that time on Web Client.

<img width="548" alt="スクリーンショット 2021-04-29 22 35 35" src="https://user-images.githubusercontent.com/19516126/116573024-6b208e80-a947-11eb-8ac8-ef16fcc2d134.png">

This PR will add the option to answer to the module and vmware.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

changelogs/fragments/821-vmware_guest_powerstate.yml
docs/community.vmware.vmware_guest_powerstate_module.rst
plugins/module_utils/vmware.py
plugins/modules/vmware_guest_powerstate.py

##### ADDITIONAL INFORMATION

tested on ESXi 7.0