### PR TITLE
vmware_host_datastore_resize: Add a new module to resize the datastore

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Name | Description
 [community.vmware.vmware_host_config_manager](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_config_manager_module.rst)|Manage advanced system settings of an ESXi host
 [community.vmware.vmware_host_custom_attributes](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_custom_attributes_module.rst)|Manage custom attributes from VMware for the given ESXi host
 [community.vmware.vmware_host_datastore](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_datastore_module.rst)|Manage a datastore on ESXi host
+[community.vmware.vmware_host_datastore_resize](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_datastore_resize_module.rst)|Resize the datastore capacity
 [community.vmware.vmware_host_disk_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_disk_info_module.rst)|Gathers information about disks attached to given ESXi host/s.
 [community.vmware.vmware_host_dns](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_dns_module.rst)|Manage DNS configuration of an ESXi host system
 [community.vmware.vmware_host_dns_facts](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_host_dns_facts_module.rst)|Gathers facts about an ESXi host's DNS configuration information

--- a/changelogs/fragments/913-vmware_host_datastore_resize.yml
+++ b/changelogs/fragments/913-vmware_host_datastore_resize.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_host_datastore_resize - added a new module to resize the vmfs datastore (https://github.com/ansible-collections/community.vmware/pull/913).

--- a/docs/community.vmware.vmware_host_datastore_resize_module.rst
+++ b/docs/community.vmware.vmware_host_datastore_resize_module.rst
@@ -86,7 +86,7 @@ Parameters
                 </td>
                 <td>
                         <div>Expand the capacity base on existing datastore free capacity.</div>
-                        <div>If not free capacity, the datastore capacity can&#x27;t be expand.</div>
+                        <div>If not free capacity, the datastore capacity can&#x27;t be expanded.</div>
                 </td>
             </tr>
                                 <tr>

--- a/docs/community.vmware.vmware_host_datastore_resize_module.rst
+++ b/docs/community.vmware.vmware_host_datastore_resize_module.rst
@@ -1,0 +1,350 @@
+.. _community.vmware.vmware_host_datastore_resize_module:
+
+
+*********************************************
+community.vmware.vmware_host_datastore_resize
+*********************************************
+
+**Resize the vmfs datastore capacity**
+
+
+Version added: 1.12.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- This module can be resized the vmfs datastore capacity.
+
+
+
+Requirements
+------------
+The below requirements are needed on the host that executes this module.
+
+- python >= 3.6
+- PyVmomi
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="2">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+            <th width="100%">Comments</th>
+        </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>datastore</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Name of the datastore to resize a capacity.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>esxi_hostname</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Name of the host system to work with.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>expand</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">dictionary</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Expand the capacity base on existing datastore free capacity.</div>
+                        <div>If not free capacity, the datastore capacity can&#x27;t be expand.</div>
+                </td>
+            </tr>
+                                <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>partition_number</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">1</div>
+                </td>
+                <td>
+                        <div>A partition number you&#x27;d like to expand the partition.</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: partition</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>resize_gb</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The resize size of the datastore capacity.</div>
+                        <div>If you&#x27;d like to specify capacity size to expand, should be specified the integer in gigabyte size.</div>
+                        <div>If you&#x27;d like to expand using all free capacity, resize_gb set to <code>all</code>.</div>
+                        <div>The <em>resize_gb</em> can be specified only the value either <code>all</code> or integer.</div>
+                </td>
+            </tr>
+
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>hostname</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The hostname or IP address of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_HOST</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The password of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PASSWORD</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: pass, pwd</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">443</div>
+                </td>
+                <td>
+                        <div>The port number of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PORT</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>proxy_host</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Address of a proxy that will receive all HTTPS requests and relay them.</div>
+                        <div>The format is a hostname or a IP.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PROXY_HOST</code> will be used instead.</div>
+                        <div>This feature depends on a version of pyvmomi greater than v6.7.1.2018.12</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>proxy_port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Port of the HTTP proxy that will receive all HTTPS requests and relay them.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PROXY_PORT</code> will be used instead.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>username</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The username of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_USER</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: admin, user</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>validate_certs</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>no</li>
+                                    <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Allows connection when SSL certificates are not valid. Set to <code>false</code> when certificates are not trusted.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_VALIDATE_CERTS</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                        <div>If set to <code>true</code>, please make sure Python &gt;= 2.7.9 is installed on the given machine.</div>
+                </td>
+            </tr>
+    </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - Supports ``check_mode``.
+   - In VCSA and ESXi will be displayed slightly smaller capacity size than you specified the size. For example, if you specified 5GB to resize_gb, the capacity will be expanded 4.75GB in VCSA and ESXi host. This module can't compare correctly between to be expanded block size and the now capacity block size because a method doesn't find to get the accurate block size to expand. So, please cautions, If already expanded 4.75GB, an error will happen if you specified 5GB to resize because VCSA and ESXi recognize 5GB is 4.75GB.
+
+
+
+Examples
+--------
+
+.. code-block:: yaml
+
+    - name: Expand the partition number 1 in the datastore capacity up to 20GB
+      community.vmware.vmware_host_datastore_resize:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        esxi_hostname: "{{ esxi1 }}"
+        datastore: "{{ datastore }}"
+        expand:
+          partition_number: 1
+          resize_gb: 20
+
+    - name: Expand the partition number 1 in the datastore capacity using free all capacity up to
+      community.vmware.vmware_host_datastore_resize:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        esxi_hostname: "{{ esxi1 }}"
+        datastore: "{{ datastore }}"
+        expand:
+          partition_number: 1
+          resize_gb: all
+
+
+
+Return Values
+-------------
+Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>resized_datastore_info</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">dictionary</span>
+                    </div>
+                </td>
+                <td>changed</td>
+                <td>
+                            <div>dict of the resized datastore capacity information.</div>
+                    <br/>
+                        <div style="font-size: smaller"><b>Sample:</b></div>
+                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{
+        &quot;changed&quot;: true,
+        &quot;failed&quot;: false,
+        &quot;resized_datastore_info&quot;: {
+            &quot;capacity&quot;: 31943819264,
+            &quot;free_space&quot;: 30434918400,
+            &quot;name&quot;: &quot;DS1&quot;
+        }
+    }</div>
+                </td>
+            </tr>
+    </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- sky-joker (@sky-joker)

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -84,6 +84,7 @@ action_groups:
   - vmware_host_config_info
   - vmware_host_config_manager
   - vmware_host_datastore
+  - vmware_host_datastore_resize
   - vmware_host_disk_info
   - vmware_host_dns
   - vmware_host_dns_info

--- a/plugins/modules/vmware_host_datastore_resize.py
+++ b/plugins/modules/vmware_host_datastore_resize.py
@@ -108,11 +108,6 @@ resized_datastore_info:
     }
 """
 
-try:
-    from pyVmomi import vim
-except ImportError:
-    pass
-
 import math
 import re
 from ansible.module_utils._text import to_native

--- a/plugins/modules/vmware_host_datastore_resize.py
+++ b/plugins/modules/vmware_host_datastore_resize.py
@@ -1,0 +1,287 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2021, sky-joker
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r"""
+---
+module: vmware_host_datastore_resize
+short_description: Resize the vmfs datastore capacity
+author:
+  - sky-joker (@sky-joker)
+description:
+  - This module can be resized the vmfs datastore capacity.
+notes:
+  - Supports C(check_mode).
+  - In VCSA and ESXi will be displayed slightly smaller capacity size than you specified the size.
+    For example, if you specified 5GB to resize_gb, the capacity will be expanded 4.75GB in VCSA and ESXi host.
+    This module can't compare correctly between to be expanded block size and the now capacity block size
+    because a method doesn't find to get the accurate block size to expand.
+    So, please cautions, If already expanded 4.75GB, an error will happen if you specified 5GB to resize
+    because VCSA and ESXi recognize 5GB is 4.75GB.
+requirements:
+  - python >= 3.6
+  - PyVmomi
+version_added: '1.12.0'
+options:
+  esxi_hostname:
+    description:
+      - Name of the host system to work with.
+    type: str
+    required: True
+  datastore:
+    description:
+      - Name of the datastore to resize a capacity.
+    type: str
+    required: True
+  expand:
+    description:
+      - Expand the capacity base on existing datastore free capacity.
+      - If not free capacity, the datastore capacity can't be expand.
+    suboptions:
+      partition_number:
+        description:
+          - A partition number you'd like to expand the partition.
+        type: int
+        default: 1
+        aliases:
+          - partition
+      resize_gb:
+        description:
+          - The resize size of the datastore capacity.
+          - If you'd like to specify capacity size to expand, should be specified the integer in gigabyte size.
+          - If you'd like to expand using all free capacity, resize_gb set to C(all).
+          - The I(resize_gb) can be specified only the value either C(all) or integer.
+        type: str
+        required: True
+    type: dict
+    required: True
+extends_documentation_fragment:
+  - community.vmware.vmware.documentation
+"""
+
+EXAMPLES = r"""
+- name: Expand the partition number 1 in the datastore capacity up to 20GB
+  community.vmware.vmware_host_datastore_resize:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    datastore: "{{ datastore }}"
+    expand:
+      partition_number: 1
+      resize_gb: 20
+
+- name: Expand the partition number 1 in the datastore capacity using free all capacity up to
+  community.vmware.vmware_host_datastore_resize:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    datastore: "{{ datastore }}"
+    expand:
+      partition_number: 1
+      resize_gb: all
+"""
+
+RETURN = r"""
+resized_datastore_info:
+  description:
+    - dict of the resized datastore capacity information.
+  returned: changed
+  type: dict
+  sample: >-
+    {
+        "changed": true,
+        "failed": false,
+        "resized_datastore_info": {
+            "capacity": 31943819264,
+            "free_space": 30434918400,
+            "name": "DS1"
+        }
+    }
+"""
+
+try:
+    from pyVmomi import vim
+except ImportError:
+    pass
+
+import math
+import re
+from ansible.module_utils._text import to_native
+from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, vmware_argument_spec
+from ansible.module_utils.basic import AnsibleModule
+
+
+class VMwareHostDatastoreResize(PyVmomi):
+    def __init__(self, module):
+        super(VMwareHostDatastoreResize, self).__init__(module)
+        self.esxi_hostname = self.params['esxi_hostname']
+        self.datastore = self.params['datastore']
+        self.expand = self.params['expand']
+
+        if not re.match(r'all|[0-9]+', self.expand["resize_gb"]):
+            self.module.fail_json(msg="resize_gb can be specified only the value either all or int.")
+        if re.match(r'[0-9]+', self.expand["resize_gb"]):
+            self.expand["resize_gb"] = int(self.expand["resize_gb"])
+
+        self.host_obj = self.find_hostsystem_by_name(self.esxi_hostname)
+        if not self.host_obj:
+            self.module.fail_json(msg="Failed to find host system: %s" % self.esxi_hostname)
+
+        # Find attached datastore at host.
+        self.datastore_obj = None
+        for datastore in self.host_obj.datastore:
+            if datastore.name == self.datastore:
+                self.datastore_obj = datastore
+                break
+        if not self.datastore_obj:
+            self.module.fail_json(msg="Failed to find datastore: %s" % self.datastore)
+
+        if not hasattr(self.datastore_obj.info, "vmfs"):
+            self.module.fail_json(msg="The datastore isn't vmfs. this module can resize vmfs only.")
+
+        # Config Manager of hostsystem
+        self.cnf_mng = self.host_obj.configManager
+        self.result = dict(changed=False)
+
+    def get_expand_partition(self, vmfs_ds_options):
+        """
+        Get information that to expand the datastore capacity.
+
+        Args:
+            vmfs_ds_options (list): list of datastore partition.
+
+        Returns:
+            - expand_disk_info (dict): information to expand the datastore capacity.
+        """
+        expand_disk_info = {}
+        for vmfs_ds_option in vmfs_ds_options:
+            for partition in vmfs_ds_option.info.layout.partition:
+                if partition.partition == self.expand["partition_number"]:
+                    expand_disk_info.update({
+                        "vmfs_datastore_expand_spec": vmfs_ds_option.spec,
+                        "scsi_disk_partition": vmfs_ds_option.spec.extent,
+                        "disk_partition_block_range": partition
+                    })
+                    return expand_disk_info
+
+        return expand_disk_info
+
+    def expand_datastore(self, vmfs_datastore_expand_spec):
+        """
+        A datastore will be expanded.
+
+        Args:
+            vmfs_datastore_expand_spec (vim.host.VmfsDatastoreExpandSpec): data object to expand the datastore capacity.
+
+        Returns:
+            - resized_datastore (vim.Datastore): datastore managed object.
+        """
+        resized_datastore = None
+        try:
+            resized_datastore = self.cnf_mng.datastoreSystem.ExpandVmfsDatastore(datastore=self.datastore_obj,
+                                                                                 spec=vmfs_datastore_expand_spec)
+        except Exception as e:
+            # It seems that the resize_block_size changes to suitable value by internal processing in the ExpandVmfsDatastore.
+            # For example, if you specified 5GB to resize_gb, will be expanded 4.75GB in VCSA and ESXi host.
+            # This module can't compare correctly the datastore size(block size) before and after because I don't find a method
+            # to get the accurate block size to expand.
+            # So, if you specified the same value the existing datastore, I implemented this error will happen.
+            self.module.fail_json(msg="%s Maybe you specified the same capacity the existing datastore." % to_native(e.msg))
+
+        return resized_datastore
+
+    def generate_return_value(self, resized_datastore):
+        """
+        Generate information of the resized datastore capacity.
+
+        Args:
+            resized_datastore (vim.Datastore): resized datastore managed object.
+
+        Returns:
+            - resized_datastore_info (dict): summarized the resized datastore information.
+        """
+        resized_datastore_info = {
+            "name": resized_datastore.summary.name,
+            "capacity": resized_datastore.summary.capacity,
+            "free_space": resized_datastore.summary.freeSpace
+        }
+
+        return resized_datastore_info
+
+    def execute(self):
+        if self.module.check_mode:
+            self.result["changed"] = True
+            self.module.exit_json(**self.result)
+
+        if self.expand:
+            vmfs_ds_options = self.cnf_mng.datastoreSystem.QueryVmfsDatastoreExpandOptions(self.datastore_obj)
+
+            # If not found vmfs_ds_options, the partition doesn't exist that can expand.
+            if not vmfs_ds_options and self.expand["resize_gb"] == "all":
+                # If resize_gb is all, it will normal termination when already expanded the datastore to full.
+                self.module.exit_json(**self.result)
+            elif not vmfs_ds_options and self.expand["resize_gb"] != "all":
+                self.module.fail_json(msg="Failed to find the partition can expand.")
+
+            expand_disk_info = self.get_expand_partition(vmfs_ds_options)
+            if not expand_disk_info:
+                self.module.fail_json(msg="Failed to find the partition number: %s" % self.expand["partition_number"])
+
+            if self.expand['resize_gb'] != "all":
+                block_size = expand_disk_info["disk_partition_block_range"].end.blockSize
+                total_block_size = expand_disk_info["disk_partition_block_range"].end.block
+                capacity_block_size = math.floor(self.datastore_obj.info.vmfs.capacity / block_size)
+                resize_block_size = math.floor(self.expand["resize_gb"] * block_size / 1024)
+
+                if total_block_size > resize_block_size and capacity_block_size < resize_block_size:
+                    disk_partition_block_range = expand_disk_info["disk_partition_block_range"]
+                    disk_partition_block_range.end.block = resize_block_size
+                    host_disk_partition_info = self.cnf_mng.storageSystem.ComputeDiskPartitionInfoForResize(expand_disk_info["scsi_disk_partition"],
+                                                                                                            disk_partition_block_range)
+
+                    vmfs_datastore_expand_spec = expand_disk_info["vmfs_datastore_expand_spec"]
+                    vmfs_datastore_expand_spec.partition = host_disk_partition_info.spec
+                    resized_datastore = self.expand_datastore(vmfs_datastore_expand_spec)
+                else:
+                    self.module.fail_json(msg="The specified the value can't expand in existing datastore: %s" % self.expand["resize_gb"])
+            else:
+                vmfs_datastore_expand_spec = expand_disk_info["vmfs_datastore_expand_spec"]
+                resized_datastore = self.expand_datastore(vmfs_datastore_expand_spec)
+
+            if resized_datastore:
+                self.result["changed"] = True
+                self.result["resized_datastore_info"] = self.generate_return_value(resized_datastore)
+
+            self.module.exit_json(**self.result)
+
+
+def main():
+    argument_spec = vmware_argument_spec()
+    argument_spec.update(
+        esxi_hostname=dict(type='str', required=True),
+        datastore=dict(type='str', required=True),
+        expand=dict(type='dict',
+                    required=True,
+                    options=dict(
+                        partition_number=dict(type='int', default=1, aliases=['partition']),
+                        resize_gb=dict(type='str', required=True)
+                    )),
+    )
+
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+
+    vmware_host_datastore_resize = VMwareHostDatastoreResize(module)
+    vmware_host_datastore_resize.execute()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/vmware_host_datastore_resize.py
+++ b/plugins/modules/vmware_host_datastore_resize.py
@@ -41,7 +41,7 @@ options:
   expand:
     description:
       - Expand the capacity base on existing datastore free capacity.
-      - If not free capacity, the datastore capacity can't be expand.
+      - If not free capacity, the datastore capacity can't be expanded.
     suboptions:
       partition_number:
         description:

--- a/plugins/modules/vmware_host_datastore_resize.py
+++ b/plugins/modules/vmware_host_datastore_resize.py
@@ -247,7 +247,7 @@ class VMwareHostDatastoreResize(PyVmomi):
                     vmfs_datastore_expand_spec.partition = host_disk_partition_info.spec
                     resized_datastore = self.expand_datastore(vmfs_datastore_expand_spec)
                 else:
-                    self.module.fail_json(msg="The specified the value can't expand in existing datastore: %s" % self.expand["resize_gb"])
+                    self.module.fail_json(msg="The specified value can't expand in the existing datastore: %s" % self.expand["resize_gb"])
             else:
                 vmfs_datastore_expand_spec = expand_disk_info["vmfs_datastore_expand_spec"]
                 resized_datastore = self.expand_datastore(vmfs_datastore_expand_spec)

--- a/tests/integration/targets/vmware_host_datastore_resize/aliases
+++ b/tests/integration/targets/vmware_host_datastore_resize/aliases
@@ -1,0 +1,3 @@
+cloud/vcenter
+needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_host_datastore_resize/tasks/main.yml
+++ b/tests/integration/targets/vmware_host_datastore_resize/tasks/main.yml
@@ -1,0 +1,63 @@
+# Test code for the vmware_host_datastore_resize module.
+# Copyright: (c) 2021, sky-joker <sky.jokerxx@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_attach_host: true
+
+- name: Expand the partition number 1 in the datastore capacity using free all capacity up to with check_mode
+  community.vmware.vmware_host_datastore_resize:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    datastore: "{{ rw_datastore }}"
+    expand:
+      partition_number: 1
+      resize_gb: all
+  check_mode: true
+  register: resized_datastore_info_check_mode
+
+- name: Make sure if change has been occurred with check_mode
+  assert:
+    that:
+      - resized_datastore_info_check_mode.changed is sameas true
+
+- name: Expand the partition number 1 in the datastore capacity using free all capacity up to
+  community.vmware.vmware_host_datastore_resize:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    datastore: "{{ rw_datastore }}"
+    expand:
+      partition_number: 1
+      resize_gb: all
+  register: resized_datastore_info
+
+- name: Make sure if change hasn't been occurred(Maybe CI environment hasn’t the free capacity to resize)
+  assert:
+    that:
+      - resized_datastore_info.changed is sameas false
+
+- name: Expand the partition number 1 in the datastore capacity using free all capacity up to (idempotency)
+  community.vmware.vmware_host_datastore_resize:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    datastore: "{{ rw_datastore }}"
+    expand:
+      partition_number: 1
+      resize_gb: all
+  register: resized_datastore_info_idempotency
+
+- name: Make sure if change has been occurred
+  assert:
+    that:
+      - resized_datastore_info_idempotency.changed is sameas false

--- a/tests/integration/targets/vmware_host_datastore_resize/tasks/main.yml
+++ b/tests/integration/targets/vmware_host_datastore_resize/tasks/main.yml
@@ -39,7 +39,7 @@
       resize_gb: all
   register: resized_datastore_info
 
-- name: Make sure if change hasn't been occurred(Maybe CI environment hasn’t the free capacity to resize)
+- name: Make sure if change hasn't been occurred(Maybe CI environment hasn't the free capacity to resize)
   assert:
     that:
       - resized_datastore_info.changed is sameas false

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -220,6 +220,8 @@ plugins/modules/vmware_host_custom_attributes.py compile-2.6!skip
 plugins/modules/vmware_host_custom_attributes.py import-2.6!skip
 plugins/modules/vmware_host_datastore.py compile-2.6!skip
 plugins/modules/vmware_host_datastore.py import-2.6!skip
+plugins/modules/vmware_host_datastore_resize.py compile-2.6!skip
+plugins/modules/vmware_host_datastore_resize.py import-2.6!skip
 plugins/modules/vmware_host_disk_info.py compile-2.6!skip
 plugins/modules/vmware_host_disk_info.py import-2.6!skip
 plugins/modules/vmware_host_dns_facts.py compile-2.6!skip

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -230,6 +230,8 @@ plugins/modules/vmware_host_custom_attributes.py compile-2.6!skip
 plugins/modules/vmware_host_custom_attributes.py import-2.6!skip
 plugins/modules/vmware_host_datastore.py compile-2.6!skip
 plugins/modules/vmware_host_datastore.py import-2.6!skip
+plugins/modules/vmware_host_datastore_resize.py compile-2.6!skip
+plugins/modules/vmware_host_datastore_resize.py import-2.6!skip
 plugins/modules/vmware_host_disk_info.py compile-2.6!skip
 plugins/modules/vmware_host_disk_info.py import-2.6!skip
 plugins/modules/vmware_host_dns_facts.py compile-2.6!skip

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -201,6 +201,8 @@ plugins/modules/vmware_host_custom_attributes.py compile-2.6!skip
 plugins/modules/vmware_host_custom_attributes.py import-2.6!skip
 plugins/modules/vmware_host_datastore.py compile-2.6!skip
 plugins/modules/vmware_host_datastore.py import-2.6!skip
+plugins/modules/vmware_host_datastore_resize.py compile-2.6!skip
+plugins/modules/vmware_host_datastore_resize.py import-2.6!skip
 plugins/modules/vmware_host_disk_info.py compile-2.6!skip
 plugins/modules/vmware_host_disk_info.py import-2.6!skip
 plugins/modules/vmware_host_dns_facts.py compile-2.6!skip

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -248,6 +248,8 @@ plugins/modules/vmware_host_custom_attributes.py compile-2.6!skip
 plugins/modules/vmware_host_custom_attributes.py import-2.6!skip
 plugins/modules/vmware_host_datastore.py compile-2.6!skip
 plugins/modules/vmware_host_datastore.py import-2.6!skip
+plugins/modules/vmware_host_datastore_resize.py compile-2.6!skip
+plugins/modules/vmware_host_datastore_resize.py import-2.6!skip
 plugins/modules/vmware_host_disk_info.py compile-2.6!skip
 plugins/modules/vmware_host_disk_info.py import-2.6!skip
 plugins/modules/vmware_host_dns_facts.py compile-2.6!skip


### PR DESCRIPTION
##### SUMMARY

This PR will add a new module to resize the datastore.  
There are two how to resize the following.

* [ExpandVmfsDatastore](https://vdc-download.vmware.com/vmwb-repository/dcr-public/b50dcbbf-051d-4204-a3e7-e1b618c1e384/538cf2ec-b34f-4bae-a332-3820ef9e7773/vim.host.DatastoreSystem.html#expandVmfsDatastore)
* [ExtendVmfsDatastore](https://vdc-download.vmware.com/vmwb-repository/dcr-public/b50dcbbf-051d-4204-a3e7-e1b618c1e384/538cf2ec-b34f-4bae-a332-3820ef9e7773/vim.host.DatastoreSystem.html#extendVmfsDatastore)

But, I haven’t been implementing ExtendVmfsDatastore yet because I couldn't prepare the environment to test.  
So, first, I'll make a PR that implemented only ExpandVmfsDatasotre.  
I'll also implement ExtendVmfsDatastore in the future.

fixes: https://github.com/ansible-collections/community.vmware/issues/910

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

README.md
changelogs/fragments/913-vmware_host_datastore_resize.yml
docs/community.vmware.vmware_host_datastore_resize_module.rst
meta/runtime.yml
plugins/modules/vmware_host_datastore_resize.py
tests/integration/targets/vmware_host_datastore_resize/aliases
tests/integration/targets/vmware_host_datastore_resize/tasks/main.yml
tests/sanity/ignore-2.9.txt
tests/sanity/ignore-2.10.txt
tests/sanity/ignore-2.11.txt
tests/sanity/ignore-2.12.txt

##### ADDITIONAL INFORMATION

tested on vCenter/ESXi 7.0.2