### PR TITLE
vmware_deploy_ovf: Added parameter to force applying non-user configurable properties

### DIFF
--- a/plugins/modules/vmware_deploy_ovf.py
+++ b/plugins/modules/vmware_deploy_ovf.py
@@ -87,6 +87,11 @@ options:
         - '   folder: folder1/datacenter1/vm'
         - '   folder: /folder1/datacenter1/vm/folder2'
         type: str
+    enable_hidden_properties:
+        description:
+        - Enable source properties that are marked as ovf:userConfigurable=false
+        default: "no"
+        type: bool
     inject_ovf_env:
         description:
         - Force the given properties to be inserted into an OVF Environment and injected through VMware Tools.
@@ -453,6 +458,10 @@ class VMwareDeployOvf(PyVmomi):
             spec_params
         )
 
+        if self.params['enable_hidden_properties']:
+            for prop in self.import_spec.importSpec.configSpec.vAppConfig.property:
+                prop.info.userConfigurable = True
+
         errors = [to_native(e.msg) for e in getattr(self.import_spec, 'error', [])]
         if self.params['fail_on_spec_warnings']:
             errors.extend(
@@ -662,6 +671,10 @@ def main():
         },
         'deployment_option': {
             'default': None,
+        },
+        'enable_hidden_properties': {
+            'default': False,
+            'type': 'bool',
         },
         'folder': {
             'default': None,


### PR DESCRIPTION
##### SUMMARY
This PR brings back some of the changes proposed in #50299 to address vmware_deploy_ovf not having a way to force applying ovf properties that are marked as non-user configurable.

`enable_hidden_properties` was added and then later dropped because it was considered unnecessary for the VCSA OVA appliance. But the change is required for other OVAs, which will throw an error in vCenter saying that the parameter X is not user-configurable.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_deploy_ovf: Added parameter to force applying non-user configurable properties 

##### ADDITIONAL INFORMATION
The details surrounding this parameter and its removal are in #50299.