### PR TITLE
vmware_content_library_manager: disable the test-suite

### DIFF
--- a/tests/integration/targets/vmware_content_library_manager/aliases
+++ b/tests/integration/targets/vmware_content_library_manager/aliases
@@ -2,3 +2,5 @@ cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
 zuul/vmware/govcsim
+# see: https://github.com/ansible-collections/community.vmware/issues/875
+disabled


### PR DESCRIPTION
Temporarily disable `vmware_content_library_manager` tests until the test-suite is fixed.

See: #875 