### PR TITLE
vmware: fix that the return value should be returned None if moId doesn't exist

### DIFF
--- a/changelogs/fragments/867-vmware.yml
+++ b/changelogs/fragments/867-vmware.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware - fix that the return value should be returned None if moId doesn't exist of a virtual machine (https://github.com/ansible-collections/community.vmware/pull/867).

--- a/plugins/module_utils/vmware.py
+++ b/plugins/module_utils/vmware.py
@@ -1128,7 +1128,7 @@ class PyVmomi(object):
         elif 'moid' in self.params and self.params['moid']:
             vm_obj = VmomiSupport.templateOf('VirtualMachine')(self.params['moid'], self.si._stub)
             try:
-                _ = getattr(vm_obj, 'name')
+                getattr(vm_obj, 'name')
             except vmodl.fault.ManagedObjectNotFound:
                 vm_obj = None
 

--- a/plugins/module_utils/vmware.py
+++ b/plugins/module_utils/vmware.py
@@ -1127,6 +1127,10 @@ class PyVmomi(object):
                     vm_obj = vms[0]
         elif 'moid' in self.params and self.params['moid']:
             vm_obj = VmomiSupport.templateOf('VirtualMachine')(self.params['moid'], self.si._stub)
+            try:
+                _ = getattr(vm_obj, 'name')
+            except vmodl.fault.ManagedObjectNotFound:
+                vm_obj = None
 
         if vm_obj:
             self.current_vm_obj = vm_obj


### PR DESCRIPTION
Depends-On: #877

##### SUMMARY

The get_vm method in vmware.py has a bug that isn’t returned None if moId doesn't exist.  
This PR will fix the issue.

fixes: https://github.com/ansible-collections/community.vmware/issues/866

In this patch will become that will be returned None if ManagedObjectNotFound occurred when accessing to any attribute.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

plugins/module_utils/vmware.py

##### ADDITIONAL INFORMATION

Tested on VCSA/ESXi 7.0
