### PR TITLE
Refactor vmware guest controller

### DIFF
--- a/plugins/module_utils/vm_device_helper.py
+++ b/plugins/module_utils/vm_device_helper.py
@@ -40,16 +40,17 @@ class PyVmomiDeviceHelper(object):
         self.sata_device_type = vim.vm.device.VirtualAHCIController
         self.nvme_device_type = vim.vm.device.VirtualNVMEController
         self.usb_device_type = {
-                'usb2': vim.vm.device.VirtualUSBController,
-                'usb3': vim.vm.device.VirtualUSBXHCIController,
+            'usb2': vim.vm.device.VirtualUSBController,
+            'usb3': vim.vm.device.VirtualUSBXHCIController,
         }
 
-    def create_scsi_controller(self, scsi_type, bus_number):
+    def create_scsi_controller(self, scsi_type, bus_number, bus_sharing='noSharing'):
         """
         Create SCSI Controller with given SCSI Type and SCSI Bus Number
         Args:
             scsi_type: Type of SCSI
             scsi_bus_number: SCSI Bus number to be assigned
+            bus_sharing: noSharing, virtualSharing, physicalSharing
 
         Returns: Virtual device spec for SCSI Controller
 
@@ -64,7 +65,7 @@ class PyVmomiDeviceHelper(object):
         # should be unique negative integers
         scsi_ctl.device.key = -randint(1000, 9999)
         scsi_ctl.device.hotAddRemove = True
-        scsi_ctl.device.sharedBus = 'noSharing'
+        scsi_ctl.device.sharedBus = bus_sharing
         scsi_ctl.device.scsiCtlrUnitNumber = 7
 
         return scsi_ctl
@@ -102,10 +103,10 @@ class PyVmomiDeviceHelper(object):
     def is_nvme_controller(device):
         return isinstance(device, vim.vm.device.VirtualNVMEController)
 
-    def create_disk_controller(self, ctl_type, ctl_number):
+    def create_disk_controller(self, ctl_type, ctl_number, bus_sharing='noSharing'):
         disk_ctl = None
-        if ctl_type in ['buslogic', 'paravirtual', 'lsilogic', 'lsilogicsas']:
-            disk_ctl = self.create_scsi_controller(ctl_type, ctl_number)
+        if ctl_type in self.scsi_device_typekeys():
+            disk_ctl = self.create_scsi_controller(ctl_type, ctl_number, bus_sharing)
         if ctl_type == 'sata':
             disk_ctl = self.create_sata_controller(ctl_number)
         if ctl_type == 'nvme':

--- a/plugins/module_utils/vm_device_helper.py
+++ b/plugins/module_utils/vm_device_helper.py
@@ -37,6 +37,12 @@ class PyVmomiDeviceHelper(object):
             'buslogic': vim.vm.device.VirtualBusLogicController,
             'lsilogicsas': vim.vm.device.VirtualLsiLogicSASController,
         }
+        self.sata_device_type = vim.vm.device.VirtualAHCIController
+        self.nvme_device_type = vim.vm.device.VirtualNVMEController
+        self.usb_device_type = {
+                'usb2': vim.vm.device.VirtualUSBController,
+                'usb3': vim.vm.device.VirtualUSBXHCIController,
+        }
 
     def create_scsi_controller(self, scsi_type, bus_number):
         """

--- a/plugins/module_utils/vm_device_helper.py
+++ b/plugins/module_utils/vm_device_helper.py
@@ -105,7 +105,7 @@ class PyVmomiDeviceHelper(object):
 
     def create_disk_controller(self, ctl_type, ctl_number, bus_sharing='noSharing'):
         disk_ctl = None
-        if ctl_type in self.scsi_device_typekeys():
+        if ctl_type in self.scsi_device_type.keys():
             disk_ctl = self.create_scsi_controller(ctl_type, ctl_number, bus_sharing)
         if ctl_type == 'sata':
             disk_ctl = self.create_sata_controller(ctl_number)

--- a/plugins/modules/vmware_guest_controller.py
+++ b/plugins/modules/vmware_guest_controller.py
@@ -248,7 +248,6 @@ try:
 except ImportError:
     pass
 
-from random import randint
 import time
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
@@ -318,29 +317,20 @@ class PyVmomiHelper(PyVmomi):
 
         Return: Virtual device spec for virtual controller
         """
-        disk_ctl = vim.vm.device.VirtualDeviceSpec()
-        disk_ctl.operation = vim.vm.device.VirtualDeviceSpec.Operation.add
-        if ctl_type == 'sata':
-            disk_ctl.device = self.device_helper.sata_device_type()
-            disk_ctl.device.key = -randint(15000, 19999)
-        elif ctl_type == 'nvme':
-            disk_ctl.device = self.device_helper.nvme_device_type()
-            disk_ctl.device.key = -randint(31000, 39999)
-        elif ctl_type in self.device_helper.scsi_device_type.keys():
-            disk_ctl.device = self.device_helper.scsi_device_type.get(ctl_type)()
-            disk_ctl.device.key = -randint(1000, 6999)
-            disk_ctl.device.hotAddRemove = True
-            disk_ctl.device.sharedBus = bus_sharing
-            disk_ctl.device.scsiCtlrUnitNumber = 7
+        if ctl_type == 'sata' or ctl_type == 'nvme' or ctl_type in self.device_helper.scsi_device_type.keys():
+            disk_ctl = self.device_helper.create_disk_controller(ctl_type, bus_number, bus_sharing)
         elif ctl_type in self.device_helper.usb_device_type.keys():
+            disk_ctl = vim.vm.device.VirtualDeviceSpec()
+            disk_ctl.operation = vim.vm.device.VirtualDeviceSpec.Operation.add
             disk_ctl.device = self.device_helper.usb_device_type.get(ctl_type)()
+
             if ctl_type == 'usb2':
                 disk_ctl.device.key = 7000
             elif ctl_type == 'usb3':
                 disk_ctl.device.key = 14000
 
-        disk_ctl.device.deviceInfo = vim.Description()
-        disk_ctl.device.busNumber = bus_number
+            disk_ctl.device.deviceInfo = vim.Description()
+            disk_ctl.device.busNumber = bus_number
 
         return disk_ctl
 

--- a/plugins/modules/vmware_guest_controller.py
+++ b/plugins/modules/vmware_guest_controller.py
@@ -260,10 +260,9 @@ class PyVmomiHelper(PyVmomi):
         super(PyVmomiHelper, self).__init__(module)
         self.device_helper = PyVmomiDeviceHelper(self.module)
         self.sleep_time = 10
-        self.controller_types = dict(self.device_helper.scsi_device_type,
-                                     self.device_helper.usb_device_type,
-                                     sata=self.device_helper.sata_device_type,
-                                     nvme=self.device_helper.nvme_device_type)
+        self.controller_types = self.device_helper.scsi_device_type.copy()
+        self.controller_types.update(self.device_helper.usb_device_type)
+        self.controller_types.update({'sata': self.device_helper.sata_device_type, 'nvme': self.device_helper.nvme_device_type})
         self.config_spec = vim.vm.ConfigSpec()
         self.config_spec.deviceChange = []
         self.change_detected = False

--- a/plugins/modules/vmware_guest_controller.py
+++ b/plugins/modules/vmware_guest_controller.py
@@ -261,12 +261,10 @@ class PyVmomiHelper(PyVmomi):
         super(PyVmomiHelper, self).__init__(module)
         self.device_helper = PyVmomiDeviceHelper(self.module)
         self.sleep_time = 10
-        self.sata_device_type = vim.vm.device.VirtualAHCIController
-        self.nvme_device_type = vim.vm.device.VirtualNVMEController
-        self.usb_device_type = dict(usb2=vim.vm.device.VirtualUSBController,
-                                    usb3=vim.vm.device.VirtualUSBXHCIController)
-        self.controller_types = dict(self.device_helper.scsi_device_type, sata=self.sata_device_type, nvme=self.nvme_device_type)
-        self.controller_types.update(self.usb_device_type)
+        self.controller_types = dict(self.device_helper.scsi_device_type,
+                                     self.device_helper.usb_device_type,
+                                     sata=self.device_helper.sata_device_type,
+                                     nvme=self.device_helper.nvme_device_type)
         self.config_spec = vim.vm.ConfigSpec()
         self.config_spec.deviceChange = []
         self.change_detected = False
@@ -279,10 +277,10 @@ class PyVmomiHelper(PyVmomi):
         Get gid of occupied bus numbers of each type of disk controller, update the available bus number list
         """
         for device in self.current_vm_obj.config.hardware.device:
-            if isinstance(device, self.sata_device_type):
+            if isinstance(device, self.device_helper.sata_device_type):
                 if len(self.disk_ctl_bus_num_list['sata']) != 0:
                     self.disk_ctl_bus_num_list['sata'].remove(device.busNumber)
-            if isinstance(device, self.nvme_device_type):
+            if isinstance(device, self.device_helper.nvme_device_type):
                 if len(self.disk_ctl_bus_num_list['nvme']) != 0:
                     self.disk_ctl_bus_num_list['nvme'].remove(device.busNumber)
             if isinstance(device, tuple(self.device_helper.scsi_device_type.values())):
@@ -323,10 +321,10 @@ class PyVmomiHelper(PyVmomi):
         disk_ctl = vim.vm.device.VirtualDeviceSpec()
         disk_ctl.operation = vim.vm.device.VirtualDeviceSpec.Operation.add
         if ctl_type == 'sata':
-            disk_ctl.device = self.sata_device_type()
+            disk_ctl.device = self.device_helper.sata_device_type()
             disk_ctl.device.key = -randint(15000, 19999)
         elif ctl_type == 'nvme':
-            disk_ctl.device = self.nvme_device_type()
+            disk_ctl.device = self.device_helper.nvme_device_type()
             disk_ctl.device.key = -randint(31000, 39999)
         elif ctl_type in self.device_helper.scsi_device_type.keys():
             disk_ctl.device = self.device_helper.scsi_device_type.get(ctl_type)()
@@ -334,8 +332,8 @@ class PyVmomiHelper(PyVmomi):
             disk_ctl.device.hotAddRemove = True
             disk_ctl.device.sharedBus = bus_sharing
             disk_ctl.device.scsiCtlrUnitNumber = 7
-        elif ctl_type in self.usb_device_type.keys():
-            disk_ctl.device = self.usb_device_type.get(ctl_type)()
+        elif ctl_type in self.device_helper.usb_device_type.keys():
+            disk_ctl.device = self.device_helper.usb_device_type.get(ctl_type)()
             if ctl_type == 'usb2':
                 disk_ctl.device.key = 7000
             elif ctl_type == 'usb3':
@@ -375,13 +373,13 @@ class PyVmomiHelper(PyVmomi):
                     ctl_facts_dict[device.busNumber]['controller_bus_sharing'] = device.sharedBus
                 if isinstance(device, tuple(self.device_helper.scsi_device_type.values())):
                     disk_ctl_facts['scsi'].update(ctl_facts_dict)
-                if isinstance(device, self.nvme_device_type):
+                if isinstance(device, self.device_helper.nvme_device_type):
                     disk_ctl_facts['nvme'].update(ctl_facts_dict)
-                if isinstance(device, self.sata_device_type):
+                if isinstance(device, self.device_helper.sata_device_type):
                     disk_ctl_facts['sata'].update(ctl_facts_dict)
-                if isinstance(device, self.usb_device_type.get('usb2')):
+                if isinstance(device, self.device_helper.usb_device_type.get('usb2')):
                     disk_ctl_facts['usb2'].update(ctl_facts_dict)
-                if isinstance(device, self.usb_device_type.get('usb3')):
+                if isinstance(device, self.device_helper.usb_device_type.get('usb3')):
                     disk_ctl_facts['usb3'].update(ctl_facts_dict)
 
         return disk_ctl_facts
@@ -401,7 +399,7 @@ class PyVmomiHelper(PyVmomi):
         controller_config = self.params.get('controllers')
         for ctl_config in controller_config:
             if ctl_config:
-                if ctl_config['type'] not in self.usb_device_type.keys():
+                if ctl_config['type'] not in self.device_helper.usb_device_type.keys():
                     if ctl_config['state'] == 'absent' and ctl_config.get('controller_number') is None:
                         self.module.fail_json(msg="Disk controller number is required when removing it.")
                     if ctl_config['state'] == 'present' and not exec_get_unused_ctl_bus_number:
@@ -415,7 +413,7 @@ class PyVmomiHelper(PyVmomi):
                                                   " is '%s', not >= 13." % vm_hwv)
         if exec_get_unused_ctl_bus_number:
             for ctl_config in controller_config:
-                if ctl_config and ctl_config['state'] == 'present' and ctl_config['type'] not in self.usb_device_type.keys():
+                if ctl_config and ctl_config['state'] == 'present' and ctl_config['type'] not in self.device_helper.usb_device_type.keys():
                     if ctl_config['type'] in self.device_helper.scsi_device_type.keys():
                         if len(self.disk_ctl_bus_num_list['scsi']) != 0:
                             ctl_config['controller_number'] = self.disk_ctl_bus_num_list['scsi'].pop(0)
@@ -444,7 +442,7 @@ class PyVmomiHelper(PyVmomi):
         for disk_ctl_config in controller_config:
             if disk_ctl_config and disk_ctl_config['state'] == 'present':
                 # create new USB controller, bus number is 0
-                if disk_ctl_config['type'] in self.usb_device_type.keys():
+                if disk_ctl_config['type'] in self.device_helper.usb_device_type.keys():
                     usb_exists, has_disks_attached = self.check_ctl_disk_exist(disk_ctl_config['type'])
                     if usb_exists:
                         self.module.warn("'%s' USB controller already exists, can not add more." % disk_ctl_config['type'])

--- a/plugins/modules/vmware_guest_disk.py
+++ b/plugins/modules/vmware_guest_disk.py
@@ -395,9 +395,8 @@ class PyVmomiHelper(PyVmomi):
         self.device_helper = PyVmomiDeviceHelper(self.module)
         self.desired_disks = self.params['disk']  # Match with vmware_guest parameter
         self.vm = None
-        self.ctl_device_type = dict(self.device_helper.scsi_device_type,
-                                    sata=self.device_helper.sata_device_type,
-                                    nvme=self.device_helper.nvme_device_type)
+        self.ctl_device_type = self.device_helper.scsi_device_type.copy()
+        self.ctl_device_type.update({'sata': self.device_helper.sata_device_type, 'nvme': self.device_helper.nvme_device_type})
         self.config_spec = vim.vm.ConfigSpec()
         self.config_spec.deviceChange = []
 

--- a/plugins/modules/vmware_guest_disk.py
+++ b/plugins/modules/vmware_guest_disk.py
@@ -395,8 +395,9 @@ class PyVmomiHelper(PyVmomi):
         self.device_helper = PyVmomiDeviceHelper(self.module)
         self.desired_disks = self.params['disk']  # Match with vmware_guest parameter
         self.vm = None
-        self.ctl_device_type = self.device_helper.scsi_device_type.copy()
-        self.ctl_device_type.update({'sata': vim.vm.device.VirtualAHCIController, 'nvme': vim.vm.device.VirtualNVMEController})
+        self.ctl_device_type = dict(self.device_helper.scsi_device_type,
+                                    sata=self.device_helper.sata_device_type,
+                                    nvme=self.device_helper.nvme_device_type)
         self.config_spec = vim.vm.ConfigSpec()
         self.config_spec.deviceChange = []
 


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/community.vmware/pull/967

##### SUMMARY
Remove duplicate code from `vmware_guest_controller` by using functions from `module_utils.vm_device_helper.PyVmomiDeviceHelper`. Also, move some definitions from `vmware_guest_controller` and `vmware_guest_disk` to `module_utils.vm_device_helper.PyVmomiDeviceHelper`.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_guest_controller
vmware_guest_disk

##### ADDITIONAL INFORMATION
Follow-up to PR #914
