### PR TITLE
Allow the username to be a vault encrypted variable.

### DIFF
--- a/changelogs/fragments/855_vmware_host_inventory.yml
+++ b/changelogs/fragments/855_vmware_host_inventory.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_host_inventory - added ability for username to be a vault encrypted variable, and updated documentation to reflect ability for username and password to be vaulted. (https://github.com/ansible-collections/community.vmware/issues/854).

--- a/changelogs/fragments/855_vmware_vm_inventory.yml
+++ b/changelogs/fragments/855_vmware_vm_inventory.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_vm_inventory - added ability for username to be a vault encrypted variable, and updated documentation to reflect ability for username and password to be vaulted. (https://github.com/ansible-collections/community.vmware/issues/854).

--- a/plugins/inventory/vmware_host_inventory.py
+++ b/plugins/inventory/vmware_host_inventory.py
@@ -202,14 +202,18 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         # set _options from config data
         self._consume_options(config_data)
 
+        username = self.get_option("username")
         password = self.get_option("password")
+
+        if isinstance(username, AnsibleVaultEncryptedUnicode):
+            username = username.data
 
         if isinstance(password, AnsibleVaultEncryptedUnicode):
             password = password.data
 
         self.pyv = BaseVMwareInventory(
             hostname=self.get_option("hostname"),
-            username=self.get_option("username"),
+            username=username,
             password=password,
             port=self.get_option("port"),
             with_tags=self.get_option("with_tags"),

--- a/plugins/inventory/vmware_host_inventory.py
+++ b/plugins/inventory/vmware_host_inventory.py
@@ -35,7 +35,7 @@ DOCUMENTATION = r"""
               - name: VMWARE_HOST
               - name: VMWARE_SERVER
         username:
-            description: 
+            description:
             - Name of vSphere user.
             - Accepts vault encrypted variable.
             required: True
@@ -43,7 +43,7 @@ DOCUMENTATION = r"""
               - name: VMWARE_USER
               - name: VMWARE_USERNAME
         password:
-            description: 
+            description:
             - Password of vSphere user.
             - Accepts vault encrypted variable.
             required: True

--- a/plugins/inventory/vmware_host_inventory.py
+++ b/plugins/inventory/vmware_host_inventory.py
@@ -35,13 +35,17 @@ DOCUMENTATION = r"""
               - name: VMWARE_HOST
               - name: VMWARE_SERVER
         username:
-            description: Name of vSphere user.
+            description: 
+            - Name of vSphere user.
+            - Accepts vault encrypted variable.
             required: True
             env:
               - name: VMWARE_USER
               - name: VMWARE_USERNAME
         password:
-            description: Password of vSphere user.
+            description: 
+            - Password of vSphere user.
+            - Accepts vault encrypted variable.
             required: True
             env:
               - name: VMWARE_PASSWORD

--- a/plugins/inventory/vmware_vm_inventory.py
+++ b/plugins/inventory/vmware_vm_inventory.py
@@ -33,13 +33,17 @@ DOCUMENTATION = r'''
               - name: VMWARE_HOST
               - name: VMWARE_SERVER
         username:
-            description: Name of vSphere user.
+            description: 
+            - Name of vSphere user.
+            - Accepts vault encrypted variable.
             required: True
             env:
               - name: VMWARE_USER
               - name: VMWARE_USERNAME
         password:
-            description: Password of vSphere user.
+            description: 
+            - Password of vSphere user.
+            - Accepts vault encrypted variable.
             required: True
             env:
               - name: VMWARE_PASSWORD

--- a/plugins/inventory/vmware_vm_inventory.py
+++ b/plugins/inventory/vmware_vm_inventory.py
@@ -716,14 +716,18 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         # set _options from config data
         self._consume_options(config_data)
 
+        username = self.get_option('username')
         password = self.get_option('password')
+
+        if isinstance(username, AnsibleVaultEncryptedUnicode):
+            username = username.data
 
         if isinstance(password, AnsibleVaultEncryptedUnicode):
             password = password.data
 
         self.pyv = BaseVMwareInventory(
             hostname=self.get_option('hostname'),
-            username=self.get_option('username'),
+            username=username,
             password=password,
             port=self.get_option('port'),
             with_tags=self.get_option('with_tags'),

--- a/plugins/inventory/vmware_vm_inventory.py
+++ b/plugins/inventory/vmware_vm_inventory.py
@@ -33,7 +33,7 @@ DOCUMENTATION = r'''
               - name: VMWARE_HOST
               - name: VMWARE_SERVER
         username:
-            description: 
+            description:
             - Name of vSphere user.
             - Accepts vault encrypted variable.
             required: True
@@ -41,7 +41,7 @@ DOCUMENTATION = r'''
               - name: VMWARE_USER
               - name: VMWARE_USERNAME
         password:
-            description: 
+            description:
             - Password of vSphere user.
             - Accepts vault encrypted variable.
             required: True


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Our environment uses a service account for the dynamic inventory, and prefers to leave the rest of the file unencrypted for easier editing. The password was already supported for vaulting, this just adds username as well.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #854 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_vm_inventory
vmware_host_inventory
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
