### PR TITLE
vmware_dvswitch: Add Network Policy

### DIFF
--- a/changelogs/fragments/833-vmware_dvswitch-network_policy.yml
+++ b/changelogs/fragments/833-vmware_dvswitch-network_policy.yml
@@ -1,2 +1,3 @@
 minor_changes:
 - vmware_dvswitch - Implement network_policy parameter with suboptions promiscuous, forged_transmits and mac_changes (https://github.com/ansible-collections/community.vmware/issues/833).
+- vmware_dvswitch - Dynamically check the DVS versions vCenter supports (https://github.com/ansible-collections/community.vmware/issues/839).

--- a/changelogs/fragments/833-vmware_dvswitch-network_policy.yml
+++ b/changelogs/fragments/833-vmware_dvswitch-network_policy.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- vmware_dvswitch - Implement network_policy parameter with suboptions promiscuous, forged_transmits and mac_changes (https://github.com/ansible-collections/community.vmware/issues/833).

--- a/docs/community.vmware.vmware_dvswitch_module.rst
+++ b/docs/community.vmware.vmware_dvswitch_module.rst
@@ -347,6 +347,83 @@ Parameters
             <tr>
                 <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>network_policy</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.11.0</div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Dictionary which configures the different default security values for portgroups.</div>
+                </td>
+            </tr>
+                                <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>forged_transmits</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                    <li>yes</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Indicates whether forged transmits are allowed.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>mac_changes</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                    <li>yes</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Indicates whether mac changes are allowed.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>promiscuous</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                    <li>yes</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Indicates whether promiscuous mode is allowed.</div>
+                </td>
+            </tr>
+
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>password</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">

--- a/docs/community.vmware.vmware_dvswitch_module.rst
+++ b/docs/community.vmware.vmware_dvswitch_module.rst
@@ -538,21 +538,9 @@ Parameters
                     </div>
                 </td>
                 <td>
-                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
-                                    <li>5.0.0</li>
-                                    <li>5.1.0</li>
-                                    <li>5.5.0</li>
-                                    <li>6.0.0</li>
-                                    <li>6.5.0</li>
-                                    <li>6.6.0</li>
-                                    <li>7.0.0</li>
-                        </ul>
                 </td>
                 <td>
                         <div>The version of the Distributed Switch to create.</div>
-                        <div>Can be 6.0.0, 5.5.0, 5.1.0, 5.0.0 with a vCenter running vSphere 6.0 and 6.5.</div>
-                        <div>Can be 6.6.0, 6.5.0, 6.0.0 with a vCenter running vSphere 6.7.</div>
-                        <div>Can be 7.0.0, 6.6.0, 6.5.0 with a vCenter running vSphere 7.0.</div>
                         <div>The version must match the version of the ESXi hosts you want to connect.</div>
                         <div>The version of the vCenter server is used if not specified.</div>
                         <div>Required only if <code>state</code> is set to <code>present</code>.</div>

--- a/docs/community.vmware.vmware_dvswitch_module.rst
+++ b/docs/community.vmware.vmware_dvswitch_module.rst
@@ -358,6 +358,7 @@ Parameters
                 </td>
                 <td>
                         <div>Dictionary which configures the different default security values for portgroups.</div>
+                        <div>If set, these options are inherited by the portgroups of the DVS.</div>
                 </td>
             </tr>
                                 <tr>

--- a/plugins/module_utils/vmware.py
+++ b/plugins/module_utils/vmware.py
@@ -946,6 +946,13 @@ def quote_obj_name(object_name=None):
     return object_name
 
 
+def dvs_supports_mac_learning(dvs):
+    """
+    Test if the switch supports MAC learning
+    """
+    return hasattr(dvs.capability.featuresSupported, 'macLearningSupported') and dvs.capability.featuresSupported.macLearningSupported
+
+
 class PyVmomi(object):
     def __init__(self, module):
         """

--- a/plugins/modules/vmware_dvs_portgroup_info.py
+++ b/plugins/modules/vmware_dvs_portgroup_info.py
@@ -141,7 +141,12 @@ except ImportError:
     pass
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.community.vmware.plugins.module_utils.vmware import vmware_argument_spec, PyVmomi, get_all_objs, find_dvs_by_name
+from ansible_collections.community.vmware.plugins.module_utils.vmware import (
+    vmware_argument_spec,
+    PyVmomi,
+    dvs_supports_mac_learning,
+    get_all_objs,
+    find_dvs_by_name)
 from ansible.module_utils.six.moves.urllib.parse import unquote
 
 
@@ -164,9 +169,6 @@ class DVSPortgroupInfoManager(PyVmomi):
         else:
             # default behaviour, gather information about all dvswitches
             self.dvsls = get_all_objs(self.content, [vim.DistributedVirtualSwitch], folder=datacenter.networkFolder)
-
-    def supports_mac_learning(self, dvs):
-        return hasattr(dvs.capability.featuresSupported, 'macLearningSupported') and dvs.capability.featuresSupported.macLearningSupported
 
     def get_vlan_info(self, vlan_obj=None):
         """
@@ -199,7 +201,7 @@ class DVSPortgroupInfoManager(PyVmomi):
         dvs_lists = self.dvsls
         result = dict()
         for dvs in dvs_lists:
-            switch_supports_mac_learning = self.supports_mac_learning(dvs)
+            switch_supports_mac_learning = dvs_supports_mac_learning(dvs)
             result[dvs.name] = list()
             for dvs_pg in dvs.portgroup:
                 mac_learning = dict()

--- a/plugins/modules/vmware_dvswitch.py
+++ b/plugins/modules/vmware_dvswitch.py
@@ -436,9 +436,9 @@ class VMwareDvSwitch(PyVmomi):
                 results['network_policy'] = {}
                 if 'promiscuous' in network_policy:
                     results['network_policy']['promiscuous'] = network_policy['promiscuous']
-                if network_policy['forged_transmits'] is not None:
+                if 'forged_transmits' in network_policy:
                     results['network_policy']['forged_transmits'] = network_policy['forged_transmits']
-                if network_policy['mac_changes'] is not None:
+                if 'mac_changes' in network_policy:
                     results['network_policy']['mac_changes'] = network_policy['mac_changes']
 
                 result = self.check_network_policy_config()
@@ -739,6 +739,12 @@ class VMwareDvSwitch(PyVmomi):
         # Check Network Policy
         if 'promiscuous' in self.network_policy or 'forged_transmits' in self.network_policy or 'mac_changes' in self.network_policy:
             results['network_policy'] = {}
+            if 'promiscuous' in self.network_policy:
+                results['network_policy']['promiscuous'] = self.network_policy['promiscuous']
+            if 'forged_transmits' in self.network_policy:
+                results['network_policy']['forged_transmits'] = self.network_policy['forged_transmits']
+            if 'mac_changes' in self.network_policy:
+                results['network_policy']['mac_changes'] = self.network_policy['mac_changes']
 
             (policy, changed_network_policy, changed_promiscuous, promiscuous_previous, changed_forged_transmits,
              forged_transmits_previous, changed_mac_changes, mac_changes_previous) = \
@@ -750,15 +756,12 @@ class VMwareDvSwitch(PyVmomi):
                 results['network_policy_previous'] = {}
                 if changed_promiscuous:
                     results['network_policy_previous']['promiscuous'] = promiscuous_previous
-                    results['network_policy']['promiscuous'] = self.network_policy['promiscuous']
 
                 if changed_forged_transmits:
                     results['network_policy_previous']['forged_transmits'] = forged_transmits_previous
-                    results['network_policy']['forged_transmits'] = self.network_policy['forged_transmits']
 
                 if changed_mac_changes:
                     results['network_policy_previous']['mac_changes'] = mac_changes_previous
-                    results['network_policy']['mac_changes'] = self.network_policy['mac_changes']
 
                 if config_spec.defaultPortConfig is None:
                     config_spec.defaultPortConfig = vim.dvs.VmwareDistributedVirtualSwitch.VmwarePortConfigPolicy()

--- a/plugins/modules/vmware_dvswitch.py
+++ b/plugins/modules/vmware_dvswitch.py
@@ -150,6 +150,7 @@ options:
         version_added: '1.11.0'
         description:
             - Dictionary which configures the different default security values for portgroups.
+            - If set, these options are inherited by the portgroups of the DVS.
         suboptions:
             promiscuous:
                 type: bool

--- a/plugins/modules/vmware_dvswitch.py
+++ b/plugins/modules/vmware_dvswitch.py
@@ -150,6 +150,25 @@ options:
             vlan_mtu_interval: 0,
             teaming_failover_interval: 0,
         }
+    network_policy:
+        version_added: '1.11.0'
+        description:
+            - Dictionary which configures the different default security values for portgroups.
+        suboptions:
+            promiscuous:
+                type: bool
+                description: Indicates whether promiscuous mode is allowed.
+                default: False
+            forged_transmits:
+                type: bool
+                description: Indicates whether forged transmits are allowed.
+                default: False
+            mac_changes:
+                type: bool
+                description: Indicates whether mac changes are allowed.
+                default: False
+        required: False
+        type: dict
     state:
         description:
             - If set to C(present) and the Distributed Switch does not exist, the Distributed Switch will be created.
@@ -264,7 +283,7 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 from ansible_collections.community.vmware.plugins.module_utils.vmware import (
-    PyVmomi, TaskError, find_dvs_by_name, vmware_argument_spec, wait_for_task
+    PyVmomi, TaskError, dvs_supports_mac_learning, find_dvs_by_name, vmware_argument_spec, wait_for_task
 )
 
 
@@ -313,6 +332,11 @@ class VMwareDvSwitch(PyVmomi):
             self.contact_name = None
             self.contact_details = None
         self.description = self.module.params['description']
+
+        self.network_policy = self.module.params['network_policy']
+        if self.network_policy is None:
+            self.network_policy = {}
+
         self.state = self.module.params['state']
 
     def process_state(self):
@@ -395,7 +419,7 @@ class VMwareDvSwitch(PyVmomi):
                 )
             # Find new DVS
             self.dvs = find_dvs_by_name(self.content, self.switch_name)
-            changed_multicast = False
+            changed_multicast = changed_network_policy = False
             spec = vim.dvs.VmwareDistributedVirtualSwitch.ConfigSpec()
             # Use the same version in the new spec; The version will be increased by one by the API automatically
             spec.configVersion = self.dvs.config.configVersion
@@ -406,8 +430,30 @@ class VMwareDvSwitch(PyVmomi):
                 changed_multicast = True
                 spec.multicastFilteringMode = multicast_filtering_mode
             spec.multicastFilteringMode = self.get_api_mc_filtering_mode(self.multicast_filtering_mode)
-            if changed_multicast:
+            # Set default network policy
+            network_policy = self.network_policy
+            if 'promiscuous' in network_policy or 'forged_transmits' in network_policy or 'mac_changes' in network_policy:
+                results['network_policy'] = {}
+                if 'promiscuous' in network_policy:
+                    results['network_policy']['promiscuous'] = network_policy['promiscuous']
+                if network_policy['forged_transmits'] is not None:
+                    results['network_policy']['forged_transmits'] = network_policy['forged_transmits']
+                if network_policy['mac_changes'] is not None:
+                    results['network_policy']['mac_changes'] = network_policy['mac_changes']
+
+                result = self.check_network_policy_config()
+                changed_network_policy = result[1]
+                if changed_network_policy:
+                    if spec.defaultPortConfig is None:
+                        spec.defaultPortConfig = vim.dvs.VmwareDistributedVirtualSwitch.VmwarePortConfigPolicy()
+                    if isinstance(result[0], vim.dvs.VmwareDistributedVirtualSwitch.MacManagementPolicy):
+                        spec.defaultPortConfig.macManagementPolicy = result[0]
+                    else:
+                        spec.defaultPortConfig.securityPolicy = result[0]
+
+            if changed_multicast or changed_network_policy:
                 self.update_dvs_config(self.dvs, spec)
+
             # Set Health Check config
             results['health_check_vlan'] = self.health_check_vlan
             results['health_check_teaming'] = self.health_check_teaming
@@ -416,7 +462,9 @@ class VMwareDvSwitch(PyVmomi):
             changed_health_check = result[1]
             if changed_health_check:
                 self.update_health_check_config(self.dvs, result[0])
+
             result = "DVS created"
+
         self.module.exit_json(changed=changed, result=to_native(result))
 
     def create_ldp_spec(self):
@@ -459,6 +507,52 @@ class VMwareDvSwitch(PyVmomi):
             self.module.fail_json(
                 msg="Failed to update DVS : %s" % to_native(invalid_argument)
             )
+
+    def check_network_policy_config(self):
+        changed_promiscuous = changed_forged_transmits = changed_mac_changes = False
+        promiscuous_previous = forged_transmits_previous = mac_changes_previous = None
+        current_config = self.dvs.config.defaultPortConfig
+
+        # If the dvSwitch supports MAC learning, it's a version where securityPolicy is deprecated
+        if dvs_supports_mac_learning(self.dvs):
+            policy = vim.dvs.VmwareDistributedVirtualSwitch.MacManagementPolicy()
+
+            if 'promiscuous' in self.network_policy and current_config.macManagementPolicy.allowPromiscuous != self.network_policy['promiscuous']:
+                changed_promiscuous = True
+                promiscuous_previous = current_config.macManagementPolicy.allowPromiscuous
+                policy.allowPromiscuous = self.network_policy['promiscuous']
+
+            if 'forged_transmits' in self.network_policy and current_config.macManagementPolicy.forgedTransmits != self.network_policy['forged_transmits']:
+                changed_forged_transmits = True
+                forged_transmits_previous = current_config.macManagementPolicy.forgedTransmits
+                policy.forgedTransmits = self.network_policy['forged_transmits']
+
+            if 'mac_changes' in self.network_policy and current_config.macManagementPolicy.macChanges != self.network_policy['mac_changes']:
+                changed_mac_changes = True
+                mac_changes_previous = current_config.macManagementPolicy.macChanges
+                policy.macChanges = self.network_policy['mac_changes']
+
+        else:
+            policy = vim.dvs.VmwareDistributedVirtualSwitch.SecurityPolicy()
+
+            if 'promiscuous' in self.network_policy and current_config.securityPolicy.allowPromiscuous.value != self.network_policy['promiscuous']:
+                changed_promiscuous = True
+                promiscuous_previous = current_config.securityPolicy.allowPromiscuous.value
+                policy.allowPromiscuous = vim.BoolPolicy(value=self.network_policy['promiscuous'])
+
+            if 'forged_transmits' in self.network_policy and current_config.securityPolicy.forgedTransmits.value != self.network_policy['forged_transmits']:
+                changed_forged_transmits = True
+                forged_transmits_previous = current_config.securityPolicy.forgedTransmits.value
+                policy.forgedTransmits = vim.BoolPolicy(value=self.network_policy['forged_transmits'])
+
+            if 'mac_changes' in self.network_policy and current_config.securityPolicy.macChanges.value != self.network_policy['mac_changes']:
+                changed_mac_changes = True
+                mac_changes_previous = current_config.securityPolicy.macChanges.value
+                policy.macChanges = vim.BoolPolicy(value=self.network_policy['mac_changes'])
+
+        changed = changed_promiscuous or changed_forged_transmits or changed_mac_changes
+        return (policy, changed, changed_promiscuous, promiscuous_previous, changed_forged_transmits,
+                forged_transmits_previous, changed_mac_changes, mac_changes_previous)
 
     def check_health_check_config(self, health_check_config):
         """Check Health Check config"""
@@ -528,7 +622,7 @@ class VMwareDvSwitch(PyVmomi):
 
     def update_dvswitch(self):
         """Check and update DVS settings"""
-        changed = changed_settings = changed_ldp = changed_version = changed_health_check = False
+        changed = changed_settings = changed_ldp = changed_version = changed_health_check = changed_network_policy = False
         results = dict(changed=changed)
         results['dvswitch'] = self.switch_name
         changed_list = []
@@ -642,6 +736,38 @@ class VMwareDvSwitch(PyVmomi):
             if changed_teaming_interval:
                 results['health_check_teaming_interval_previous'] = teaming_interval_previous
 
+        # Check Network Policy
+        if 'promiscuous' in self.network_policy or 'forged_transmits' in self.network_policy or 'mac_changes' in self.network_policy:
+            results['network_policy'] = {}
+
+            (policy, changed_network_policy, changed_promiscuous, promiscuous_previous, changed_forged_transmits,
+             forged_transmits_previous, changed_mac_changes, mac_changes_previous) = \
+                self.check_network_policy_config()
+
+            if changed_network_policy:
+                changed = changed_settings = True
+                changed_list.append("network policy")
+                results['network_policy_previous'] = {}
+                if changed_promiscuous:
+                    results['network_policy_previous']['promiscuous'] = promiscuous_previous
+                    results['network_policy']['promiscuous'] = self.network_policy['promiscuous']
+
+                if changed_forged_transmits:
+                    results['network_policy_previous']['forged_transmits'] = forged_transmits_previous
+                    results['network_policy']['forged_transmits'] = self.network_policy['forged_transmits']
+
+                if changed_mac_changes:
+                    results['network_policy_previous']['mac_changes'] = mac_changes_previous
+                    results['network_policy']['mac_changes'] = self.network_policy['mac_changes']
+
+                if config_spec.defaultPortConfig is None:
+                    config_spec.defaultPortConfig = vim.dvs.VmwareDistributedVirtualSwitch.VmwarePortConfigPolicy()
+
+                if isinstance(policy, vim.dvs.VmwareDistributedVirtualSwitch.MacManagementPolicy):
+                    config_spec.defaultPortConfig.macManagementPolicy = policy
+                else:
+                    config_spec.defaultPortConfig.securityPolicy = policy
+
         # Check switch version
         if self.switch_version:
             results['version'] = self.switch_version
@@ -733,6 +859,14 @@ def main():
             ),
             description=dict(type='str'),
             state=dict(default='present', choices=['present', 'absent']),
+            network_policy=dict(
+                type='dict',
+                options=dict(
+                    promiscuous=dict(type='bool', default=False),
+                    forged_transmits=dict(type='bool', default=False),
+                    mac_changes=dict(type='bool', default=False)
+                ),
+            ),
         )
     )
 

--- a/tests/integration/targets/vmware_dvswitch/tasks/main.yml
+++ b/tests/integration/targets/vmware_dvswitch/tasks/main.yml
@@ -31,7 +31,7 @@
     that:
       - dvs_result_0001.changed
 
-- name: Create a VM folder on given Datacenter
+- name: Create a network folder on given Datacenter
   vcenter_folder:
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
@@ -76,6 +76,102 @@
       that:
         - not dvs_result_0002.changed
 
+  - name: Add distributed vSwitch with network policy
+    vmware_dvswitch:
+      validate_certs: false
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      datacenter_name: "{{ dc1 }}"
+      state: present
+      switch_name: dvswitch_network_policy
+      mtu: 9000
+      uplink_quantity: 2
+      discovery_proto: lldp
+      discovery_operation: both
+      network_policy:
+        promiscuous: false
+        forged_transmits: false
+        mac_changes: false
+    register: dvs_with_network_policy_result
+
+  - name: Ensure distributed vswitch is present
+    assert:
+      that:
+        - dvs_with_network_policy_result.changed
+
+  - name: Add distributed vSwitch with network policy again (idempotency)
+    vmware_dvswitch:
+      validate_certs: false
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      datacenter_name: "{{ dc1 }}"
+      state: present
+      switch_name: dvswitch_network_policy
+      mtu: 9000
+      uplink_quantity: 2
+      discovery_proto: lldp
+      discovery_operation: both
+      network_policy:
+        promiscuous: false
+        forged_transmits: false
+        mac_changes: false
+    register: dvs_with_network_policy_again_result
+
+  - name: Ensure distributed vswitch is present
+    assert:
+      that:
+        - not dvs_with_network_policy_again_result.changed
+
+  - name: Change network policy
+    vmware_dvswitch:
+      validate_certs: false
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      datacenter_name: "{{ dc1 }}"
+      state: present
+      switch_name: dvswitch_network_policy
+      mtu: 9000
+      uplink_quantity: 2
+      discovery_proto: lldp
+      discovery_operation: both
+      network_policy:
+        promiscuous: true
+        forged_transmits: false
+        mac_changes: false
+    register: dvs_change_network_policy_result
+
+  - name: Ensure network policy is changed
+    assert:
+      that:
+        - dvs_change_network_policy_result.changed
+
+  - name: Change network policy again (idempotency)
+    vmware_dvswitch:
+      validate_certs: false
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      datacenter_name: "{{ dc1 }}"
+      state: present
+      switch_name: dvswitch_network_policy
+      mtu: 9000
+      uplink_quantity: 2
+      discovery_proto: lldp
+      discovery_operation: both
+      network_policy:
+        promiscuous: true
+        forged_transmits: false
+        mac_changes: false
+    register: dvs_change_network_policy_again_result
+
+  - name: Ensure network policy is not changed
+    assert:
+      that:
+        - not dvs_change_network_policy_again_result.changed
+
 # FIXME: Remove this testcase from block once vcsim supports distributed vswitch delete method
 # Currently, vcsim does not support distributed vswitch delete option,
 # Once this feature is available we can move this out of this block
@@ -93,6 +189,7 @@
     loop:
       - dvswitch_0001
       - dvswitch_0002
+      - dvswitch_network_policy
     register: dvswitch_delete
   - debug: var=dvswitch_delete
 
@@ -101,6 +198,7 @@
       that:
         - dvswitch_delete.results[0] is changed
         - dvswitch_delete.results[1] is changed
+        - dvswitch_delete.results[2] is changed
 
   - name: Create dvSwitch with special characters
     vmware_dvswitch:


### PR DESCRIPTION
##### SUMMARY
This PR implements `promiscuous`, `forged_transmits` and `mac_changes` on the distributed switch. This allows people to to use port groups that inherit a default set on the DVS.

Fixes #833 
Fixes #839 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_dvswitch

##### ADDITIONAL INFORMATION
I've moved the function checking if the distributed virtual switch supports MAC learning to `module_utils/vmware.py` because DRY.