### PR TITLE
vmware_object_custom_attributes_info: Add a new module to gather custom attributes of an object

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ Name | Description
 [community.vmware.vmware_local_user_manager](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_local_user_manager_module.rst)|Manage local users on an ESXi host
 [community.vmware.vmware_maintenancemode](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_maintenancemode_module.rst)|Place a host into maintenance mode
 [community.vmware.vmware_migrate_vmk](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_migrate_vmk_module.rst)|Migrate a VMK interface from VSS to VDS
+[community.vmware.vmware_object_custom_attributes_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_object_custom_attributes_info_module.rst)|Gather custom attributes of an object
 [community.vmware.vmware_object_rename](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_object_rename_module.rst)|Renames VMware objects
 [community.vmware.vmware_object_role_permission](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_object_role_permission_module.rst)|Manage local roles on an ESXi host
 [community.vmware.vmware_portgroup](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_portgroup_module.rst)|Create a VMware portgroup

--- a/changelogs/fragments/851-vmware_object_custom_attributes_info.yml
+++ b/changelogs/fragments/851-vmware_object_custom_attributes_info.yml
@@ -1,0 +1,2 @@
+major_changes:
+  - vmware_object_custom_attributes_info - added a new module to gather custom attributes of an object (https://github.com/ansible-collections/community.vmware/pull/851).

--- a/docs/community.vmware.vmware_object_custom_attributes_info_module.rst
+++ b/docs/community.vmware.vmware_object_custom_attributes_info_module.rst
@@ -25,7 +25,7 @@ Requirements
 ------------
 The below requirements are needed on the host that executes this module.
 
-- python >= 2.7
+- python >= 3.6
 - PyVmomi
 
 
@@ -215,6 +215,12 @@ Parameters
     <br/>
 
 
+Notes
+-----
+
+.. note::
+   - Supports ``check_mode``.
+
 
 
 Examples
@@ -223,7 +229,7 @@ Examples
 .. code-block:: yaml
 
     - name: Gather custom attributes of a virtual machine
-      vmware_object_custom_attributes_info:
+      community.vmware.vmware_object_custom_attributes_info:
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"

--- a/docs/community.vmware.vmware_object_custom_attributes_info_module.rst
+++ b/docs/community.vmware.vmware_object_custom_attributes_info_module.rst
@@ -1,0 +1,296 @@
+.. _community.vmware.vmware_object_custom_attributes_info_module:
+
+
+*****************************************************
+community.vmware.vmware_object_custom_attributes_info
+*****************************************************
+
+**Gather custom attributes of an object**
+
+
+Version added: 1.11.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- This module can be gathered custom attributes of an object.
+
+
+
+Requirements
+------------
+The below requirements are needed on the host that executes this module.
+
+- python >= 2.7
+- PyVmomi
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+            <th width="100%">Comments</th>
+        </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>hostname</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The hostname or IP address of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_HOST</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>object_name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Name of the object to work with.</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: name</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>object_type</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>Datacenter</li>
+                                    <li>Cluster</li>
+                                    <li>HostSystem</li>
+                                    <li>ResourcePool</li>
+                                    <li>Folder</li>
+                                    <li>VirtualMachine</li>
+                                    <li>DistributedVirtualSwitch</li>
+                                    <li>DistributedVirtualPortgroup</li>
+                                    <li>Datastore</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Type of an object to work with.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The password of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PASSWORD</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: pass, pwd</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">443</div>
+                </td>
+                <td>
+                        <div>The port number of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PORT</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>proxy_host</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Address of a proxy that will receive all HTTPS requests and relay them.</div>
+                        <div>The format is a hostname or a IP.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PROXY_HOST</code> will be used instead.</div>
+                        <div>This feature depends on a version of pyvmomi greater than v6.7.1.2018.12</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>proxy_port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Port of the HTTP proxy that will receive all HTTPS requests and relay them.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PROXY_PORT</code> will be used instead.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>username</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The username of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_USER</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: admin, user</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>validate_certs</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>no</li>
+                                    <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Allows connection when SSL certificates are not valid. Set to <code>false</code> when certificates are not trusted.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_VALIDATE_CERTS</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                        <div>If set to <code>true</code>, please make sure Python &gt;= 2.7.9 is installed on the given machine.</div>
+                </td>
+            </tr>
+    </table>
+    <br/>
+
+
+
+
+Examples
+--------
+
+.. code-block:: yaml
+
+    - name: Gather custom attributes of a virtual machine
+      vmware_object_custom_attributes_info:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        object_type: VirtualMachine
+        object_name: "{{ object_name }}"
+      register: vm_attributes
+
+
+
+Return Values
+-------------
+Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>custom_attributes</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                    </div>
+                </td>
+                <td>always</td>
+                <td>
+                            <div>list of custom attributes of an object.</div>
+                    <br/>
+                        <div style="font-size: smaller"><b>Sample:</b></div>
+                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[
+        {
+            &quot;attribute&quot;: &quot;example01&quot;,
+            &quot;key&quot;: 132,
+            &quot;type&quot;: &quot;VirtualMachine&quot;,
+            &quot;value&quot;: &quot;10&quot;
+        },
+        {
+            &quot;attribute&quot;: &quot;example02&quot;,
+            &quot;key&quot;: 131,
+            &quot;type&quot;: &quot;VirtualMachine&quot;,
+            &quot;value&quot;: &quot;20&quot;
+        },
+        {
+            &quot;attribute&quot;: &quot;example03&quot;,
+            &quot;key&quot;: 130,
+            &quot;type&quot;: &quot;VirtualMachine&quot;,
+            &quot;value&quot;: null
+        }
+    ]</div>
+                </td>
+            </tr>
+    </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- sky-joker (@sky-joker)

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -120,6 +120,7 @@ action_groups:
   - vmware_local_user_manager
   - vmware_maintenancemode
   - vmware_migrate_vmk
+  - vmware_object_custom_attributes_info
   - vmware_object_rename
   - vmware_object_role_permission
   - vmware_portgroup

--- a/plugins/modules/vmware_object_custom_attributes_info.py
+++ b/plugins/modules/vmware_object_custom_attributes_info.py
@@ -48,7 +48,7 @@ extends_documentation_fragment:
 
 EXAMPLES = r"""
 - name: Gather custom attributes of a virtual machine
-  vmware_object_custom_attributes_info:
+  community.vmware.vmware_object_custom_attributes_info:
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
@@ -118,7 +118,7 @@ class VmwareCustomAttributesInfo(PyVmomi):
 
         obj = find_obj(self.content, [self.valid_object_types[self.object_type]], self.object_name)
         if not obj:
-            self.module.fail_json(msg="can't found the object: %s" % self.object_name)
+            self.module.fail_json(msg="can't find the object: %s" % self.object_name)
 
         custom_attributes = []
         available_fields = {}

--- a/plugins/modules/vmware_object_custom_attributes_info.py
+++ b/plugins/modules/vmware_object_custom_attributes_info.py
@@ -15,8 +15,10 @@ author:
   - sky-joker (@sky-joker)
 description:
   - This module can be gathered custom attributes of an object.
+notes:
+  - Supports C(check_mode).
 requirements:
-  - python >= 2.7
+  - python >= 3.6
   - PyVmomi
 version_added: '1.11.0'
 options:

--- a/plugins/modules/vmware_object_custom_attributes_info.py
+++ b/plugins/modules/vmware_object_custom_attributes_info.py
@@ -1,0 +1,181 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2021, sky-joker
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: vmware_object_custom_attributes_info
+short_description: Gather custom attributes of an object
+author:
+  - sky-joker (@sky-joker)
+description:
+  - This module can be gathered custom attributes of an object.
+requirements:
+  - python >= 2.7
+  - PyVmomi
+version_added: '1.11.0'
+options:
+  object_type:
+    description:
+      - Type of an object to work with.
+    type: str
+    choices:
+      - Datacenter
+      - Cluster
+      - HostSystem
+      - ResourcePool
+      - Folder
+      - VirtualMachine
+      - DistributedVirtualSwitch
+      - DistributedVirtualPortgroup
+      - Datastore
+    required: True
+  object_name:
+    description:
+      - Name of the object to work with.
+    type: str
+    aliases:
+      - name
+    required: True
+extends_documentation_fragment:
+  - community.vmware.vmware.documentation
+"""
+
+EXAMPLES = r"""
+- name: Gather custom attributes of a virtual machine
+  vmware_object_custom_attributes_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    object_type: VirtualMachine
+    object_name: "{{ object_name }}"
+  register: vm_attributes
+"""
+
+RETURN = r"""
+custom_attributes:
+  description: list of custom attributes of an object.
+  returned: always
+  type: list
+  sample: >-
+    [
+        {
+            "attribute": "example01",
+            "key": 132,
+            "type": "VirtualMachine",
+            "value": "10"
+        },
+        {
+            "attribute": "example02",
+            "key": 131,
+            "type": "VirtualMachine",
+            "value": "20"
+        },
+        {
+            "attribute": "example03",
+            "key": 130,
+            "type": "VirtualMachine",
+            "value": null
+        }
+    ]
+"""
+
+try:
+    from pyVmomi import vim
+except ImportError:
+    pass
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_text
+from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, vmware_argument_spec, find_obj
+
+
+class VmwareCustomAttributesInfo(PyVmomi):
+    def __init__(self, module):
+        super(VmwareCustomAttributesInfo, self).__init__(module)
+        self.object_type = self.params['object_type']
+        self.object_name = self.params['object_name']
+
+        self.valid_object_types = {
+            'Datacenter': vim.Datacenter,
+            'Cluster': vim.ClusterComputeResource,
+            'HostSystem': vim.HostSystem,
+            'ResourcePool': vim.ResourcePool,
+            'Folder': vim.Folder,
+            'VirtualMachine': vim.VirtualMachine,
+            'DistributedVirtualSwitch': vim.DistributedVirtualSwitch,
+            'DistributedVirtualPortgroup': vim.DistributedVirtualPortgroup,
+            'Datastore': vim.Datastore
+        }
+
+    def execute(self):
+        result = {'changed': False}
+
+        obj = find_obj(self.content, [self.valid_object_types[self.object_type]], self.object_name)
+        if not obj:
+            self.module.fail_json(msg="didn't found the object: %s" % self.object_name)
+
+        custom_attributes = []
+        if obj:
+            available_fields = {}
+            for available_custom_attribute in obj.availableField:
+                available_fields.update({
+                    available_custom_attribute.key: {
+                        'name': available_custom_attribute.name,
+                        'type': available_custom_attribute.managedObjectType
+                    }
+                })
+
+            custom_values = {}
+            for custom_value in obj.customValue:
+                custom_values.update({
+                    custom_value.key: custom_value.value
+                })
+
+            for key, value in available_fields.items():
+                attribute_result = {
+                    'attribute': value['name'],
+                    'type': self.to_json(value['type']).replace('vim.', ''),
+                    'key': key,
+                    'value': None
+                }
+
+                if key in custom_values:
+                    attribute_result['value'] = custom_values[key]
+
+                custom_attributes.append(attribute_result)
+
+        self.module.exit_json(changed=False, custom_attributes=custom_attributes)
+
+
+def main():
+    argument_spec = vmware_argument_spec()
+    argument_spec.update(
+        object_type=dict(type='str', required=True, choices=[
+            'Datacenter',
+            'Cluster',
+            'HostSystem',
+            'ResourcePool',
+            'Folder',
+            'VirtualMachine',
+            'DistributedVirtualSwitch',
+            'DistributedVirtualPortgroup',
+            'Datastore'
+        ]),
+        object_name=dict(type='str', required=True, aliases=['name']),
+    )
+
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+
+    vmware_custom_attributes_info = VmwareCustomAttributesInfo(module)
+    vmware_custom_attributes_info.execute()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/vmware_object_custom_attributes_info/aliases
+++ b/tests/integration/targets/vmware_object_custom_attributes_info/aliases
@@ -1,0 +1,3 @@
+cloud/vcenter
+needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_object_custom_attributes_info/tasks/main.yml
+++ b/tests/integration/targets/vmware_object_custom_attributes_info/tasks/main.yml
@@ -1,0 +1,15 @@
+# Test code for the vmware_object_custom_attributes_info module.
+# Copyright: (c) 2021, sky-joker <sky.jokerxx@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_attach_host: true
+    setup_virtualmachines: true
+
+- name: Include tasks pre.yml
+  include_tasks: pre.yml
+
+- name: Include tasks vmware_object_custom_attributes_info_tests.yml
+  include_tasks: vmware_object_custom_attributes_info_tests.yml

--- a/tests/integration/targets/vmware_object_custom_attributes_info/tasks/pre.yml
+++ b/tests/integration/targets/vmware_object_custom_attributes_info/tasks/pre.yml
@@ -3,7 +3,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 - name: Add custom attributes to a virtual machine
-  vmware_guest_custom_attributes:
+  community.vmware.vmware_guest_custom_attributes:
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
@@ -17,7 +17,7 @@
     state: present
 
 - name: Add custom attributes to an ESXi
-  vmware_host_custom_attributes:
+  community.vmware.vmware_host_custom_attributes:
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"

--- a/tests/integration/targets/vmware_object_custom_attributes_info/tasks/pre.yml
+++ b/tests/integration/targets/vmware_object_custom_attributes_info/tasks/pre.yml
@@ -17,8 +17,7 @@
     state: present
 
 - name: Add custom attributes to an ESXi
-  #vmware_host_custom_attributes:
-  community.vmware.vmware_host_custom_attributes:
+  vmware_host_custom_attributes:
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"

--- a/tests/integration/targets/vmware_object_custom_attributes_info/tasks/pre.yml
+++ b/tests/integration/targets/vmware_object_custom_attributes_info/tasks/pre.yml
@@ -1,0 +1,32 @@
+# Test code for the vmware_object_custom_attributes_info module.
+# Copyright: (c) 2021, sky-joker <sky.jokerxx@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Add custom attributes to a virtual machine
+  vmware_guest_custom_attributes:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    name: "{{ virtual_machines.0.name }}"
+    attributes:
+      - name: vm_example01
+        value: test1
+      - name: vm_example02
+        value: test2
+    state: present
+
+- name: Add custom attributes to an ESXi
+  #vmware_host_custom_attributes:
+  community.vmware.vmware_host_custom_attributes:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    attributes:
+      - name: esxi_example01
+        value: test1
+      - name: esxi_example02
+        value: test2
+    state: present

--- a/tests/integration/targets/vmware_object_custom_attributes_info/tasks/vmware_object_custom_attributes_info_tests.yml
+++ b/tests/integration/targets/vmware_object_custom_attributes_info/tasks/vmware_object_custom_attributes_info_tests.yml
@@ -3,7 +3,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 - name: Gather custom attributes of a virtual machine
-  vmware_object_custom_attributes_info:
+  community.vmware.vmware_object_custom_attributes_info:
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
@@ -11,6 +11,8 @@
     object_type: VirtualMachine
     object_name: "{{ virtual_machines.0.name }}"
   register: vm_custom_attributes_result
+
+- debug: msg="{{ vm_custom_attributes_result }}"
 
 - name: Make sure if custom attributes exist
   assert:
@@ -21,7 +23,7 @@
       - vm_custom_attributes_result.custom_attributes | selectattr('value', 'equalto', 'test2')
 
 - name: Gather custom attributes of an ESXi
-  vmware_object_custom_attributes_info:
+  community.vmware.vmware_object_custom_attributes_info:
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"

--- a/tests/integration/targets/vmware_object_custom_attributes_info/tasks/vmware_object_custom_attributes_info_tests.yml
+++ b/tests/integration/targets/vmware_object_custom_attributes_info/tasks/vmware_object_custom_attributes_info_tests.yml
@@ -1,0 +1,41 @@
+# Test code for the vmware_object_custom_attributes_info module.
+# Copyright: (c) 2021, sky-joker <sky.jokerxx@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Gather custom attributes of a virtual machine
+  vmware_object_custom_attributes_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    object_type: VirtualMachine
+    object_name: "{{ virtual_machines.0.name }}"
+  register: vm_custom_attributes_result
+
+- debug: msg="{{ vm_custom_attributes_result }}"
+
+- name: Make sure if custom attributes exist
+  assert:
+    that:
+      - vm_custom_attributes_result.custom_attributes | selectattr('attribute', 'equalto', 'vm_example01')
+      - vm_custom_attributes_result.custom_attributes | selectattr('value', 'equalto', 'test1')
+      - vm_custom_attributes_result.custom_attributes | selectattr('attribute', 'equalto', 'vm_example02')
+      - vm_custom_attributes_result.custom_attributes | selectattr('value', 'equalto', 'test2')
+
+- name: Gather custom attributes of an ESXi
+  vmware_object_custom_attributes_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    object_type: HostSystem
+    object_name: "{{ esxi1 }}"
+  register: esxi_custom_attributes_result
+
+- name: Make sure if custom attributes exist
+  assert:
+    that:
+      - esxi_custom_attributes_result.custom_attributes | selectattr('attribute', 'equalto', 'esxi_example01')
+      - esxi_custom_attributes_result.custom_attributes | selectattr('value', 'equalto', 'test1')
+      - esxi_custom_attributes_result.custom_attributes | selectattr('attribute', 'equalto', 'esxi_example02')
+      - esxi_custom_attributes_result.custom_attributes | selectattr('value', 'equalto', 'test2')

--- a/tests/integration/targets/vmware_object_custom_attributes_info/tasks/vmware_object_custom_attributes_info_tests.yml
+++ b/tests/integration/targets/vmware_object_custom_attributes_info/tasks/vmware_object_custom_attributes_info_tests.yml
@@ -12,8 +12,6 @@
     object_name: "{{ virtual_machines.0.name }}"
   register: vm_custom_attributes_result
 
-- debug: msg="{{ vm_custom_attributes_result }}"
-
 - name: Make sure if custom attributes exist
   assert:
     that:

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -315,6 +315,8 @@ plugins/modules/vmware_maintenancemode.py compile-2.6!skip
 plugins/modules/vmware_maintenancemode.py import-2.6!skip
 plugins/modules/vmware_migrate_vmk.py compile-2.6!skip
 plugins/modules/vmware_migrate_vmk.py import-2.6!skip
+plugins/modules/vmware_object_custom_attributes_info.py compile-2.6!skip
+plugins/modules/vmware_object_custom_attributes_info.py import-2.6!skip
 plugins/modules/vmware_object_rename.py compile-2.6!skip
 plugins/modules/vmware_object_rename.py import-2.6!skip
 plugins/modules/vmware_object_role_permission.py compile-2.6!skip

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -325,6 +325,8 @@ plugins/modules/vmware_maintenancemode.py compile-2.6!skip
 plugins/modules/vmware_maintenancemode.py import-2.6!skip
 plugins/modules/vmware_migrate_vmk.py compile-2.6!skip
 plugins/modules/vmware_migrate_vmk.py import-2.6!skip
+plugins/modules/vmware_object_custom_attributes_info.py compile-2.6!skip
+plugins/modules/vmware_object_custom_attributes_info.py import-2.6!skip
 plugins/modules/vmware_object_rename.py compile-2.6!skip
 plugins/modules/vmware_object_rename.py import-2.6!skip
 plugins/modules/vmware_object_role_permission.py compile-2.6!skip

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -297,6 +297,8 @@ plugins/modules/vmware_maintenancemode.py compile-2.6!skip
 plugins/modules/vmware_maintenancemode.py import-2.6!skip
 plugins/modules/vmware_migrate_vmk.py compile-2.6!skip
 plugins/modules/vmware_migrate_vmk.py import-2.6!skip
+plugins/modules/vmware_object_custom_attributes_info.py compile-2.6!skip
+plugins/modules/vmware_object_custom_attributes_info.py import-2.6!skip
 plugins/modules/vmware_object_rename.py compile-2.6!skip
 plugins/modules/vmware_object_rename.py import-2.6!skip
 plugins/modules/vmware_object_role_permission.py compile-2.6!skip

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -365,6 +365,8 @@ plugins/modules/vmware_maintenancemode.py compile-2.6!skip
 plugins/modules/vmware_maintenancemode.py import-2.6!skip
 plugins/modules/vmware_migrate_vmk.py compile-2.6!skip
 plugins/modules/vmware_migrate_vmk.py import-2.6!skip
+plugins/modules/vmware_object_custom_attributes_info.py compile-2.6!skip
+plugins/modules/vmware_object_custom_attributes_info.py import-2.6!skip
 plugins/modules/vmware_object_rename.py compile-2.6!skip
 plugins/modules/vmware_object_rename.py import-2.6!skip
 plugins/modules/vmware_object_role_permission.py compile-2.6!skip


### PR DESCRIPTION
##### SUMMARY

This PR will add a new module to gather custom attributes of an object.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

README.md
changelogs/fragments/851-vmware_object_custom_attributes_info.yml
docs/community.vmware.vmware_object_custom_attributes_info_module.rst
meta/runtime.yml
plugins/modules/vmware_object_custom_attributes_info.py
tests/integration/targets/vmware_object_custom_attributes_info/aliases
tests/integration/targets/vmware_object_custom_attributes_info/tasks/main.yml
tests/integration/targets/vmware_object_custom_attributes_info/tasks/pre.yml
tests/integration/targets/vmware_object_custom_attributes_info/tasks/vmware_object_custom_attributes_info_tests.yml
tests/sanity/ignore-2.9.txt
tests/sanity/ignore-2.10.txt
tests/sanity/ignore-2.11.txt
tests/sanity/ignore-2.12.txt

##### ADDITIONAL INFORMATION

tested on vCenter 7.0