### PR TITLE
vmware_host_datastore: Add a new parameter to expand a datastore capacity

### DIFF
--- a/changelogs/fragments/915-vmware_host_datastore.yml
+++ b/changelogs/fragments/915-vmware_host_datastore.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_host_datastore - added a new parameter to expand a datastore capacity (https://github.com/ansible-collections/community.vmware/pull/915).

--- a/docs/community.vmware.vmware_host_datastore_module.rst
+++ b/docs/community.vmware.vmware_host_datastore_module.rst
@@ -45,6 +45,28 @@ Parameters
             <tr>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>auto_expand</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.12.0</div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>no</li>
+                                    <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Expand a datastore capacity to full if it has free capacity.</div>
+                        <div>This parameter can&#x27;t be extend using another datastore.</div>
+                        <div>A use case example in <em>auto_expand</em>, it can be used to expand a datastore capacity after increasing LUN volume.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>datastore_name</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">

--- a/docs/community.vmware.vmware_host_datastore_module.rst
+++ b/docs/community.vmware.vmware_host_datastore_module.rst
@@ -50,7 +50,7 @@ Parameters
                     <div style="font-size: small">
                         <span style="color: purple">boolean</span>
                     </div>
-                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.12.0</div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.13.0</div>
                 </td>
                 <td>
                         <ul style="margin: 0; padding: 0"><b>Choices:</b>

--- a/plugins/modules/vmware_host_datastore.py
+++ b/plugins/modules/vmware_host_datastore.py
@@ -219,11 +219,12 @@ class VMwareHostDatastore(PyVmomi):
         # Check that whether the datastore has free capacity to expand.
         vmfs_ds_options = cnf_mng.datastoreSystem.QueryVmfsDatastoreExpandOptions(expand_datastore_obj)
         if vmfs_ds_options:
-            try:
-                cnf_mng.datastoreSystem.ExpandVmfsDatastore(datastore=expand_datastore_obj,
-                                                            spec=vmfs_ds_options[0].spec)
-            except Exception as e:
-                self.module.fail_json(msg="%s can not expand the datastore: %s" % (to_native(e.msg), self.datastore_name))
+            if self.module.check_mode is False:
+                try:
+                    cnf_mng.datastoreSystem.ExpandVmfsDatastore(datastore=expand_datastore_obj,
+                                                                spec=vmfs_ds_options[0].spec)
+                except Exception as e:
+                    self.module.fail_json(msg="%s can not expand the datastore: %s" % (to_native(e.msg), self.datastore_name))
 
             self.module.exit_json(changed=True)
 

--- a/plugins/modules/vmware_host_datastore.py
+++ b/plugins/modules/vmware_host_datastore.py
@@ -78,7 +78,7 @@ options:
     - A use case example in I(auto_expand), it can be used to expand a datastore capacity after increasing LUN volume.
     type: bool
     default: True
-    version_added: '1.12.0'
+    version_added: '1.13.0'
   state:
     description:
     - "present: Mount datastore on host if datastore is absent else do nothing."

--- a/plugins/modules/vmware_host_datastore.py
+++ b/plugins/modules/vmware_host_datastore.py
@@ -71,6 +71,14 @@ options:
     - Required when used with a vcenter
     type: str
     required: false
+  auto_expand:
+    description:
+    - Expand a datastore capacity to full if it has free capacity.
+    - This parameter can't be extend using another datastore.
+    - A use case example in I(auto_expand), it can be used to expand a datastore capacity after increasing LUN volume.
+    type: bool
+    default: True
+    version_added: '1.12.0'
   state:
     description:
     - "present: Mount datastore on host if datastore is absent else do nothing."
@@ -166,6 +174,7 @@ class VMwareHostDatastore(PyVmomi):
         self.vmfs_device_name = module.params['vmfs_device_name']
         self.vmfs_version = module.params['vmfs_version']
         self.esxi_hostname = module.params['esxi_hostname']
+        self.auto_expand = module.params['auto_expand']
         self.state = module.params['state']
 
         if self.is_vcenter():
@@ -195,6 +204,29 @@ class VMwareHostDatastore(PyVmomi):
         except Exception as e:
             self.module.fail_json(msg=to_native(e))
 
+    def expand_datastore_to_full(self):
+        """
+        Expand a datastore capacity to full if there is free capacity.
+        """
+        cnf_mng = self.esxi.configManager
+
+        # Find attached datastore at host.
+        for datastore_obj in self.esxi.datastore:
+            if datastore_obj.name == self.datastore_name:
+                expand_datastore_obj = datastore_obj
+                break
+
+        # Check that whether the datastore has free capacity to expand.
+        vmfs_ds_options = cnf_mng.datastoreSystem.QueryVmfsDatastoreExpandOptions(expand_datastore_obj)
+        if vmfs_ds_options:
+            try:
+                cnf_mng.datastoreSystem.ExpandVmfsDatastore(datastore=expand_datastore_obj,
+                                                            spec=vmfs_ds_options[0].spec)
+            except Exception as e:
+                self.module.fail_json(msg="%s can not expand the datastore: %s" % (to_native(e.msg), self.datastore_name))
+
+            self.module.exit_json(changed=True)
+
     def state_exit_unchanged(self):
         self.module.exit_json(changed=False)
 
@@ -203,6 +235,8 @@ class VMwareHostDatastore(PyVmomi):
         host_file_sys_vol_mount_info = storage_system.fileSystemVolumeInfo.mountInfo
         for host_mount_info in host_file_sys_vol_mount_info:
             if host_mount_info.volume.name == self.datastore_name:
+                if self.auto_expand and host_mount_info.volume.type == "VMFS":
+                    self.expand_datastore_to_full()
                 return 'present'
         return 'absent'
 
@@ -304,6 +338,7 @@ def main():
         vmfs_device_name=dict(type='str'),
         vmfs_version=dict(type='int'),
         esxi_hostname=dict(type='str', required=False),
+        auto_expand=dict(type='bool', default=True),
         state=dict(type='str', default='present', choices=['absent', 'present'])
     )
 

--- a/plugins/modules/vmware_host_datastore.py
+++ b/plugins/modules/vmware_host_datastore.py
@@ -206,7 +206,7 @@ class VMwareHostDatastore(PyVmomi):
 
     def expand_datastore_to_full(self):
         """
-        Expand a datastore capacity to full if there is free capacity.
+        Expand a datastore capacity up to full if there is free capacity.
         """
         cnf_mng = self.esxi.configManager
 

--- a/plugins/modules/vmware_host_datastore.py
+++ b/plugins/modules/vmware_host_datastore.py
@@ -204,7 +204,7 @@ class VMwareHostDatastore(PyVmomi):
         except Exception as e:
             self.module.fail_json(msg=to_native(e))
 
-    def expand_datastore_to_full(self):
+    def expand_datastore_up_to_full(self):
         """
         Expand a datastore capacity up to full if there is free capacity.
         """
@@ -236,7 +236,7 @@ class VMwareHostDatastore(PyVmomi):
         for host_mount_info in host_file_sys_vol_mount_info:
             if host_mount_info.volume.name == self.datastore_name:
                 if self.auto_expand and host_mount_info.volume.type == "VMFS":
-                    self.expand_datastore_to_full()
+                    self.expand_datastore_up_to_full()
                 return 'present'
         return 'absent'
 


### PR DESCRIPTION
##### SUMMARY

This PR will add a new option to expand a datastore capacity.  
For example, I think it is a useful parameter in expanding a datastore capacity after increasing LUN capacity with a new enclosure and so on.  

Alternative PR from: https://github.com/ansible-collections/community.vmware/pull/913

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

changelogs/fragments/915-vmware_host_datastore.yml
docs/community.vmware.vmware_host_datastore_module.rst
plugins/modules/vmware_host_datastore.py

##### ADDITIONAL INFORMATION

tested on vCenter/ESXi 7.0.2