### PR TITLE
vmware_guest_powerstate: Fix an error that the datacenter key error has been occurring

### DIFF
--- a/changelogs/fragments/924-vmware_guest_powerstate.yml
+++ b/changelogs/fragments/924-vmware_guest_powerstate.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_guest_powerstate - added the datacenter parameter to fix an issue that datacenter key error has been occurring (https://github.com/ansible-collections/community.vmware/pull/924).

--- a/docs/community.vmware.vmware_guest_powerstate_module.rst
+++ b/docs/community.vmware.vmware_guest_powerstate_module.rst
@@ -96,6 +96,24 @@ Parameters
             <tr>
                 <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>datacenter</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.12.0</div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">"ha-datacenter"</div>
+                </td>
+                <td>
+                        <div>The <em>datacenter</em> where the VM you&#x27;d like to operate the power.</div>
+                        <div>This parameter is case sensitive.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>folder</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">

--- a/docs/community.vmware.vmware_guest_powerstate_module.rst
+++ b/docs/community.vmware.vmware_guest_powerstate_module.rst
@@ -101,7 +101,7 @@ Parameters
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
                     </div>
-                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.12.0</div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.13.0</div>
                 </td>
                 <td>
                         <b>Default:</b><br/><div style="color: blue">"ha-datacenter"</div>

--- a/plugins/modules/vmware_guest_powerstate.py
+++ b/plugins/modules/vmware_guest_powerstate.py
@@ -20,6 +20,13 @@ requirements:
 - python >= 2.6
 - PyVmomi
 options:
+  datacenter:
+    description:
+      - The I(datacenter) where the VM you'd like to operate the power.
+      - This parameter is case sensitive.
+    default: ha-datacenter
+    type: str
+    version_added: '1.12.0'
   state:
     description:
     - Set the state of the virtual machine.
@@ -220,6 +227,7 @@ from ansible.module_utils._text import to_native
 def main():
     argument_spec = vmware_argument_spec()
     argument_spec.update(
+        datacenter=dict(type='str', default='ha-datacenter'),
         state=dict(type='str', default='present',
                    choices=['present', 'powered-off', 'powered-on', 'reboot-guest', 'restarted', 'shutdown-guest', 'suspended']),
         name=dict(type='str'),

--- a/plugins/modules/vmware_guest_powerstate.py
+++ b/plugins/modules/vmware_guest_powerstate.py
@@ -26,7 +26,7 @@ options:
       - This parameter is case sensitive.
     default: ha-datacenter
     type: str
-    version_added: '1.12.0'
+    version_added: '1.13.0'
   state:
     description:
     - Set the state of the virtual machine.

--- a/tests/integration/targets/vmware_guest_powerstate/tasks/main.yml
+++ b/tests/integration/targets/vmware_guest_powerstate/tasks/main.yml
@@ -9,7 +9,7 @@
     setup_datastore: true
 
 - name: Create a VM with the state poweredoff
-  vmware_guest:
+  community.vmware.vmware_guest:
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
@@ -34,7 +34,7 @@
     - name: VM Network
 
 - name: set state to poweroff the first VM
-  vmware_guest_powerstate:
+  community.vmware.vmware_guest_powerstate:
     validate_certs: false
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
@@ -52,10 +52,27 @@
     that:
         - not (poweroff_d1_c1_f0 is changed)
 
+- name: set state to poweroff the first VM with datacenter
+  community.vmware.vmware_guest_powerstate:
+    validate_certs: false
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter: "{{ dc1 }}"
+    name: test_vm1
+    folder: '{{ f0 }}'
+    state: powered-off
+  register: poweroff_d1_c1_f0_datacenter
+
+- name: make sure change was made
+  assert:
+    that:
+        - not (poweroff_d1_c1_f0_datacenter is changed)
+
 - when: vcsim is not defined
   block:
   - name: Set a schedule task for first VM
-    vmware_guest_powerstate:
+    community.vmware.vmware_guest_powerstate:
       validate_certs: false
       hostname: "{{ vcenter_hostname }}"
       username: "{{ vcenter_username }}"


### PR DESCRIPTION
Depends-on https://github.com/ansible-collections/community.vmware/pull/945

##### SUMMARY

vmware_guest_powerstate module has a bug that datacenter key error has been occurring if the same VM name is detected in VCSA.  
The datacenter parameter should be required in the get_vm method if the same VM name is detected.  
https://github.com/ansible-collections/community.vmware/blob/main/plugins/module_utils/vmware.py#L1208-L1221

So, this PR will add the datacenter parameter to the module to fix the bug.

fixes: https://github.com/ansible-collections/community.vmware/issues/921

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

changelogs/fragments/924-vmware_guest_powerstate.yml
docs/community.vmware.vmware_guest_powerstate_module.rst
plugins/modules/vmware_guest_powerstate.py
tests/integration/targets/vmware_guest_powerstate/tasks/main.yml

##### ADDITIONAL INFORMATION

tested on vCenter/ESXi 7.0