### PR TITLE
Add datacenter option to vmware_guest_tools_wait

### DIFF
--- a/changelogs/fragments/870_vmware_guest_tools_wait.yml
+++ b/changelogs/fragments/870_vmware_guest_tools_wait.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- vmware_guest_tools_wait - add documentation about datacenter parameter (https://github.com/ansible-collections/community.vmware/pull/870).

--- a/plugins/modules/vmware_guest_tools_wait.py
+++ b/plugins/modules/vmware_guest_tools_wait.py
@@ -74,6 +74,7 @@ options:
      - Name of the datacenter.
      - The datacenter to search for a virtual machine.
      type: str
+     version_added: '1.15.0'
 extends_documentation_fragment:
 - community.vmware.vmware.documentation
 
@@ -117,6 +118,7 @@ EXAMPLES = r'''
     password: "{{ vcenter_password }}"
     name: test-vm
     folder: "/{{datacenter}}/vm"
+    datacenter: "{{ datacenter }}"
   delegate_to: localhost
   register: facts
 '''

--- a/plugins/modules/vmware_guest_tools_wait.py
+++ b/plugins/modules/vmware_guest_tools_wait.py
@@ -71,7 +71,8 @@ options:
      type: int
    datacenter:
      description:
-     - Destination datacenter for the deploy operation
+     - Name of the datacenter.
+     - The datacenter to search for a virtual machine.
      type: str
 extends_documentation_fragment:
 - community.vmware.vmware.documentation

--- a/plugins/modules/vmware_guest_tools_wait.py
+++ b/plugins/modules/vmware_guest_tools_wait.py
@@ -69,6 +69,10 @@ options:
      - Max duration of the waiting period (seconds).
      default: 500
      type: int
+   datacenter:
+     description:
+     - Destination datacenter for the deploy operation
+     type: str
 extends_documentation_fragment:
 - community.vmware.vmware.documentation
 
@@ -165,6 +169,7 @@ def main():
         moid=dict(type='str'),
         use_instance_uuid=dict(type='bool', default=False),
         timeout=dict(type='int', default=500),
+        datacenter=dict(type='str'),
     )
     module = AnsibleModule(
         argument_spec=argument_spec,


### PR DESCRIPTION
Depends-On: #877 

##### SUMMARY
Add datacenter option to vmware_guest_tools_wait module.

Resolves  #869 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
vmware_guest_tools_wait
