### PR TITLE
Add a string composed variable example for vmware_vm_inventory plugin

### DIFF
--- a/plugins/inventory/vmware_host_inventory.py
+++ b/plugins/inventory/vmware_host_inventory.py
@@ -141,6 +141,20 @@ EXAMPLES = r"""
     password: Esxi@123$%
     validate_certs: False
     with_tags: True
+
+# Using compose
+    plugin: community.vmware.vmware_host_inventory
+    hostname: 10.65.223.31
+    username: administrator@vsphere.local
+    password: Esxi@123$%
+    validate_certs: False
+    properties:
+    - name
+    - summary
+    - config.lockdownMode
+    compose:
+        ansible_user: "'root'"
+        ansible_connection: "'ssh'"
 """
 
 try:

--- a/plugins/inventory/vmware_vm_inventory.py
+++ b/plugins/inventory/vmware_vm_inventory.py
@@ -251,6 +251,9 @@ EXAMPLES = r'''
       # and will be used while communicating to the given virtual machine
       ansible_host: 'guest.ipAddress'
       composed_var: 'config.name'
+      # This will populate a host variable with a string value
+      ansible_user: "'admin'"
+      ansible_connection: "'ssh'"
     groups:
       VMs: True
     hostnames:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add an example for compose in the inventory plugin to populate a string value for host variables.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_vm_inventory

