### PR TITLE
vmware_guest_disk: allow the creation of the vmdk if a custom filenam…

### DIFF
--- a/changelogs/fragments/898_vmware_guest_disk.yml
+++ b/changelogs/fragments/898_vmware_guest_disk.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_guest_disk - allow the creation of the vmdk if a custom filename is provided

--- a/changelogs/fragments/898_vmware_guest_disk.yml
+++ b/changelogs/fragments/898_vmware_guest_disk.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - vmware_guest_disk - allow the creation of the vmdk if a custom filename is provided
+  - vmware_guest_disk - allow the creation of the vmdk if a custom filename is provided (https://github.com/ansible-collections/community.vmware/pull/898).

--- a/plugins/modules/vmware_guest_disk.py
+++ b/plugins/modules/vmware_guest_disk.py
@@ -142,7 +142,7 @@ options:
          default: True
        filename:
          description:
-           - Existing disk image to be used. Filename must already exist on the datastore. Can be overriden by specifying C(force_create)
+           - Existing disk image to be used. Filename must already exist on the datastore. Can be overridden by specifying C(force_create).
            - Specify filename string in C([datastore_name] path/to/file.vmdk) format. Added in version 2.10.
          type: str
        force_create:

--- a/plugins/modules/vmware_guest_disk.py
+++ b/plugins/modules/vmware_guest_disk.py
@@ -150,7 +150,7 @@ options:
            - Force the creation of the file specified in C(filename) if it does not exist.
          type: bool
          default: False
-         version_added: 1.12.0
+         version_added: 1.13.0
        state:
          description:
            - State of disk.

--- a/plugins/modules/vmware_guest_disk.py
+++ b/plugins/modules/vmware_guest_disk.py
@@ -1019,7 +1019,7 @@ def main():
                 scsi_type=dict(type='str', choices=['buslogic', 'lsilogic', 'paravirtual', 'lsilogicsas']),
                 destroy=dict(type='bool', default=True),
                 filename=dict(type='str'),
-                force_create=dictt(type='bool', default=False),
+                force_create=dict(type='bool', default=False),
                 state=dict(type='str', default='present', choices=['present', 'absent']),
                 controller_type=dict(type='str', choices=['buslogic', 'lsilogic', 'paravirtual', 'lsilogicsas', 'sata', 'nvme']),
                 controller_number=dict(type='int', choices=[0, 1, 2, 3]),


### PR DESCRIPTION
Depends-on https://github.com/ansible-collections/community.vmware/pull/991
Depends-on https://github.com/ansible-collections/community.vmware/pull/977

##### SUMMARY
Allow the creation of the disk if a custom filename is provided

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_guest_disk

##### ADDITIONAL INFORMATION
Tested on vSphere 6.7