### PR TITLE
Using configspec for opaque networks to fix VMC issue

### DIFF
--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -2057,13 +2057,8 @@ class PyVmomiHelper(PyVmomi):
                     nic_change_detected = True
 
             if nic_change_detected:
-                # Change to fix the issue found while configuring opaque network
-                # VMs cloned from a template with opaque network will get disconnected
-                # Replacing deprecated config parameter with relocation Spec
-                if isinstance(net_obj, vim.OpaqueNetwork):
-                    self.relospec.deviceChange.append(nic)
-                else:
-                    self.configspec.deviceChange.append(nic)
+                # TODO: is a relospec needed here?
+                self.configspec.deviceChange.append(nic)
                 self.change_detected = True
 
     def set_vapp_properties(self, property_spec):


### PR DESCRIPTION
##### SUMMARY
Fixes #746 when creating guests with vmware_guest on a vSphere environment leveraging NSX. As mentioned in that issue, the fix was simply to change from a relospec to a configspec. It's unclear why opaque networks were using a relospec in the first place, and that information might be helpful before merging this PR.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_guest causes an issue when adding network devices connected to an opaque network (specifically NSX) wherein the the VM is created without a network device.