### PR TITLE
vmware_host_passthrough: Add a new module to enable or disable passthrough of PCI devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ Name | Description
 [community.vmware.vmware_host_ntp_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_ntp_info_module.rst)|Gathers info about NTP configuration on an ESXi host
 [community.vmware.vmware_host_package_facts](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_package_facts_module.rst)|Gathers facts about available packages on an ESXi host
 [community.vmware.vmware_host_package_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_package_info_module.rst)|Gathers info about available packages on an ESXi host
+[community.vmware.vmware_host_passthrough](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_passthrough_module.rst)|Manage PCI device passthrough settings on host
 [community.vmware.vmware_host_powermgmt_policy](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_powermgmt_policy_module.rst)|Manages the Power Management Policy of an ESXI host system
 [community.vmware.vmware_host_powerstate](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_powerstate_module.rst)|Manages power states of host systems in vCenter
 [community.vmware.vmware_host_scanhba](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_scanhba_module.rst)|Rescan host HBA's and optionally refresh the storage system

--- a/changelogs/fragments/872-vmware_host_passthrough.yml
+++ b/changelogs/fragments/872-vmware_host_passthrough.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_host_passthrough - added a new module to enable or disable passthrough of PCI devices with ESXi host has (https://github.com/ansible-collections/community.vmware/pull/872).

--- a/docs/community.vmware.vmware_host_passthrough_module.rst
+++ b/docs/community.vmware.vmware_host_passthrough_module.rst
@@ -1,0 +1,371 @@
+.. _community.vmware.vmware_host_passthrough_module:
+
+
+****************************************
+community.vmware.vmware_host_passthrough
+****************************************
+
+**Manage PCI device passthrough settings on host**
+
+
+Version added: 1.11.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- This module can be managed PCI device passthrough settings on host.
+
+
+
+Requirements
+------------
+The below requirements are needed on the host that executes this module.
+
+- python >= 3.6
+- PyVmomi
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+            <th width="100%">Comments</th>
+        </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>cluster</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Name of the cluster from which all host systems will be used.</div>
+                        <div>This parameter is required if <code>esxi_hostname</code> is not specified.</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: cluster_name</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>devices</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=dictionary</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>List of PCI device name.</div>
+                </td>
+            </tr>
+                                <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>device_name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Name of PCI device to enable passthrough.</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: name</div>
+                </td>
+            </tr>
+
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>esxi_hostname</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Name of the host system to work with.</div>
+                        <div>This parameter is required if <code>cluster_name</code> is not specified.</div>
+                        <div>User can specify specific host from the cluster.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>hostname</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The hostname or IP address of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_HOST</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The password of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PASSWORD</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: pass, pwd</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">443</div>
+                </td>
+                <td>
+                        <div>The port number of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PORT</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>proxy_host</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Address of a proxy that will receive all HTTPS requests and relay them.</div>
+                        <div>The format is a hostname or a IP.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PROXY_HOST</code> will be used instead.</div>
+                        <div>This feature depends on a version of pyvmomi greater than v6.7.1.2018.12</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>proxy_port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Port of the HTTP proxy that will receive all HTTPS requests and relay them.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PROXY_PORT</code> will be used instead.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                    <li>absent</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>If <em>state=present</em>, passthrough of PCI device will be enabled.</div>
+                        <div>If <em>state=absent</em>, passthrough of PCI device will be disabled.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>username</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The username of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_USER</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: admin, user</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>validate_certs</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>no</li>
+                                    <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Allows connection when SSL certificates are not valid. Set to <code>false</code> when certificates are not trusted.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_VALIDATE_CERTS</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                        <div>If set to <code>true</code>, please make sure Python &gt;= 2.7.9 is installed on the given machine.</div>
+                </td>
+            </tr>
+    </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - Supports ``check_mode``.
+
+
+
+Examples
+--------
+
+.. code-block:: yaml
+
+    - name: Enable PCI device passthrough against the whole ESXi in a cluster
+      community.vmware.vmware_host_passthrough:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        cluster: "{{ ccr1 }}"
+        devices:
+          - device_name: "Dual Band Wireless AC 3165"
+        state: present
+
+    - name: Enable PCI device passthrough against one ESXi
+      community.vmware.vmware_host_passthrough:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        esxi_hostname: "{{ esxi1 }}"
+        devices:
+          - device_name: "Dual Band Wireless AC 3165"
+        state: present
+
+    - name: Disable PCI device passthrough against the whole ESXi in a cluster
+      community.vmware.vmware_host_passthrough:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        cluster: "{{ ccr1 }}"
+        devices:
+          - device_name: "Dual Band Wireless AC 3165"
+        state: absent
+
+
+
+Return Values
+-------------
+Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>passthrough_configs</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                       / <span style="color: purple">elements=dictionary</span>
+                    </div>
+                </td>
+                <td>changed</td>
+                <td>
+                            <div>list of that PCI devices have been enabled passthrough for each host system.</div>
+                    <br/>
+                        <div style="font-size: smaller"><b>Sample:</b></div>
+                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[
+        {
+            &quot;esxi-01.example.com&quot;: [
+                {
+                    &quot;device_id&quot;: &quot;0000:03:00.0&quot;,
+                    &quot;device_name&quot;: &quot;Dual Band Wireless AC 3165&quot;,
+                    &quot;passthruEnabled&quot;: true
+                }
+            ]
+        },
+        {
+            &quot;esxi-02.example.com&quot;: [
+                {
+                    &quot;device_id&quot;: &quot;0000:03:00.0&quot;,
+                    &quot;device_name&quot;: &quot;Dual Band Wireless AC 3165&quot;,
+                    &quot;passthruEnabled&quot;: true
+                }
+            ]
+        }
+    ]</div>
+                </td>
+            </tr>
+    </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- sky-joker (@sky-joker)

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -102,6 +102,7 @@ action_groups:
   - vmware_host_ntp
   - vmware_host_ntp_info
   - vmware_host_package_info
+  - vmware_host_passthrough
   - vmware_host_powermgmt_policy
   - vmware_host_powerstate
   - vmware_host_scanhba

--- a/plugins/modules/vmware_host_passthrough.py
+++ b/plugins/modules/vmware_host_passthrough.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright: (c) 2020, sky-joker
+# Copyright: (c) 2021, sky-joker
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function

--- a/plugins/modules/vmware_host_passthrough.py
+++ b/plugins/modules/vmware_host_passthrough.py
@@ -1,0 +1,325 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2020, sky-joker
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: vmware_host_passthrough
+short_description: Manage PCI device passthrough settings on host
+author:
+  - sky-joker (@sky-joker)
+description:
+  - This module can be managed PCI device passthrough settings on host.
+notes:
+  - Supports C(check_mode).
+requirements:
+  - python >= 3.6
+  - PyVmomi
+version_added: '1.11.0'
+options:
+  cluster:
+    description:
+      - Name of the cluster from which all host systems will be used.
+      - This parameter is required if C(esxi_hostname) is not specified.
+    aliases:
+      - cluster_name
+    type: str
+  esxi_hostname:
+    description:
+      - Name of the host system to work with.
+      - This parameter is required if C(cluster_name) is not specified.
+      - User can specify specific host from the cluster.
+    type: str
+  devices:
+    description:
+      - List of PCI device name.
+    suboptions:
+      device_name:
+        description:
+          - Name of PCI device to enable passthrough.
+        aliases:
+          - name
+        type: str
+    elements: dict
+    required: True
+    type: list
+  state:
+    description:
+      - If I(state=present), passthrough of PCI device will be enabled.
+      - If I(state=absent), passthrough of PCI device will be disabled.
+    choices:
+      - present
+      - absent
+    default: present
+    type: str
+extends_documentation_fragment:
+  - community.vmware.vmware.documentation
+"""
+
+EXAMPLES = r"""
+- name: Enable PCI device passthrough against the whole ESXi in a cluster
+  community.vmware.vmware_host_passthrough:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    cluster: "{{ ccr1 }}"
+    devices:
+      - device_name: "Dual Band Wireless AC 3165"
+    state: present
+
+- name: Enable PCI device passthrough against one ESXi
+  community.vmware.vmware_host_passthrough:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    devices:
+      - device_name: "Dual Band Wireless AC 3165"
+    state: present
+
+- name: Disable PCI device passthrough against the whole ESXi in a cluster
+  community.vmware.vmware_host_passthrough:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    cluster: "{{ ccr1 }}"
+    devices:
+      - device_name: "Dual Band Wireless AC 3165"
+    state: absent
+"""
+
+RETURN = r"""
+passthrough_configs:
+  description:
+    - list of that PCI devices have been enabled passthrough for each host system.
+  returned: changed
+  type: list
+  elements: dict
+  sample: >-
+    [
+        {
+            "esxi-01.example.com": [
+                {
+                    "device_id": "0000:03:00.0",
+                    "device_name": "Dual Band Wireless AC 3165",
+                    "passthruEnabled": true
+                }
+            ]
+        },
+        {
+            "esxi-02.example.com": [
+                {
+                    "device_id": "0000:03:00.0",
+                    "device_name": "Dual Band Wireless AC 3165",
+                    "passthruEnabled": true
+                }
+            ]
+        }
+    ]
+"""
+
+try:
+    from pyVmomi import vim
+except ImportError:
+    pass
+
+import copy
+from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, vmware_argument_spec
+from ansible.module_utils.basic import AnsibleModule
+
+
+class VMwareHostPassthrough(PyVmomi):
+    def __init__(self, module):
+        super(VMwareHostPassthrough, self).__init__(module)
+        self.cluster = self.params['cluster']
+        self.esxi_hostname = self.params['esxi_hostname']
+        self.devices = self.params['devices']
+        self.state = self.params['state']
+
+        self.hosts = self.get_all_host_objs(cluster_name=self.cluster, esxi_host_name=self.esxi_hostname)
+        # Looks for a specified ESXi host from a cluster if specified cluster and ESXi host.
+        if self.cluster and self.esxi_hostname:
+            self.hosts = [host_obj for host_obj in self.hosts if host_obj.name == self.esxi_hostname]
+        if not self.hosts:
+            self.module.fail_json(msg="Failed to find host system: %s" % self.esxi_hostname)
+
+        self.result = dict(changed=False, passthrough_configs=[], diff={})
+
+    def collect_pci_device_ids_for_supported_passthrough(self):
+        """
+        Collect device ids for supported passthrough from pciPassthruInfo.
+        The condition for whether support passthrough is that passthruCapable property has True.
+        """
+        self.hosts_passthrough_pci_device_id = {}
+        for host_obj in self.hosts:
+            esxi_hostname = host_obj.name
+            self.hosts_passthrough_pci_device_id[esxi_hostname] = {
+                'host_obj': host_obj,
+                'pci_device_ids': []
+            }
+            for pci_device in host_obj.config.pciPassthruInfo:
+                if pci_device.passthruCapable:
+                    self.hosts_passthrough_pci_device_id[esxi_hostname]['pci_device_ids'].append(pci_device)
+
+    def collect_pci_devices_able_to_enable_passthrough(self):
+        """
+        Collect devices able to enable passthrough based on device id.
+        """
+        self.hosts_passthrough_pci_devices = []
+        for esxi_hostname, value in self.hosts_passthrough_pci_device_id.items():
+            pci_devices = []
+            for device_id in value['pci_device_ids']:
+                for device in self.hosts_passthrough_pci_device_id[esxi_hostname]['host_obj'].hardware.pciDevice:
+                    if device.id == device_id.id:
+                        pci_devices.append({
+                            'device_name': device.deviceName,
+                            'device_id': device.id,
+                            'passthruEnabled': device_id.passthruEnabled,
+                        })
+            self.hosts_passthrough_pci_devices.append({
+                esxi_hostname: {
+                    'host_obj': value['host_obj'],
+                    'pci_devices': pci_devices
+                }
+            })
+
+    def check_whether_devices_exist(self):
+        """
+        Check specified pci devices are exists.
+        """
+        self.existent_devices = []
+        self.non_existent_devices = []
+
+        for host_pci_device in self.hosts_passthrough_pci_devices:
+            pci_devices = []
+            for esxi_hostname, value in host_pci_device.items():
+                for target_device in self.devices:
+                    device_name = target_device['device_name']
+                    if device_name in [device['device_name'] for device in value['pci_devices']]:
+                        pci_devices.append(
+                            [device for device in value['pci_devices'] if device_name == device['device_name']]
+                        )
+                    else:
+                        self.non_existent_devices.append(device_name)
+                self.existent_devices.append({
+                    esxi_hostname: {
+                        'host_obj': value['host_obj'],
+                        'checked_pci_devices': sum(pci_devices, [])
+                    }
+                })
+
+    def diff_passthrough_config(self):
+        """
+        Check there are differences between a new and existing config each ESXi host.
+        """
+        # Make the diff_config variable to check the difference between a new and existing config.
+        self.diff_config = dict(before={}, after={})
+
+        self.change_flag = False
+        self.host_target_device_to_change_configuration = {}
+        state = True if self.state == "present" else False
+        for host_has_checked_pci_devices in self.existent_devices:
+            for esxi_hostname, value in host_has_checked_pci_devices.items():
+                for key in 'before', 'after':
+                    self.diff_config[key][esxi_hostname] = []
+                self.host_target_device_to_change_configuration[esxi_hostname] = {
+                    'host_obj': None,
+                    'new_configs': []
+                }
+                for target_device in self.devices:
+                    device_name = target_device['device_name']
+                    for checked_pci_device in value['checked_pci_devices']:
+                        if device_name == checked_pci_device['device_name']:
+                            before = dict(checked_pci_device)
+                            after = dict(copy.deepcopy(checked_pci_device))
+
+                            if state != checked_pci_device['passthruEnabled']:
+                                self.change_flag = True
+                                after['passthruEnabled'] = state
+
+                                self.host_target_device_to_change_configuration[esxi_hostname]['new_configs'].append(after)
+                            self.host_target_device_to_change_configuration[esxi_hostname]['host_obj'] = value['host_obj']
+                            self.diff_config['before'][esxi_hostname].append(before)
+                            self.diff_config['after'][esxi_hostname].append(after)
+
+    def generate_passthrough_configurations_to_be_applied(self):
+        """
+        Generate configs to enable or disable PCI device passthrough.
+        The configs are generated against only ESXi host has PCI device to be changed.
+        """
+        self.host_passthrough_configs = {}
+        for esxi_hostname, value in self.host_target_device_to_change_configuration.items():
+            self.host_passthrough_configs[esxi_hostname] = {
+                'host_obj': value['host_obj'],
+                'generated_new_configs': []
+            }
+            if value['new_configs']:
+                state = True if self.state == "present" else False
+                for new_config in value['new_configs']:
+                    config = vim.host.PciPassthruConfig()
+                    config.passthruEnabled = state
+                    config.id = new_config['device_id']
+                    self.host_passthrough_configs[esxi_hostname]['generated_new_configs'].append(config)
+
+    def execute(self):
+        self.collect_pci_device_ids_for_supported_passthrough()
+        self.collect_pci_devices_able_to_enable_passthrough()
+
+        self.check_whether_devices_exist()
+        if self.non_existent_devices:
+            self.module.fail_json(msg="Failed to fined device: %s" % list(set(self.non_existent_devices)))
+
+        self.diff_passthrough_config()
+        if self.change_flag and self.module.check_mode is False:
+            self.generate_passthrough_configurations_to_be_applied()
+            for value in self.host_passthrough_configs.values():
+                try:
+                    host_obj = value['host_obj']
+                    config = value['generated_new_configs']
+                    host_obj.configManager.pciPassthruSystem.UpdatePassthruConfig(config)
+                except Exception as e:
+                    self.module.fail_json(msg="Failed to operate PCI device passthrough: %s" % e)
+
+        # ESXi host configuration will be included in the result if it will be changed.
+        self.result['passthrough_configs'] = [
+            {
+                esxi_hostname: value['new_configs']
+            } for esxi_hostname, value in self.host_target_device_to_change_configuration.items() if value['new_configs']
+        ]
+        self.result['changed'] = self.change_flag
+        self.result['diff'] = self.diff_config
+        self.module.exit_json(**self.result)
+
+
+def main():
+    argument_spec = vmware_argument_spec()
+    argument_spec.update(
+        cluster=dict(type='str', aliases=['cluster_name']),
+        esxi_hostname=dict(type='str'),
+        devices=dict(type='list', elements='dict', required=True,
+                     options=dict(
+                         device_name=dict(type='str', aliases=['name'])
+                     )),
+        state=dict(type='str', default='present', choices=['present', 'absent'])
+    )
+
+    module = AnsibleModule(argument_spec=argument_spec,
+                           required_one_of=[
+                               ['cluster', 'esxi_hostname']
+                           ],
+                           supports_check_mode=True)
+
+    vmware_host_passthrough = VMwareHostPassthrough(module)
+    vmware_host_passthrough.execute()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/vmware_host_passthrough/aliases
+++ b/tests/integration/targets/vmware_host_passthrough/aliases
@@ -1,0 +1,3 @@
+cloud/vcenter
+needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_host_passthrough/tasks/main.yml
+++ b/tests/integration/targets/vmware_host_passthrough/tasks/main.yml
@@ -1,0 +1,17 @@
+# Test code for the vmware_host_passthrough module.
+# Copyright: (c) 2021, sky-joker <sky.jokerxx@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_attach_host: true
+
+- name: Include tasks pre.yml
+  include_tasks: pre.yml
+
+- name: Include tasks vmware_host_passthrough_tests.yml
+  include_tasks: vmware_host_passthrough.yml
+  when:
+    - list_of_pci_devices_that_can_be_enabled_passthrough is defined
+    - list_of_pci_devices_that_can_be_enabled_passthrough | length >= 1

--- a/tests/integration/targets/vmware_host_passthrough/tasks/pre.yml
+++ b/tests/integration/targets/vmware_host_passthrough/tasks/pre.yml
@@ -1,0 +1,40 @@
+# Test code for the vmware_host_passthrough module.
+# Copyright: (c) 2021, sky-joker <sky.jokerxx@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Gather PCI devices info from ESXi host
+  community.vmware.vmware_host_facts:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    schema: vsphere
+    properties:
+      - config.pciPassthruInfo
+      - hardware.pciDevice
+  register: pci_devices_result
+
+- name: Set the device_ids variable that includes to be enabled passthrough devices only
+  set_fact:
+    device_ids: >-
+      {{ device_ids | default([])
+        + [item]
+      }}
+  loop: "{{ pci_devices_result.ansible_facts.config.pciPassthruInfo }}"
+  when:
+    - item.passthruCapable is sameas true
+
+- name: The block task is collected PCI devices that can be enable passthrough if the device_ids variable is defined
+  when:
+    - device_ids is defined
+  block:
+    - name: Set the list_of_pci_devices_that_can_be_enabled_passthrough variable
+      set_fact:
+        list_of_pci_devices_that_can_be_enabled_passthrough: >-
+          {{ list_of_pci_devices_that_can_be_enabled_passthrough | default([])
+            + [item.1]
+          }}
+      loop: "{{ device_ids | product(pci_devices_result.ansible_facts.hardware.pciDevice) | list }}"
+      when:
+        - item.0.id == item.1.id

--- a/tests/integration/targets/vmware_host_passthrough/tasks/pre.yml
+++ b/tests/integration/targets/vmware_host_passthrough/tasks/pre.yml
@@ -25,7 +25,7 @@
   when:
     - item.passthruCapable is sameas true
 
-- name: The block task is collected PCI devices that can be enable passthrough if the device_ids variable is defined
+- name: The block task is collected PCI devices that can be enabled passthrough if the device_ids variable is defined
   when:
     - device_ids is defined
   block:

--- a/tests/integration/targets/vmware_host_passthrough/tasks/vmware_host_passthrough.yml
+++ b/tests/integration/targets/vmware_host_passthrough/tasks/vmware_host_passthrough.yml
@@ -1,0 +1,229 @@
+# Test code for the vmware_host_passthrough module.
+# Copyright: (c) 2021, sky-joker <sky.jokerxx@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Set the target_pci_device variable to execute the integration tests
+  set_fact:
+    target_pci_device: "{{ list_of_pci_devices_that_can_be_enabled_passthrough.0.deviceName }}"
+
+- name: Enable passthrough of PCI device with check_mode and diff without the cluster
+  community.vmware.vmware_host_passthrough:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    devices:
+      - device_name: "{{ target_pci_device }}"
+  check_mode: true
+  diff: true
+  register: enable_passthrough_check_mode_diff_result
+
+- name: Make sure if the change has occurred
+  assert:
+    that:
+      - enable_passthrough_check_mode_diff_result.changed is sameas true
+
+- name: Enable passthrough of PCI device with check_mode without the cluster
+  community.vmware.vmware_host_passthrough:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    devices:
+      - device_name: "{{ target_pci_device }}"
+  check_mode: true
+  register: enable_passthrough_check_mode_result
+
+- name: Make sure if the change has occurred
+  assert:
+    that:
+      - enable_passthrough_check_mode_result.changed is sameas true
+
+- name: Enable passthrough of PCI device without the cluster
+  community.vmware.vmware_host_passthrough:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    devices:
+      - device_name: "{{ target_pci_device }}"
+  register: enable_passthrough_result
+
+- name: Make sure if the change has occurred
+  assert:
+    that:
+      - enable_passthrough_result.changed is sameas true
+      - enable_passthrough_result.passthrough_configs is defined
+      - enable_passthrough_result.passthrough_configs | length >= 1
+
+- name: Wait 10 sec because need a little time to enable completely passthrough of PCI device
+  pause:
+    seconds: 10
+
+- name: Enable passthrough of PCI device without the cluster (idempotency)
+  community.vmware.vmware_host_passthrough:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    devices:
+      - device_name: "{{ target_pci_device }}"
+  register: enable_passthrough_indempotency_result
+
+- name: Make sure if the change hasn't occurred
+  assert:
+    that:
+      - enable_passthrough_indempotency_result.changed is sameas false
+
+- name: Disable passthrough of PCI device without the cluster
+  community.vmware.vmware_host_passthrough:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    devices:
+      - device_name: "{{ target_pci_device }}"
+    state: absent
+  register: disable_passthrough_result
+
+- name: Make sure if the change has occurred
+  assert:
+    that:
+      - disable_passthrough_result.changed is sameas true
+
+- name: Wait 10 sec because need a little time to disable completely passthrough of PCI device
+  pause:
+    seconds: 10
+
+- name: Disable passthrough of PCI device without the cluster (idempotency)
+  community.vmware.vmware_host_passthrough:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    devices:
+      - device_name: "{{ target_pci_device }}"
+    state: absent
+  register: disable_passthrough_idempotency_result
+
+- name: Make sure if the change hasn't occurred
+  assert:
+    that:
+      - disable_passthrough_idempotency_result.changed is sameas false
+
+- name: Enable passthrough of PCI device with check_mode and diff without the esxi_hostname
+  community.vmware.vmware_host_passthrough:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    cluster: "{{ ccr1 }}"
+    devices:
+      - device_name: "{{ target_pci_device }}"
+  check_mode: true
+  diff: true
+  register: enable_passthrough_cluster_check_mode_diff_result
+
+- name: Make sure if the change has occurred
+  assert:
+    that:
+      - enable_passthrough_cluster_check_mode_diff_result.changed is sameas true
+
+- name: Enable passthrough of PCI device with check_mode without the esxi_hostname
+  community.vmware.vmware_host_passthrough:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    cluster: "{{ ccr1 }}"
+    devices:
+      - device_name: "{{ target_pci_device }}"
+  check_mode: true
+  register: enable_passthrough_cluster_check_mode_result
+
+- name: Make sure if the change has occurred
+  assert:
+    that:
+      - enable_passthrough_cluster_check_mode_result.changed is sameas true
+
+- name: Enable passthrough of PCI device without the esxi_hostname
+  community.vmware.vmware_host_passthrough:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    cluster: "{{ ccr1 }}"
+    devices:
+      - device_name: "{{ target_pci_device }}"
+  register: enable_passthrough_cluster_result
+
+- name: Make sure if the change has occurred
+  assert:
+    that:
+      - enable_passthrough_cluster_result.changed is sameas true
+      - enable_passthrough_cluster_result.passthrough_configs is defined
+      - enable_passthrough_cluster_result.passthrough_configs | length >= 1
+
+- name: Wait 10 sec because need a little time to enable completely passthrough of PCI device
+  pause:
+    seconds: 10
+
+- name: Enable passthrough of PCI device without the esxi_hostname (idempotency)
+  community.vmware.vmware_host_passthrough:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    cluster: "{{ ccr1 }}"
+    devices:
+      - device_name: "{{ target_pci_device }}"
+  register: enable_passthrough_cluster_indempotency_result
+
+- name: Make sure if the change hasn't occurred
+  assert:
+    that:
+      - enable_passthrough_cluster_indempotency_result.changed is sameas false
+
+- name: Disable passthrough of PCI device without the esxi_hostname
+  community.vmware.vmware_host_passthrough:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    cluster: "{{ ccr1 }}"
+    devices:
+      - device_name: "{{ target_pci_device }}"
+    state: absent
+  register: disable_passthrough_cluster_result
+
+- name: Make sure if the change has occurred
+  assert:
+    that:
+      - disable_passthrough_cluster_result.changed is sameas true
+
+- name: Wait 10 sec because need a little time to disable completely passthrough of PCI device
+  pause:
+    seconds: 10
+
+- name: Disable passthrough of PCI device without the esxi_hostname (idempotency)
+  community.vmware.vmware_host_passthrough:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    cluster: "{{ ccr1 }}"
+    devices:
+      - device_name: "{{ target_pci_device }}"
+    state: absent
+  register: disable_passthrough_cluster_idempotency_result
+
+- name: Make sure if the change hasn't occurred
+  assert:
+    that:
+      - disable_passthrough_cluster_idempotency_result.changed is sameas false

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -266,6 +266,8 @@ plugins/modules/vmware_host_package_facts.py compile-2.6!skip
 plugins/modules/vmware_host_package_facts.py import-2.6!skip
 plugins/modules/vmware_host_package_info.py compile-2.6!skip
 plugins/modules/vmware_host_package_info.py import-2.6!skip
+plugins/modules/vmware_host_passthrough.py compile-2.6!skip
+plugins/modules/vmware_host_passthrough.py import-2.6!skip
 plugins/modules/vmware_host_powermgmt_policy.py compile-2.6!skip
 plugins/modules/vmware_host_powermgmt_policy.py import-2.6!skip
 plugins/modules/vmware_host_powerstate.py compile-2.6!skip

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -276,6 +276,8 @@ plugins/modules/vmware_host_package_facts.py compile-2.6!skip
 plugins/modules/vmware_host_package_facts.py import-2.6!skip
 plugins/modules/vmware_host_package_info.py compile-2.6!skip
 plugins/modules/vmware_host_package_info.py import-2.6!skip
+plugins/modules/vmware_host_passthrough.py compile-2.6!skip
+plugins/modules/vmware_host_passthrough.py import-2.6!skip
 plugins/modules/vmware_host_powermgmt_policy.py compile-2.6!skip
 plugins/modules/vmware_host_powermgmt_policy.py import-2.6!skip
 plugins/modules/vmware_host_powerstate.py compile-2.6!skip

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -247,6 +247,8 @@ plugins/modules/vmware_host_package_facts.py compile-2.6!skip
 plugins/modules/vmware_host_package_facts.py import-2.6!skip
 plugins/modules/vmware_host_package_info.py compile-2.6!skip
 plugins/modules/vmware_host_package_info.py import-2.6!skip
+plugins/modules/vmware_host_passthrough.py compile-2.6!skip
+plugins/modules/vmware_host_passthrough.py import-2.6!skip
 plugins/modules/vmware_host_powermgmt_policy.py compile-2.6!skip
 plugins/modules/vmware_host_powermgmt_policy.py import-2.6!skip
 plugins/modules/vmware_host_powerstate.py compile-2.6!skip

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -304,6 +304,8 @@ plugins/modules/vmware_host_package_facts.py validate-modules:deprecation-mismat
 plugins/modules/vmware_host_package_facts.py validate-modules:invalid-documentation
 plugins/modules/vmware_host_package_info.py compile-2.6!skip
 plugins/modules/vmware_host_package_info.py import-2.6!skip
+plugins/modules/vmware_host_passthrough.py compile-2.6!skip
+plugins/modules/vmware_host_passthrough.py import-2.6!skip
 plugins/modules/vmware_host_powermgmt_policy.py compile-2.6!skip
 plugins/modules/vmware_host_powermgmt_policy.py import-2.6!skip
 plugins/modules/vmware_host_powerstate.py compile-2.6!skip


### PR DESCRIPTION
Depends-On: #877

##### SUMMARY

This PR will add a new module to enable or disable the passthrough of PCI devices with ESXi has.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

README.md
changelogs/fragments/872-vmware_host_passthrough.yml
docs/community.vmware.vmware_host_passthrough_module.rst
meta/runtime.yml
plugins/modules/vmware_host_passthrough.py
tests/integration/targets/vmware_host_passthrough/aliases
tests/integration/targets/vmware_host_passthrough/tasks/main.yml
tests/integration/targets/vmware_host_passthrough/tasks/pre.yml
tests/integration/targets/vmware_host_passthrough/tasks/vmware_host_passthrough.yml
tests/sanity/ignore-2.9.txt
tests/sanity/ignore-2.10.txt
tests/sanity/ignore-2.11.txt
tests/sanity/ignore-2.12.txt

##### ADDITIONAL INFORMATION

tested on vCenter/ESXi 7.0
