### PR TITLE
DNM - Proposal about adding the common answer method into vmware.py

### DIFF
--- a/plugins/modules/vmware_guest_powerstate.py
+++ b/plugins/modules/vmware_guest_powerstate.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = r'''
+DOCUMENTATION = r"""
 ---
 module: vmware_guest_powerstate
 short_description: Manages power states of virtual machines in vCenter
@@ -104,12 +104,26 @@ options:
     - The value sets a timeout in seconds for the module to wait for the state change.
     default: 0
     type: int
+  answer:
+    description:
+    - The I(answer) is required in the vm starting process if the vm is blocked after you copied or moved the vm.
+    - The I(answer) can be used if I(state) is C(powered-on).
+    suboptions:
+      question:
+        description: TBD
+        type: str
+        required: True
+      response:
+        description: TBD
+        type: str
+        required: True
+    type: list
+    elements: dict
 extends_documentation_fragment:
 - community.vmware.vmware.documentation
+"""
 
-'''
-
-EXAMPLES = r'''
+EXAMPLES = r"""
 - name: Set the state of a virtual machine to poweroff
   community.vmware.vmware_guest_powerstate:
     hostname: "{{ vcenter_hostname }}"
@@ -157,9 +171,9 @@ EXAMPLES = r'''
     state_change_timeout: 200
   delegate_to: localhost
   register: deploy
-'''
+"""
 
-RETURN = r''' # '''
+RETURN = r""" # """
 
 try:
     from pyVmomi import vim, vmodl
@@ -169,7 +183,8 @@ except ImportError:
 from random import randint
 from datetime import datetime
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, set_vm_power_state, vmware_argument_spec
+from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, set_vm_power_state, vmware_argument_spec, \
+    check_answer_question_status, make_answer_response, answer_question, gather_vm_facts
 from ansible.module_utils._text import to_native
 
 
@@ -190,6 +205,12 @@ def main():
         schedule_task_description=dict(),
         schedule_task_enabled=dict(type='bool', default=True),
         state_change_timeout=dict(type='int', default=0),
+        answer=dict(type='list',
+                    elements='dict',
+                    options=dict(
+                        question=dict(type='str', required=True),
+                        response=dict(type='str', required=True)
+                    ))
     )
 
     module = AnsibleModule(
@@ -197,6 +218,7 @@ def main():
         supports_check_mode=False,
         mutually_exclusive=[
             ['name', 'uuid', 'moid'],
+            ['scheduled_at', 'answer']
         ],
     )
 
@@ -258,7 +280,24 @@ def main():
                                      "given are invalid: %s" % (module.params.get('state'),
                                                                 to_native(e.msg)))
         else:
-            result = set_vm_power_state(pyv.content, vm, module.params['state'], module.params['force'], module.params['state_change_timeout'])
+            # Check if a virtual machine is locked by a question
+            if check_answer_question_status(vm) and module.params['answer']:
+                try:
+                    responses = make_answer_response(vm, module.params['answer'])
+                    answer_question(vm, responses)
+                except Exception as e:
+                    module.fail_json(msg="%s" % e)
+
+                # Wait until a virtual machine is unlocked
+                while True:
+                    if check_answer_question_status(vm) is False:
+                        break
+
+                module.exit_json(changed=True, instance=gather_vm_facts(pyv.content, vm))
+            else:
+                result = set_vm_power_state(pyv.content, vm, module.params['state'], module.params['force'], module.params['state_change_timeout'],
+                                            module.params['answer'])
+            result["answer"] = module.params['answer']
     else:
         id = module.params.get('uuid') or module.params.get('moid') or module.params.get('name')
         module.fail_json(msg="Unable to set power state for non-existing virtual machine : '%s'" % id)


### PR DESCRIPTION
##### SUMMARY

This PR is for discussion about adding the answer method, so as not to merge.  
Related comments: https://github.com/ansible-collections/community.vmware/pull/821#issuecomment-829801696

I made some methods for the answer.  

* check_answer_question_status
    * Check whether the virtual machine has a question.
* make_anwer_response
    * Make the response list to answer the question.
* answer_question
    * Answer the question to unlock the virtual machine.

I made a sample using them in the vmware_guest_powerstate module.  
I'm thinking that the same can-do also the vmware_guest module.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/module_utils/vmware.py
plugins/modules/vmware_guest_powerstate.py

##### ADDITIONAL INFORMATION

If you know beforehand the virtual machine has a question, you can be used the answer parameter the following like.

```yaml
---
- name: Example playbook to answer the question
  hosts: all
  gather_facts: false
  tasks:
    - name: Answer the question to unlock a virtual machine
      vmware_guest_powerstate:
        hostname: "{{ ansible_host }}"
        username: "{{ ansible_user }}"
        password: "{{ ansible_password }}"
        validate_certs: false
        folder: '/vm'
        name: clone_vm01
        answer:
          - question: msg.uuid.altered
            response: button.uuid.copiedTheVM
        state: powered-on
      delegate_to: localhost
```

If you don't know whether the virtual machine has a question, you can make the answer after executing power on processing is failed the following like.

```yaml
---
- name: Example playbook to answer the question based on the instance info
  hosts: all
  gather_facts: false
  tasks:
    - name: Power on a virtual machine without the answer param
      vmware_guest_powerstate:
        hostname: "{{ ansible_host }}"
        username: "{{ ansible_user }}"
        password: "{{ ansible_password }}"
        validate_certs: false
        folder: '/vm'
        name: clone_vm01
        state: powered-on
      delegate_to: localhost
      ignore_errors: true
      register: result

    - when:
        - result.failed is true
      block:
        - name: set the question variable
          set_fact:
            question: "{{ item.value.0.id }}"
          with_dict: "{{ result.instance.guest_question }}"
          when:
            - item.key == "message"

        - name: set the response variable
          set_fact:
            response: >-
              {{ ['label'] | map('extract',
                 (item.value.choiceInfo
                  | selectattr('label', 'equalto', 'button.uuid.copiedTheVM')
                  | list
                  | first)
                 )
                | list
                | first
              }}
          with_dict: "{{ result.instance.guest_question }}"
          when:
            - item.key == "choice"

        - name: Power on a virtual machine with the answer param
          vmware_guest_powerstate:
            hostname: "{{ ansible_host }}"
            username: "{{ ansible_user }}"
            password: "{{ ansible_password }}"
            validate_certs: false
            folder: '/vm'
            name: clone_vm01
            answer:
              - question: "{{ question }}"
                response: "{{ response }}"
            state: powered-on
          delegate_to: localhost
          ignore_errors: true
```

Also, you can be gathered about the question information with the vmware_guest_info module.  
The following is a sample question info of a locked virtual machine.

```
(snip)
            "guest_question": {
                "_vimtype": "vim.vm.QuestionInfo",
                "choice": {
                    "_vimtype": "vim.option.ChoiceOption",
                    "choiceInfo": [
                        {
                            "_vimtype": "vim.ElementDescription",
                            "dynamicProperty": [],
                            "dynamicType": null,
                            "key": "0",
                            "label": "button.uuid.cancel",
                            "summary": "Cancel"
                        },
                        {
                            "_vimtype": "vim.ElementDescription",
                            "dynamicProperty": [],
                            "dynamicType": null,
                            "key": "1",
                            "label": "button.uuid.movedTheVM",
                            "summary": "I Moved It"
                        },
                        {
                            "_vimtype": "vim.ElementDescription",
                            "dynamicProperty": [],
                            "dynamicType": null,
                            "key": "2",
                            "label": "button.uuid.copiedTheVM",
                            "summary": "I Copied It"
                        }
                    ],
                    "defaultIndex": 2,
                    "dynamicProperty": [],
                    "dynamicType": null,
                    "valueIsReadonly": null
                },
                "dynamicProperty": [],
                "dynamicType": null,
                "id": "194940986",
                "message": [
                    {
                        "_vimtype": "vim.vm.Message",
                        "argument": [
                            "VMware ESX",
                            "button.uuid.copiedTheVM"
                        ],
                        "dynamicProperty": [],
                        "dynamicType": null,
                        "id": "msg.uuid.altered",
                        "text": "This virtual machine might have been moved or copied. In order to configure certain management and networking features, VMware ESX needs to know if this virtual machine was moved or copied. If you don't know, answer \"I Copied It\". "
                    }
                ],
                "text": "This virtual machine might have been moved or copied. In order to configure certain management and networking features, VMware ESX needs to know if this virtual machine was moved or copied. If you don't know, answer \"I Copied It\". "
            },
(snip)
```

What do you think?

