### PR TITLE
vmware_guest_instant_clone: Improve some features

### DIFF
--- a/changelogs/fragments/904-vmware_guest_instant_clone.yml
+++ b/changelogs/fragments/904-vmware_guest_instant_clone.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - vmware_guest_instant_clone - added a new option to wait until the vmware tools start (https://github.com/ansible-collections/community.vmware/pull/904).
+  - vmware_guest_instant_clone - added a reboot processing to reflect the customization parameters to an instant clone vm (https://github.com/ansible-collections/community.vmware/pull/904).

--- a/docs/community.vmware.vmware_guest_instant_clone_module.rst
+++ b/docs/community.vmware.vmware_guest_instant_clone_module.rst
@@ -490,6 +490,26 @@ Parameters
                         <div>Only required when using guest customization feature.</div>
                 </td>
             </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>wait_vm_tools</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.12.0</div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>no</li>
+                                    <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Whether waiting until vm tools start after rebooting an instant clone vm.</div>
+                </td>
+            </tr>
     </table>
     <br/>
 
@@ -626,9 +646,10 @@ Common return values are documented `here <https://docs.ansible.com/ansible/late
                 <td>always</td>
                 <td>
                             <div>metadata about the virtual machine</div>
+                            <div>added instance_uuid from version 1.12.0</div>
                     <br/>
                         <div style="font-size: smaller"><b>Sample:</b></div>
-                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{&#x27;vm_name&#x27;: &#x27;&#x27;, &#x27;vcenter&#x27;: &#x27;&#x27;, &#x27;host&#x27;: &#x27;&#x27;, &#x27;datastore&#x27;: &#x27;&#x27;, &#x27;vm_folder&#x27;: &#x27;&#x27;}</div>
+                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{&#x27;vm_name&#x27;: &#x27;&#x27;, &#x27;vcenter&#x27;: &#x27;&#x27;, &#x27;host&#x27;: &#x27;&#x27;, &#x27;datastore&#x27;: &#x27;&#x27;, &#x27;vm_folder&#x27;: &#x27;&#x27;, &#x27;instance_uuid&#x27;: &#x27;&#x27;}</div>
                 </td>
             </tr>
     </table>

--- a/docs/community.vmware.vmware_guest_instant_clone_module.rst
+++ b/docs/community.vmware.vmware_guest_instant_clone_module.rst
@@ -510,6 +510,23 @@ Parameters
                         <div>Whether waiting until vm tools start after rebooting an instant clone vm.</div>
                 </td>
             </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>wait_vm_tools_timeout</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.12.0</div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">300</div>
+                </td>
+                <td>
+                        <div>Define a timeout (in seconds) for <em>the wait_vm_tools</em> parameter.</div>
+                </td>
+            </tr>
     </table>
     <br/>
 

--- a/plugins/modules/vmware_guest_instant_clone.py
+++ b/plugins/modules/vmware_guest_instant_clone.py
@@ -138,6 +138,12 @@ options:
     type: bool
     default: True
     version_added: '1.12.0'
+  wait_vm_tools_timeout:
+    description:
+      - Define a timeout (in seconds) for I(the wait_vm_tools) parameter.
+    type: int
+    default: 300
+    version_added: '1.12.0'
 extends_documentation_fragment:
 - community.vmware.vmware.documentation
 
@@ -265,6 +271,8 @@ vm_info:
         "instance_uuid": ""
     }
 '''
+
+import time
 from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import AnsibleModule
 
@@ -308,6 +316,7 @@ class VmwareGuestInstantClone(PyVmomi):
         self.port = self.params.get('port')
         self.use_instance_uuid = self.params.get('use_instance_uuid')
         self.wait_vm_tools = self.params.get('wait_vm_tools')
+        self.wait_vm_tools_timeout = self.params.get('wait_vm_tools_timeout')
         self.guestinfo_vars = self.params.get('guestinfo_vars')
 
     def get_new_vm_info(self, vm):
@@ -393,15 +402,24 @@ class VmwareGuestInstantClone(PyVmomi):
             # Should require rebooting to reflect customization parameters to instant clone vm.
             instant_vm_obj = find_vm_by_id(content=self.content, vm_id=vm_info['instance_uuid'], vm_id_type='instance_uuid')
             set_vm_power_state(content=self.content, vm=instant_vm_obj, state='rebootguest', force=False)
+
             if self.wait_vm_tools:
+                interval = 15
                 # Wait vm tools is started after rebooting.
-                while True:
+                while self.wait_vm_tools_timeout > 0:
                     if instant_vm_obj.guest.toolsRunningStatus != 'guestToolsRunning':
                         break
+                    self.wait_vm_tools_timeout -= interval
+                    time.sleep(interval)
 
-                while True:
+                while self.wait_vm_tools_timeout > 0:
                     if instant_vm_obj.guest.toolsRunningStatus == 'guestToolsRunning':
                         break
+                    self.wait_vm_tools_timeout -= interval
+                    time.sleep(interval)
+
+                if self.wait_vm_tools_timeout <= 0:
+                    self.module.fail_json(msg="Timeout has been reached for waiting to start the vm tools.")
 
         return result
 
@@ -522,6 +540,7 @@ def main():
         resource_pool=dict(type='str', required=False),
         parent_vm=dict(type='str'),
         wait_vm_tools=dict(type='bool', default=True),
+        wait_vm_tools_timeout=dict(type='int', default=300),
         guestinfo_vars=dict(
             type='list',
             default=[],

--- a/plugins/modules/vmware_guest_instant_clone.py
+++ b/plugins/modules/vmware_guest_instant_clone.py
@@ -132,6 +132,12 @@ options:
     default: []
     type: list
     elements: dict
+  wait_vm_tools:
+    description:
+      - Whether waiting until vm tools start after rebooting an instant clone vm.
+    type: bool
+    default: True
+    version_added: '1.12.0'
 extends_documentation_fragment:
 - community.vmware.vmware.documentation
 
@@ -245,7 +251,9 @@ EXAMPLES = r'''
 
 RETURN = r'''
 vm_info:
-    description: metadata about the virtual machine
+    description:
+      - metadata about the virtual machine
+      - added instance_uuid from version 1.12.0
     returned: always
     type: dict
     sample: {
@@ -253,7 +261,8 @@ vm_info:
         "vcenter": "",
         "host": "",
         "datastore": "",
-        "vm_folder": ""
+        "vm_folder": "",
+        "instance_uuid": ""
     }
 '''
 from ansible.module_utils._text import to_native
@@ -268,6 +277,7 @@ from ansible_collections.community.vmware.plugins.module_utils.vmware import (
     vmware_argument_spec,
     find_obj,
     wait_for_task,
+    set_vm_power_state
 )
 
 try:
@@ -297,6 +307,7 @@ class VmwareGuestInstantClone(PyVmomi):
         self.uuid = self.params.get('uuid')
         self.port = self.params.get('port')
         self.use_instance_uuid = self.params.get('use_instance_uuid')
+        self.wait_vm_tools = self.params.get('wait_vm_tools')
         self.guestinfo_vars = self.params.get('guestinfo_vars')
 
     def get_new_vm_info(self, vm):
@@ -314,6 +325,7 @@ class VmwareGuestInstantClone(PyVmomi):
         info['host'] = vm_facts['hw_esxi_host']
         info['datastore'] = vm_facts['hw_datastores']
         info['vm_folder'] = vm_facts['hw_folder']
+        info['instance_uuid'] = vm_facts['instance_uuid']
         return info
 
     def Instant_clone(self):
@@ -321,8 +333,8 @@ class VmwareGuestInstantClone(PyVmomi):
         if self.vm_obj is None:
             vm_id = self.parent_vm or self.uuid or self.moid
             self.module.fail_json(msg="Failed to find the VM/template with %s" % vm_id)
-        task = self.vm_obj.InstantClone_Task(spec=self.instant_clone_spec)
         try:
+            task = self.vm_obj.InstantClone_Task(spec=self.instant_clone_spec)
             wait_for_task(task)
             vm_info = self.get_new_vm_info(self.vm_name)
             result = {'changed': True, 'failed': False, 'vm_info': vm_info}
@@ -370,13 +382,26 @@ class VmwareGuestInstantClone(PyVmomi):
 
             customization_spec.nicSettingMap.append(adapter_mapping_obj)
 
-            task_guest = guest_custom_mng.CustomizeGuest_Task(vm_IC, auth_obj, customization_spec)
             try:
+                task_guest = guest_custom_mng.CustomizeGuest_Task(vm_IC, auth_obj, customization_spec)
                 wait_for_task(task_guest)
                 vm_info = self.get_new_vm_info(self.vm_name)
                 result = {'changed': True, 'failed': False, 'vm_info': vm_info}
             except TaskError as task_e:
                 self.module.fail_json(msg=to_native(task_e))
+
+            # Should require rebooting to reflect customization parameters to instant clone vm.
+            instant_vm_obj = find_vm_by_id(content=self.content, vm_id=vm_info['instance_uuid'], vm_id_type='instance_uuid')
+            set_vm_power_state(content=self.content, vm=instant_vm_obj, state='rebootguest', force=False)
+            if self.wait_vm_tools:
+                # Wait vm tools is started after rebooting.
+                while True:
+                    if instant_vm_obj.guest.toolsRunningStatus != 'guestToolsRunning':
+                        break
+
+                while True:
+                    if instant_vm_obj.guest.toolsRunningStatus == 'guestToolsRunning':
+                        break
 
         return result
 
@@ -496,6 +521,7 @@ def main():
         folder=dict(type='str', required=False),
         resource_pool=dict(type='str', required=False),
         parent_vm=dict(type='str'),
+        wait_vm_tools=dict(type='bool', default=True),
         guestinfo_vars=dict(
             type='list',
             default=[],
@@ -519,6 +545,9 @@ def main():
         mutually_exclusive=[
             ['uuid', 'parent_vm', 'moid'],
         ],
+        required_together=[
+            ['vm_username', 'vm_password', 'guestinfo_vars']
+        ]
     )
     result = {'failed': False, 'changed': False}
 


### PR DESCRIPTION
##### SUMMARY

This PR will add the following points.

* Reboot an instant clone after making it.
    * Should require rebooting to reflect the customization parameters to the instant clone vm
* add a new option that is wait_vm_tools for checking reboot process complete
* add a new option that is wait_vm_tools_timeout
* Must require vm_username, vm_password, and guestinfo_vars if you are executed the customization, so I add required_together
* add instance_uuid to the return value

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

docs/community.vmware.vmware_guest_instant_clone_module.rst
plugins/modules/vmware_guest_instant_clone.py

##### ADDITIONAL INFORMATION

tested on vCenter/ESXi 7.0
