### PR TITLE
Improve behavior for setting vSAN service on a vmk

### DIFF
--- a/changelogs/fragments/892-vmware_vmkernel.yml
+++ b/changelogs/fragments/892-vmware_vmkernel.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_vmkernel - manage vSAN service configuration on vmk interfaces so that it is possible to define multiple vSAN interfaces at the same, along with merely explicitly adding/removing interfaces, instead of applying a configuration that only enables the last specified vmk interface (https://github.com/ansible-collections/community.vmware/issues/891)

--- a/changelogs/fragments/892-vmware_vmkernel.yml
+++ b/changelogs/fragments/892-vmware_vmkernel.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - Fix a bug that prevented enabling VSAN on more than one vmk, risking splutting the whole cluster during interface migration scenarios (https://github.com/ansible-collections/community.vmware/issues/891)
+  - Fix a bug that prevented enabling VSAN on more than one vmk, risking splitting the whole cluster during interface migration scenarios (https://github.com/ansible-collections/community.vmware/issues/891)

--- a/changelogs/fragments/892-vmware_vmkernel.yml
+++ b/changelogs/fragments/892-vmware_vmkernel.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - vmware_vmkernel - manage vSAN service configuration on vmk interfaces so that it is possible to define multiple vSAN interfaces at the same, along with merely explicitly adding/removing interfaces, instead of applying a configuration that only enables the last specified vmk interface (https://github.com/ansible-collections/community.vmware/issues/891)
+  - Fix a bug that prevented enabling VSAN on more than one vmk, risking splutting the whole cluster during interface migration scenarios (https://github.com/ansible-collections/community.vmware/issues/891)

--- a/plugins/modules/vmware_vmkernel.py
+++ b/plugins/modules/vmware_vmkernel.py
@@ -751,12 +751,7 @@ class PyVmomiHelper(PyVmomi):
                 if changed_service_vsan:
                     if self.vnic.device in service_type_vmks['vsan']:
                         services_previous.append('VSAN')
-                    if self.enable_vsan:
-                        results['vsan'] = self.set_vsan_service_type()
-                    else:
-                        self.set_service_type(
-                            vnic_manager=vnic_manager, vmk=self.vnic, service_type='vsan', operation=operation
-                        )
+                    results['vsan'] = self.set_vsan_service_type(self.enable_vsan)
 
                 results['services_previous'] = ', '.join(services_previous)
         else:
@@ -792,7 +787,7 @@ class PyVmomiHelper(PyVmomi):
 
         return None
 
-    def set_vsan_service_type(self):
+    def set_vsan_service_type(self, enable_vsan=True):
         """
         Set VSAN service type
         Returns: result of UpdateVsan_Task
@@ -801,20 +796,43 @@ class PyVmomiHelper(PyVmomi):
         result = None
         vsan_system = self.esxi_host_obj.configManager.vsanSystem
 
-        vsan_port_config = vim.vsan.host.ConfigInfo.NetworkInfo.PortConfig()
-        vsan_port_config.device = self.vnic.device
-
+        vsan_system_config = vsan_system.config
         vsan_config = vim.vsan.host.ConfigInfo()
-        vsan_config.networkInfo = vim.vsan.host.ConfigInfo.NetworkInfo()
-        vsan_config.networkInfo.port = [vsan_port_config]
-        if not self.module.check_mode:
+
+        vsan_config.networkInfo = vsan_system_config.networkInfo
+        current_vsan_vnics = [portConfig.device for portConfig in vsan_system_config.networkInfo.port]
+        changed = False
+        result = "%s NIC %s (currently enabled NICs: %s) : " % ("Enable" if enable_vsan else "Disable", self.vnic.device, current_vsan_vnics)
+        if not enable_vsan:
+            if self.vnic.device in current_vsan_vnics:
+                vsan_config.networkInfo.port = list(filter(lambda portConfig: portConfig.device != self.vnic.device, vsan_config.networkInfo.port))
+                changed = True
+        else:
+            if self.vnic.device not in current_vsan_vnics:
+                vsan_port_config = vim.vsan.host.ConfigInfo.NetworkInfo.PortConfig()
+                vsan_port_config.device = self.vnic.device
+
+                if vsan_config.networkInfo is None:
+                    vsan_config.networkInfo = vim.vsan.host.ConfigInfo.NetworkInfo()
+                    vsan_config.networkInfo.port = [vsan_port_config]
+                else:
+                    vsan_config.networkInfo.port += [vsan_port_config]
+                changed = True
+
+        if not self.module.check_mode and changed:
             try:
                 vsan_task = vsan_system.UpdateVsan_Task(vsan_config)
-                wait_for_task(vsan_task)
+                task_result = wait_for_task(vsan_task)
+                if task_result[0]:
+                    result += "Success"
+                else:
+                    result += "Failed"
             except TaskError as task_err:
                 self.module.fail_json(
                     msg="Failed to set service type to vsan for %s : %s" % (self.vnic.device, to_native(task_err))
                 )
+        if self.module.check_mode:
+            result += "Dry-run"
         return result
 
     def host_vmk_create(self):

--- a/plugins/modules/vmware_vmkernel.py
+++ b/plugins/modules/vmware_vmkernel.py
@@ -787,7 +787,7 @@ class PyVmomiHelper(PyVmomi):
 
         return None
 
-    def set_vsan_service_type(self, enable_vsan=False):
+    def set_vsan_service_type(self, enable_vsan):
         """
         Set VSAN service type
         Returns: result of UpdateVsan_Task
@@ -816,7 +816,7 @@ class PyVmomiHelper(PyVmomi):
                     vsan_config.networkInfo = vim.vsan.host.ConfigInfo.NetworkInfo()
                     vsan_config.networkInfo.port = [vsan_port_config]
                 else:
-                    vsan_config.networkInfo.port += [vsan_port_config]
+                    vsan_config.networkInfo.port.append(vsan_port_config)
                 changed = True
 
         if not self.module.check_mode and changed:

--- a/plugins/modules/vmware_vmkernel.py
+++ b/plugins/modules/vmware_vmkernel.py
@@ -787,7 +787,7 @@ class PyVmomiHelper(PyVmomi):
 
         return None
 
-    def set_vsan_service_type(self, enable_vsan=True):
+    def set_vsan_service_type(self, enable_vsan=False):
         """
         Set VSAN service type
         Returns: result of UpdateVsan_Task
@@ -927,7 +927,7 @@ class PyVmomiHelper(PyVmomi):
 
             # VSAN
             if self.enable_vsan:
-                results['vsan'] = self.set_vsan_service_type()
+                results['vsan'] = self.set_vsan_service_type(self.enable_vsan)
 
             # Other service type
             host_vnic_manager = self.esxi_host_obj.configManager.virtualNicManager


### PR DESCRIPTION
- List all vNICs with from the current vSAN config
- Check intent before adding/removing
- Implement proper addition/removal, instead of previous config squashing (which only enabled one vNIC)
- Return a result message instead of a None value

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #891 

This implementation allows to set more than one vmk NIC with the vSAN service, it will look up current configuration and modify it instead of crafting a new configuration that handles the last vmk NIC added.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cloud/vmware/vmware_vmkernel.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
$ ansible-playbook -i development ./provision.yml -v -t esxi_vmk_interfaces -l esxi_host
PLAY [vsan]

TASK [esxi_vmk_intrefaces : Configure vmkernel port vmk0]
changed: [esxi_host -> localhost] => {"changed": true, "device": "vmk0", "ipv4": "static", "ipv4_gw": "No override", "ipv4_ip": "10.0.0.1", "ipv4_sm": "255.255.255.0", "msg": "VMkernel Adapter services updated", "mtu": 1500, "portgroup": "Management Network", "services": "Mgmt, VSAN", "services_previous": "Mgmt", "switch": "vSwitch0", "tcpip_stack": "default", "vsan": "Enable NIC vmk0 (currenty enabled NICs: [])"}

TASK [esxi_vmk_intrefaces : Configure vmkernel port vmk3]
changed: [esxi_host -> localhost] => {"changed": true, "device": "vmk3", "ipv4": "static", "ipv4_gw": "No override", "ipv4_ip": "192.168.0.1", "ipv4_sm": "255.255.255.0", "msg": "VMkernel Adapter services updated", "mtu": 1500, "portgroup": "vSAN", "services": "VSAN", "services_previous": "", "switch": "vSwitch1", "tcpip_stack": "default", "vsan": "Enable NIC vmk3 (currenty enabled NICs: [])"}

$ ansible-playbook -i development ./provision.yml -v -t esxi_vmk_interfaces -l esxi_host
PLAY [vsan]

TASK [esxi_vmk_intrefaces : Configure vmkernel port vmk0]
changed: [esxi_host -> localhost] => {"changed": false, "device": "vmk0", "ipv4": "static", "ipv4_gw": "No override", "ipv4_ip": "10.0.0.1", "ipv4_sm": "255.255.255.0", "msg": "VMkernel Adapter already configured properly", "mtu": 1500, "portgroup": "Management Network", "services": "Mgmt, VSAN", "switch": "vSwitch0", "tcpip_stack": "default"}

TASK [esxi_vmk_intrefaces : Configure vmkernel port vmk3]
changed: [esxi_host -> localhost] => {"changed": false, "device": "vmk3", "ipv4": "static", "ipv4_gw": "No override", "ipv4_ip": "192.168.0.1", "ipv4_sm": "255.255.255.0", "msg": "VMkernel Adapter already configured properly", "mtu": 1500, "portgroup": "vSAN", "services": "VSAN", "switch": "vSwitch1", "tcpip_stack": "default"}
```

Status of the vSAN service and the vmk NICs can then be confirmed on the ESXi host :
```
[root@esxi_host:~] esxcli vsan network list | grep VmkNic
   VmkNic Name: vmk0
   VmkNic Name: vmk3
```