### PR TITLE
vmware_host_iscsi/tests: ensure vmhba_name is defined

### DIFF
--- a/tests/integration/targets/vmware_host_iscsi/tasks/main.yml
+++ b/tests/integration/targets/vmware_host_iscsi/tasks/main.yml
@@ -48,7 +48,8 @@
   loop: "{{ gather_facts_host_bus_adapters_result.ansible_facts.config.storageDevice.hostBusAdapter }}"
   when:
     - "'device' in item"
-    - "'isSoftwareBased' in item and item.isSoftwareBased is sameas true"
+# See: https://github.com/ansible-collections/community.vmware/issues/927
+#    - "'isSoftwareBased' in item and item.isSoftwareBased is sameas true"
 
 - name: vmware_host_iscsi module test - connect to vCenter
   include_tasks: iscsi_module_test_tasks.yml


### PR DESCRIPTION
It's not clear why, but `vmware_host_facts` does not set
`isSoftwareBased` on the hba devices.

Closes: https://github.com/ansible-collections/community.vmware/issues/927