### PR TITLE
vmware_dvs_host: Implement adding pNICs to LAGs

### DIFF
--- a/changelogs/fragments/112-vmware_dvs_host.yml
+++ b/changelogs/fragments/112-vmware_dvs_host.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - vmware_dvs_host - implement adding pNICs to LAGs (https://github.com/ansible-collections/community.vmware/issues/112).
+ 

--- a/docs/community.vmware.vmware_dvs_host_module.rst
+++ b/docs/community.vmware.vmware_dvs_host_module.rst
@@ -75,6 +75,58 @@ Parameters
             <tr>
                 <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>lag_uplinks</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=dictionary</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.12.0</div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The ESXi hosts vmnics to use with specific LAGs.</div>
+                </td>
+            </tr>
+                                <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>lag</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Name of the LAG.</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>vmnics</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The ESXi hosts vmnics to use with the LAG.</div>
+                </td>
+            </tr>
+
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>password</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
@@ -311,6 +363,25 @@ Examples
         vmnics:
             - vmnic0
             - vmnic1
+        state: present
+      delegate_to: localhost
+
+    - name: Add vmnics to LAGs
+      community.vmware.vmware_dvs_host:
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        esxi_hostname: '{{ esxi_hostname }}'
+        switch_name: dvSwitch
+        lag_uplinks:
+            - lag: lag1
+              vmnics:
+                  - vmnic0
+                  - vmnic1
+            - lag: lag2
+              vmnics:
+                  - vmnic2
+                  - vmnic3
         state: present
       delegate_to: localhost
 

--- a/plugins/modules/vmware_dvs_host.py
+++ b/plugins/modules/vmware_dvs_host.py
@@ -44,6 +44,7 @@ options:
         type: list
         elements: str
     lag_uplinks:
+        version_added: '1.12.0'
         required: False
         type: list
         elements: dict
@@ -58,7 +59,7 @@ options:
             vmnics:
                 description:
                 - The ESXi hosts vmnics to use with the LAG.
-                required: False
+                required: True
                 type: list
                 elements: str
     state:
@@ -100,6 +101,25 @@ EXAMPLES = r'''
     vmnics:
         - vmnic0
         - vmnic1
+    state: present
+  delegate_to: localhost
+
+- name: Add vmnics to LAGs
+  community.vmware.vmware_dvs_host:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    esxi_hostname: '{{ esxi_hostname }}'
+    switch_name: dvSwitch
+    lag_uplinks:
+        - lag: lag1
+          vmnics:
+              - vmnic0
+              - vmnic1
+        - lag: lag2
+          vmnics:
+              - vmnic2
+              - vmnic3
     state: present
   delegate_to: localhost
 
@@ -373,7 +393,7 @@ def main():
                     ),
                     vmnics=dict(
                         type='list',
-                        required=False,
+                        required=True,
                         elements='str',
                         default=[],
                     ),

--- a/plugins/modules/vmware_dvs_host.py
+++ b/plugins/modules/vmware_dvs_host.py
@@ -59,7 +59,7 @@ options:
             vmnics:
                 description:
                 - The ESXi hosts vmnics to use with the LAG.
-                required: True
+                required: False
                 type: list
                 elements: str
     state:
@@ -393,7 +393,7 @@ def main():
                     ),
                     vmnics=dict(
                         type='list',
-                        required=True,
+                        required=False,
                         elements='str',
                         default=[],
                     ),

--- a/plugins/modules/vmware_dvs_host.py
+++ b/plugins/modules/vmware_dvs_host.py
@@ -43,6 +43,24 @@ options:
         required: False
         type: list
         elements: str
+    lag_uplinks:
+        required: False
+        type: list
+        elements: dict
+        description:
+        - The ESXi hosts vmnics to use with specific LAGs.
+        suboptions:
+            lag:
+                description:
+                - Name of the LAG.
+                type: str
+                required: True
+            vmnics:
+                description:
+                - The ESXi hosts vmnics to use with the LAG.
+                required: False
+                type: list
+                elements: str
     state:
         description:
         - If the host should be present or absent attached to the vSwitch.
@@ -284,6 +302,24 @@ def main():
                 options=dict(
                     key=dict(type='str', required=True, no_log=False),
                     value=dict(type='str', required=True),
+                ),
+            ),
+            lag_uplinks=dict(
+                type='list',
+                default=[],
+                required=False,
+                elements='dict',
+                options=dict(
+                    lag=dict(
+                        type='str',
+                        required=True,
+                    ),
+                    vmnics=dict(
+                        type='list',
+                        required=False,
+                        elements='str',
+                        default=[],
+                    ),
                 ),
             ),
         )

--- a/plugins/modules/vmware_dvs_host.py
+++ b/plugins/modules/vmware_dvs_host.py
@@ -121,12 +121,6 @@ EXAMPLES = r'''
 '''
 
 try:
-    from collections import Counter
-    HAS_COLLECTIONS_COUNTER = True
-except ImportError:
-    HAS_COLLECTIONS_COUNTER = False
-
-try:
     from pyVmomi import vim, vmodl
 except ImportError:
     pass
@@ -390,9 +384,6 @@ def main():
 
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True)
-
-    if not HAS_COLLECTIONS_COUNTER:
-        module.fail_json(msg='collections.Counter from Python-2.7 is required for this module')
 
     vmware_dvs_host = VMwareDvsHost(module)
     vmware_dvs_host.process_state()

--- a/plugins/modules/vmware_dvs_host.py
+++ b/plugins/modules/vmware_dvs_host.py
@@ -357,6 +357,9 @@ class VMwareDvsHost(PyVmomi):
                 self.module.fail_json(msg="The esxi_hostname %s does not exist "
                                           "in vCenter" % self.esxi_hostname)
             return 'absent'
+        # Skip checking uplinks if the host should be absent, anyway
+        elif self.state == 'absent':
+            return 'present'
         else:
             if self.check_uplinks():
                 return 'present'

--- a/plugins/modules/vmware_dvs_host.py
+++ b/plugins/modules/vmware_dvs_host.py
@@ -182,7 +182,7 @@ class VMwareDvsHost(PyVmomi):
 
         for lag_uplink in self.lag_uplinks:
             if lag_uplink['lag'] not in self.lags:
-                self.module.fail_json(msg="LAG %s not found" % lag_uplink.lag)
+                self.module.fail_json(msg="LAG %s not found" % lag_uplink['lag'])
 
     def process_state(self):
         dvs_host_states = {

--- a/plugins/modules/vmware_dvs_host.py
+++ b/plugins/modules/vmware_dvs_host.py
@@ -144,16 +144,31 @@ from ansible.module_utils._text import to_native
 class VMwareDvsHost(PyVmomi):
     def __init__(self, module):
         super(VMwareDvsHost, self).__init__(module)
-        self.dv_switch = None
         self.uplink_portgroup = None
         self.host = None
         self.dv_switch = None
-        self.nic = None
+        self.desired_state = {}
+
         self.state = self.module.params['state']
         self.switch_name = self.module.params['switch_name']
         self.esxi_hostname = self.module.params['esxi_hostname']
         self.vmnics = self.module.params['vmnics']
+        self.lag_uplinks = self.module.params['lag_uplinks']
         self.vendor_specific_config = self.module.params['vendor_specific_config']
+
+        self.dv_switch = find_dvs_by_name(self.content, self.switch_name)
+
+        if self.dv_switch is None:
+            self.module.fail_json(msg="A distributed virtual switch %s "
+                                      "does not exist" % self.switch_name)
+
+        self.lags = {}
+        for lag in self.dv_switch.config.lacpGroupConfig:
+            self.lags[lag.name] = lag
+
+        for lag_uplink in self.lag_uplinks:
+            if lag_uplink['lag'] not in self.lags:
+                self.module.fail_json(msg="LAG %s not found" % lag_uplink.lag)
 
     def process_state(self):
         dvs_host_states = {
@@ -197,14 +212,15 @@ class VMwareDvsHost(PyVmomi):
                 config.append(vim.dvs.KeyedOpaqueBlob(key=item['key'], opaqueData=item['value']))
             spec.host[0].vendorSpecificConfig = config
 
-        if operation in ("edit", "add"):
+        if operation == "edit":
             spec.host[0].backing = vim.dvs.HostMember.PnicBacking()
             count = 0
 
-            for nic in self.vmnics:
+            for nic, uplinkPortKey in self.desired_state.items():
                 spec.host[0].backing.pnicSpec.append(vim.dvs.HostMember.PnicSpec())
                 spec.host[0].backing.pnicSpec[count].pnicDevice = nic
                 spec.host[0].backing.pnicSpec[count].uplinkPortgroupKey = self.uplink_portgroup.key
+                spec.host[0].backing.pnicSpec[count].uplinkPortKey = uplinkPortKey
                 count += 1
 
         try:
@@ -238,6 +254,12 @@ class VMwareDvsHost(PyVmomi):
 
         if not self.module.check_mode:
             changed, result = self.modify_dvs_host(operation)
+            if changed:
+                self.set_desired_state()
+                changed, result = self.modify_dvs_host("edit")
+            else:
+                self.module.exit_json(changed=changed, result=to_native(result))
+
         self.module.exit_json(changed=changed, result=to_native(result))
 
     def find_host_attached_dvs(self):
@@ -247,23 +269,64 @@ class VMwareDvsHost(PyVmomi):
 
         return None
 
+    def set_desired_state(self):
+        lag_uplinks = []
+        switch_uplink_ports = {'non_lag': []}
+
+        portCriteria = vim.dvs.PortCriteria()
+        portCriteria.host = [self.host]
+        portCriteria.portgroupKey = self.uplink_portgroup.key
+        portCriteria.uplinkPort = True
+        ports = self.dv_switch.FetchDVPorts(portCriteria)
+
+        for name, lag in self.lags.items():
+            switch_uplink_ports[name] = []
+            count = 0
+            while count < len(lag.uplinkName):
+                for port in ports:
+                    if port.config.name == lag.uplinkName[count]:
+                        switch_uplink_ports[name].append(port.key)
+                        lag_uplinks.append(port.key)
+                count += 1
+
+        for port in ports:
+            if port.key in self.uplink_portgroup.portKeys and port.key not in lag_uplinks:
+                switch_uplink_ports['non_lag'].append(port.key)
+
+        count = 0
+        while count < len(self.vmnics):
+            self.desired_state[self.vmnics[count]] = switch_uplink_ports['non_lag'][count]
+            count += 1
+
+        for lag in self.lag_uplinks:
+            count = 0
+            while count < len(lag['vmnics']):
+                self.desired_state[lag['vmnics'][count]] = switch_uplink_ports[lag['lag']][count]
+                count += 1
+
     def check_uplinks(self):
         pnic_device = []
 
-        for dvs_host_member in self.dv_switch.config.host:
-            if dvs_host_member.config.host == self.host:
-                for pnicSpec in dvs_host_member.config.backing.pnicSpec:
-                    pnic_device.append(pnicSpec.pnicDevice)
+        self.set_desired_state()
 
-        return Counter(pnic_device) == Counter(self.vmnics)
+        for dvs_host_member in self.dv_switch.config.host:
+            if dvs_host_member.config.host.name == self.esxi_hostname:
+                break
+
+        for pnicSpec in dvs_host_member.config.backing.pnicSpec:
+            pnic_device.append(pnicSpec.pnicDevice)
+            if pnicSpec.pnicDevice not in self.desired_state:
+                return False
+            if pnicSpec.uplinkPortKey != self.desired_state[pnicSpec.pnicDevice]:
+                return False
+
+        for vmnic in self.desired_state:
+            if vmnic not in pnic_device:
+                return False
+
+        return True
 
     def check_dvs_host_state(self):
-        self.dv_switch = find_dvs_by_name(self.content, self.switch_name)
-
-        if self.dv_switch is None:
-            self.module.fail_json(msg="A distributed virtual switch %s "
-                                      "does not exist" % self.switch_name)
-
         self.uplink_portgroup = self.find_dvs_uplink_pg()
 
         if self.uplink_portgroup is None:

--- a/tests/integration/targets/vmware_dvs_host/tasks/main.yml
+++ b/tests/integration/targets/vmware_dvs_host/tasks/main.yml
@@ -17,7 +17,7 @@
       state: present
 
   - name: Create LAG
-    vmware_dvswitch:
+    vmware_dvswitch_lacp:
       switch: 'dvs_host_test_switch'
       support_mode: enhanced
       link_aggregation_groups:

--- a/tests/integration/targets/vmware_dvs_host/tasks/main.yml
+++ b/tests/integration/targets/vmware_dvs_host/tasks/main.yml
@@ -3,8 +3,8 @@
     name: prepare_vmware_tests
   vars:
     setup_attach_host: true
-- name: 'Attach the hosts to the DVSwitch without specifying any vnics (Issue #185)'
-  when: vcsim is not defined
+
+- when: vcsim is not defined
   block:
   - name: Create the DVSwitch
     vmware_dvswitch:
@@ -16,7 +16,16 @@
       discovery_operation: both
       state: present
 
-  - name: 'Attach the hosts to the DVSwitch without specifying any vnics'
+  - name: Create LAG
+    vmware_dvswitch:
+      switch: 'dvs_host_test_switch'
+      support_mode: enhanced
+      link_aggregation_groups:
+          - name: lag1
+            mode: active
+            uplink_number: 2
+
+  - name: 'Attach host to the DVSwitch without specifying any vmnics (Issue #185)'
     vmware_dvs_host:
       esxi_hostname: '{{ esxi1 }}'
       switch_name: 'dvs_host_test_switch'
@@ -26,9 +35,71 @@
       that:
         - host_dvs_attachment is changed
 
+  - name: 'Attach hosts to the DVSwitch without specifying any vmnics again (idempotency)'
+    vmware_dvs_host:
+      esxi_hostname: '{{ esxi1 }}'
+      switch_name: 'dvs_host_test_switch'
+      state: present
+    register: host_dvs_attachment_again
+  - assert:
+      that:
+        - host_dvs_attachment_again is not changed
+
+  - name: 'Add vmnic to uplink'
+    vmware_dvs_host:
+      esxi_hostname: '{{ esxi1 }}'
+      switch_name: 'dvs_host_test_switch'
+      vmnics:
+          - vmnic1
+      state: present
+    register: host_dvs_uplink
+  - assert:
+      that:
+        - host_dvs_uplink is changed
+
+  - name: 'Add vmnic to uplink again (idempotency)'
+    vmware_dvs_host:
+      esxi_hostname: '{{ esxi1 }}'
+      switch_name: 'dvs_host_test_switch'
+      vmnics:
+          - vmnic1
+      state: present
+    register: host_dvs_uplink_again
+  - assert:
+      that:
+        - host_dvs_uplink_again is not changed
+
+  - name: 'Add vmnic to LAG uplink'
+    vmware_dvs_host:
+      esxi_hostname: '{{ esxi1 }}'
+      switch_name: 'dvs_host_test_switch'
+      lag_uplinks:
+          - lag: lag1
+            vmnics:
+                - vmnic1
+      state: present
+    register: host_dvs_lag_uplink
+  - assert:
+      that:
+        - host_dvs_lag_uplink is changed
+
+  - name: 'Add vmnic to LAG uplink again (idempotency)'
+    vmware_dvs_host:
+      esxi_hostname: '{{ esxi1 }}'
+      switch_name: 'dvs_host_test_switch'
+      lag_uplinks:
+          - lag: lag1
+            vmnics:
+                - vmnic1
+      state: present
+    register: host_dvs_lag_uplink_again
+  - assert:
+      that:
+        - host_dvs_lag_uplink_again is not changed
+
 # Cleanup
   always:
-    - name: 'Cleanup: detaching hosts from dvs'
+    - name: 'Cleanup: detaching host from dvs'
       vmware_dvs_host:
         esxi_hostname: "{{ esxi1 }}"
         switch_name: 'dvs_host_test_switch'

--- a/tests/integration/targets/vmware_dvs_host/tasks/main.yml
+++ b/tests/integration/targets/vmware_dvs_host/tasks/main.yml
@@ -24,6 +24,7 @@
           - name: lag1
             mode: active
             uplink_number: 2
+            load_balancing_mode: srcDestIpTcpUdpPortVlan
 
   - name: 'Attach host to the DVSwitch without specifying any vmnics (Issue #185)'
     vmware_dvs_host:


### PR DESCRIPTION
##### SUMMARY
This change allows users to add pNICs to LAGs.

Fixes #112

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_dvs_host

##### ADDITIONAL INFORMATION
```
vmnic:
    - vmnic0
    - vmnic1
lag_uplinks:
    - lag: foo
      vmnic:
          - vmnic2
          - vmnic3
    - lag: bar
      vmnic:
          - vmnic4
          - vmnic5
```

I didn't find a way to directly add vmnics to LAGs when adding a host so I had to change the logic a bit: First add the host to the switch, then add the vmnics to the (LAG) uplink ports.