### PR TITLE
vmware_object_custom_attributes_info: add a new parameter to support moid

### DIFF
--- a/changelogs/fragments/879-vmware_object_custom_attributes_info.yml
+++ b/changelogs/fragments/879-vmware_object_custom_attributes_info.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - vmware - added a new method to search Managed Object based on moid and object type (https://github.com/ansible-collections/community.vmware/pull/879).
+  - vmware_object_custom_attributes_info - added a new parameter to support moid (https://github.com/ansible-collections/community.vmware/pull/879).

--- a/docs/community.vmware.vmware_object_custom_attributes_info_module.rst
+++ b/docs/community.vmware.vmware_object_custom_attributes_info_module.rst
@@ -60,11 +60,26 @@ Parameters
             <tr>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>moid</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Managed Object ID of the instance to get if known, this is a unique identifier only within a single vCenter instance.</div>
+                        <div>This is required if <code>object_name</code> is not supplied.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>object_name</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
-                         / <span style="color: red">required</span>
                     </div>
                 </td>
                 <td>
@@ -236,6 +251,16 @@ Examples
         validate_certs: false
         object_type: VirtualMachine
         object_name: "{{ object_name }}"
+      register: vm_attributes
+
+    - name: Gather custom attributes of a virtual machine with moid
+      community.vmware.vmware_object_custom_attributes_info:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        object_type: VirtualMachine
+        moid: "{{ moid }}"
       register: vm_attributes
 
 

--- a/plugins/module_utils/vmware.py
+++ b/plugins/module_utils/vmware.py
@@ -1770,3 +1770,25 @@ class PyVmomi(object):
             cur = cur.parent
             full_path = '/' + cur.name + full_path
         return full_path
+
+    def find_obj_by_moid(self, object_type, moid):
+        """
+        Get Managed Object based on an object type and moid.
+        If you'd like to search for a virtual machine, recommended you use get_vm method.
+
+        Args:
+          - object_type: Managed Object type
+                It is possible to specify types the following.
+                ["Datacenter", "ClusterComputeResource", "ResourcePool", "Folder", "HostSystem",
+                 "VirtualMachine", "DistributedVirtualSwitch", "DistributedVirtualPortgroup", "Datastore"]
+          - moid: moid of Managed Object
+        :return: Managed Object if it exists else None
+        """
+
+        obj = VmomiSupport.templateOf(object_type)(moid, self.si._stub)
+        try:
+            getattr(obj, 'name')
+        except vmodl.fault.ManagedObjectNotFound:
+            obj = None
+
+        return obj

--- a/tests/integration/targets/vmware_object_custom_attributes_info/tasks/pre.yml
+++ b/tests/integration/targets/vmware_object_custom_attributes_info/tasks/pre.yml
@@ -29,3 +29,30 @@
       - name: esxi_example02
         value: test2
     state: present
+
+- name: Gather virtual machine information
+  community.vmware.vmware_guest_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    datacenter: "{{ dc1 }}"
+    name: "{{ virtual_machines.0.name }}"
+  register: vm_info
+
+- name: Gather ESXi host information
+  community.vmware.vmware_host_facts:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    schema: vsphere
+    properties:
+      - _moId
+  register: esxi_info
+
+- name: Set vm_moid and esxi_moid variable
+  set_fact:
+    vm_moid: "{{ vm_info.instance.moid }}"
+    esxi_moid: "{{ esxi_info.ansible_facts.moid }}"

--- a/tests/integration/targets/vmware_object_custom_attributes_info/tasks/vmware_object_custom_attributes_info_tests.yml
+++ b/tests/integration/targets/vmware_object_custom_attributes_info/tasks/vmware_object_custom_attributes_info_tests.yml
@@ -12,8 +12,6 @@
     object_name: "{{ virtual_machines.0.name }}"
   register: vm_custom_attributes_result
 
-- debug: msg="{{ vm_custom_attributes_result }}"
-
 - name: Make sure if custom attributes exist
   assert:
     that:
@@ -30,6 +28,42 @@
     validate_certs: false
     object_type: HostSystem
     object_name: "{{ esxi1 }}"
+  register: esxi_custom_attributes_result
+
+- name: Make sure if custom attributes exist
+  assert:
+    that:
+      - esxi_custom_attributes_result.custom_attributes | selectattr('attribute', 'equalto', 'esxi_example01')
+      - esxi_custom_attributes_result.custom_attributes | selectattr('value', 'equalto', 'test1')
+      - esxi_custom_attributes_result.custom_attributes | selectattr('attribute', 'equalto', 'esxi_example02')
+      - esxi_custom_attributes_result.custom_attributes | selectattr('value', 'equalto', 'test2')
+
+- name: Gather custom attributes of a virtual machine with moid
+  community.vmware.vmware_object_custom_attributes_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    object_type: VirtualMachine
+    moid: "{{ vm_moid }}"
+  register: vm_custom_attributes_with_moid_result
+
+- name: Make sure if custom attributes exist
+  assert:
+    that:
+      - vm_custom_attributes_with_moid_result.custom_attributes | selectattr('attribute', 'equalto', 'vm_example01')
+      - vm_custom_attributes_with_moid_result.custom_attributes | selectattr('value', 'equalto', 'test1')
+      - vm_custom_attributes_with_moid_result.custom_attributes | selectattr('attribute', 'equalto', 'vm_example02')
+      - vm_custom_attributes_with_moid_result.custom_attributes | selectattr('value', 'equalto', 'test2')
+
+- name: Gather custom attributes of an ESXi with moid
+  community.vmware.vmware_object_custom_attributes_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    object_type: HostSystem
+    moid: "{{ esxi_moid }}"
   register: esxi_custom_attributes_result
 
 - name: Make sure if custom attributes exist


### PR DESCRIPTION
##### SUMMARY

This PR will add a new parameter to support moid to the module and a new method to get Managed Object based on moid and object type to vmware.py.  
We can quickly search Managed Object based on moid and object type by using the find_obj_by_moid method.  
Also, the method will be standardized to search by moid.  
The method can be also searched a virtual machine but already implemented get_vm that dedicated to a virtual machine, so I've added a comment about recommended searching method when a virtual machine.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

changelogs/fragments/879-vmware_object_custom_attributes_info.yml
docs/community.vmware.vmware_object_custom_attributes_info_module.rst  
plugins/module_utils/vmware.py  
plugins/modules/vmware_object_custom_attributes_info.py  
tests/integration/targets/vmware_object_custom_attributes_info/tasks/pre.yml  
tests/integration/targets/vmware_object_custom_attributes_info/tasks/vmware_object_custom_attributes_info_tests.yml  

##### ADDITIONAL INFORMATION

tested on vCenter/ESXi 7.0