### PR TITLE
vmware_guest: Fix hostname is None when not used in playbook.

### DIFF
--- a/changelogs/fragments/831-vmware_guest-hostname.yml
+++ b/changelogs/fragments/831-vmware_guest-hostname.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_guest - Use hostname parameter in customization only if value is not None (https://github.com/ansible-collections/community.vmware/issues/655)

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -2324,7 +2324,12 @@ class PyVmomiHelper(PyVmomi):
                 default_name = vm_obj.name.replace(' ', '')
             punctuation = string.punctuation.replace('-', '')
             default_name = ''.join([c for c in default_name if c not in punctuation])
-            ident.userData.computerName.name = str(self.params['customization'].get('hostname', default_name[0:15]))
+
+            if self.params['customization']['hostname'] is not None:
+                ident.userData.computerName.name = self.params['customization']['hostname'][0:15]
+            else:
+                ident.userData.computerName.name = default_name[0:15]
+
             ident.userData.fullName = str(self.params['customization'].get('fullname', 'Administrator'))
             ident.userData.orgName = str(self.params['customization'].get('orgname', 'ACME'))
 
@@ -2385,7 +2390,12 @@ class PyVmomiHelper(PyVmomi):
                 default_name = self.params['name']
             elif vm_obj:
                 default_name = vm_obj.name
-            hostname = str(self.params['customization'].get('hostname', default_name.split('.')[0]))
+
+            if self.params['customization']['hostname'] is not None:
+                hostname = self.params['customization']['hostname'].split('.')[0]
+            else:
+                hostname = default_name.split('.')[0]
+
             # Remove all characters except alphanumeric and minus which is allowed by RFC 952
             valid_hostname = re.sub(r"[^a-zA-Z0-9\-]", "", hostname)
             ident.hostName.name = valid_hostname


### PR DESCRIPTION
##### SUMMARY
Only use hostname from customization dictionary if value is not None. 

Fixes #655

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_guest.py

##### ADDITIONAL INFORMATION
The "customization" dictionary seems to be filled with None values when parameters like hostname aren't set in playbook. default_name is not used here because hostname already exists in the dictionary.