### PR TITLE
vmware_vswitch: remove / from special char tests

### DIFF
--- a/tests/integration/targets/vmware_vswitch/tasks/main.yml
+++ b/tests/integration/targets/vmware_vswitch/tasks/main.yml
@@ -91,7 +91,7 @@
       username: "{{ esxi_user }}"
       password: "{{ esxi_password }}"
       validate_certs: false
-      switch: 'Switch\/%'
+      switch: 'Switch\%'
       state: present
     register: create_switch_with_special_characters_result
 
@@ -105,7 +105,7 @@
       username: "{{ esxi_user }}"
       password: "{{ esxi_password }}"
       validate_certs: false
-      switch: 'Switch\/%'
+      switch: 'Switch\%'
       state: present
     register: create_switch_with_special_characters_idempotency_check_result
 
@@ -119,7 +119,7 @@
       username: "{{ esxi_user }}"
       password: "{{ esxi_password }}"
       validate_certs: false
-      switch: 'Switch\/%'
+      switch: 'Switch\%'
       state: absent
     register: delete_switch_with_special_characters_result
 
@@ -133,7 +133,7 @@
       username: "{{ esxi_user }}"
       password: "{{ esxi_password }}"
       validate_certs: false
-      switch: 'Switch\/%'
+      switch: 'Switch\%'
       state: absent
     register: delete_switch_with_special_characters_idempotency_check_result
 


### PR DESCRIPTION
With ESXi 7.0.2, we cannot add a network if the name comes with a '/'.

ESXi 7.0.2 and vSphere 7.0.2:

    $ govc host.vswitch.add -host.dns=esxi1.test -dc=my-dc foobar
    $ govc host.vswitch.add -host.dns=esxi1.test -dc=my-dc 'foo\\bar'
    $ govc host.vswitch.add -host.dns=esxi1.test -dc=my-dc 'foo/bar'
    govc: ServerFaultCode: An error occurred during host configuration.
    $ govc host.vswitch.add -host.dns=esxi1.test -dc=my-dc 'foo//bar'
    govc: ServerFaultCode: An error occurred during host configuration.
    $ govc host.vswitch.add -host.dns=esxi1.test -dc=my-dc 'foo\\bar2'
    $ govc host.vswitch.add -host.dns=esxi1.test -dc=my-dc 'foo\%'