### PR TITLE
Revert "vmware_content_library_manager: disable the test-suite (#877)"

### DIFF
--- a/tests/integration/targets/vmware_content_library_manager/aliases
+++ b/tests/integration/targets/vmware_content_library_manager/aliases
@@ -2,5 +2,3 @@ cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
 zuul/vmware/govcsim
-# see: https://github.com/ansible-collections/community.vmware/issues/875
-disabled


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/957

This reverts commit b44ec019efec3018b52e5c66681933316ebf1f3f.