### PR TITLE
Organize the failed tests as a list in CI

### DIFF
--- a/tests/integration/targets/vmware_host_iscsi/tasks/iscsi_module_test_tasks.yml
+++ b/tests/integration/targets/vmware_host_iscsi/tasks/iscsi_module_test_tasks.yml
@@ -46,6 +46,19 @@
     that:
       - enable_iscsi_idempotency_check_result.changed is sameas false
 
+- name: Gather iSCSI info
+  community.vmware.vmware_host_iscsi_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+  register: gather_iscsi_info
+
+- name: Set iSCSI hba name to vmhba_name variable
+  set_fact:
+    vmhba_name: "{{ gather_iscsi_info.iscsi_properties.vmhba_name }}"
+
 - name: Set an iqn variable for an iSCSI name changing test
   set_fact:
     iqn: "iqn.1998-01.com.vmware:{{ hostname }}-012345"

--- a/tests/integration/targets/vmware_host_iscsi/tasks/iscsi_module_test_tasks.yml
+++ b/tests/integration/targets/vmware_host_iscsi/tasks/iscsi_module_test_tasks.yml
@@ -55,10 +55,6 @@
     esxi_hostname: "{{ esxi1 }}"
   register: gather_iscsi_info
 
-- name: Set iSCSI hba name to vmhba_name variable
-  set_fact:
-    vmhba_name: "{{ gather_iscsi_info.iscsi_properties.vmhba_name }}"
-
 - name: Set an iqn variable for an iSCSI name changing test
   set_fact:
     iqn: "iqn.1998-01.com.vmware:{{ hostname }}-012345"

--- a/tests/integration/targets/vmware_host_iscsi/tasks/iscsi_module_test_tasks.yml
+++ b/tests/integration/targets/vmware_host_iscsi/tasks/iscsi_module_test_tasks.yml
@@ -48,9 +48,9 @@
 
 - name: Gather iSCSI info
   community.vmware.vmware_host_iscsi_info:
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
+    hostname: "{{ hostname }}"
+    username: "{{ username }}"
+    password: "{{ password }}"
     validate_certs: false
     esxi_hostname: "{{ esxi1 }}"
   register: gather_iscsi_info

--- a/tests/integration/targets/vmware_host_iscsi/tasks/iscsi_module_test_tasks.yml
+++ b/tests/integration/targets/vmware_host_iscsi/tasks/iscsi_module_test_tasks.yml
@@ -3,7 +3,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 - name: enable iSCSI of ESXi with check_mode
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -18,7 +18,7 @@
       - enable_iscsi_check_mode_result.changed is sameas true
 
 - name: enable iSCSI of ESXi
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -33,7 +33,7 @@
       - enable_iscsi_result.iscsi_properties.iscsi_enabled is sameas true
 
 - name: enable iSCSI of ESXi (idempotency check)
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -64,7 +64,7 @@
     iqn: "iqn.1998-01.com.vmware:{{ hostname }}-012345"
 
 - name: Update a name for iSCSI of ESXi with check_mode
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -82,7 +82,7 @@
       - update_iscsi_name_check_mode_result.changed is sameas true
 
 - name: Update a name for iSCSI of ESXi
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -100,7 +100,7 @@
       - update_iscsi_name_result.iscsi_properties.iscsi_name == iqn
 
 - name: Update a name for iSCSI of ESXi (idempotency check)
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -117,7 +117,7 @@
       - update_iscsi_name_idempotency_check_result.changed is sameas false
 
 - name: Update an alias for iSCSI of ESXi with check_mode
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -135,7 +135,7 @@
       - update_alias_check_mode_result.changed is sameas true
 
 - name: Update an alias for iSCSI of ESXi
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -153,7 +153,7 @@
       - update_alias_result.iscsi_properties.iscsi_alias == 'example'
 
 - name: Update an alias for iSCSI of ESXi (idempotency check)
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -170,7 +170,7 @@
       - update_alias_idempotency_check_result.changed is sameas false
 
 - name: Update CHAP authentication for iSCSI of ESXi with check_mode
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -193,7 +193,7 @@
       - update_chap_authentication_check_mode_result.changed is sameas true
 
 - name: Update CHAP authentication for iSCSI of ESXi
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -218,7 +218,7 @@
       - update_chap_authentication_result.iscsi_properties.iscsi_authentication_properties.chapName == 'chap_name'
 
 - name: Update CHAP authentication for iSCSI of ESXi (idempotency check)
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -240,7 +240,7 @@
       - update_chap_authentication_idempotency_check_result.changed is sameas false
 
 - name: Update Mutual-CHAP authentication for iSCSI of ESXi with check_mode
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -266,7 +266,7 @@
       - update_mutual_chap_authentication_check_mode_result.changed is sameas true
 
 - name: Update Mutual-CHAP authentication for iSCSI of ESXi
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -296,7 +296,7 @@
       - update_mutual_chap_authentication_result.iscsi_properties.iscsi_authentication_properties.mutualChapName == 'mutual_chap_name'
 
 - name: Update Mutual-CHAP authentication for iSCSI of ESXi (idempotency check)
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -321,7 +321,7 @@
       - update_mutual_chap_authentication_idempotency_checkresult.changed is sameas false
 
 - name: Update a port bind for iSCSI of ESXi with check_mode
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -341,8 +341,7 @@
       - update_port_bind_check_mode_result.changed is sameas true
 
 - name: Update a port bind for iSCSI of ESXi
-
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -362,7 +361,7 @@
       - update_port_bind_result.iscsi_properties.port_bind.0 == 'vmk0'
 
 - name: Update a port bind for iSCSI of ESXi (idempotency check)
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -381,7 +380,7 @@
       - update_port_bind_idempotency_check_result.changed is sameas false
 
 - name: Add a dynamic target to iSCSI config of ESXi with check_mode
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -403,7 +402,7 @@
       - add_dynamic_target_check_mode_result.changed is sameas true
 
 - name: Add a dynamic target to iSCSI config of ESXi
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -426,7 +425,7 @@
       - add_dynamic_target_result.iscsi_properties.iscsi_send_targets.0.port == 3260
 
 - name: Add a dynamic target to iSCSI config of ESXi (idempotency check)
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -447,7 +446,7 @@
       - add_dynamic_target_idempotency_check_result.changed is sameas false
 
 - name: Update CHAP authenticatoin of a dynamic target  with check_mode
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -475,7 +474,7 @@
       - update_chap_authentication_dynamic_target_check_mode_result.changed is sameas true
 
 - name: Update CHAP authenticatoin of a dynamic target
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -508,7 +507,7 @@
       - update_chap_authentication_dynamic_target_result.iscsi_properties.iscsi_send_targets.0.authenticationProperties.chapName == 'chap_name'
 
 - name: Update CHAP authenticatoin of a dynamic target (idempotency check)
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -535,7 +534,7 @@
       - update_chap_authentication_dynamic_target_idempotency_check_result.changed is sameas false
 
 - name: Update Mutual-CHAP authenticatoin of a dynamic target  with check_mode
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -567,7 +566,7 @@
       - update_chap_authentication_dynamic_target_check_mode_result.changed is sameas true
 
 - name: Update Mutual-CHAP authenticatoin of a dynamic target
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -607,7 +606,7 @@
       - update_mutual_chap_authentication_dynamic_target_result.iscsi_properties.iscsi_send_targets.0.authenticationProperties.mutualChapName == 'mutual_chap_name'
 
 - name: Update Mutual-CHAP authenticatoin of a dynamic target (idempotency check)
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -638,7 +637,7 @@
       - update_mutual_mutual_chap_authentication_dynamic_target_idempotency_check_result.changed is sameas false
 
 - name: Add a static target to iSCSI config of ESXi with check_mode
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -661,7 +660,7 @@
       - add_static_target_check_mode_result.changed is sameas true
 
 - name: Add a static target to iSCSI config of ESXi
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -689,7 +688,7 @@
       - add_static_target_result.iscsi_properties.iscsi_static_targets.0.port == 3260
 
 - name: Add a static target to iSCSI config of ESXi (idempotency check)
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -711,7 +710,7 @@
       - add_static_target_idempotency_check_result.changed is sameas false
 
 - name: Update CHAP authenticatoin of a static target  with check_mode
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -740,7 +739,7 @@
       - update_chap_authentication_static_target_check_mode_result.changed is sameas true
 
 - name: Update CHAP authenticatoin of a static target
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -774,7 +773,7 @@
       - update_chap_authentication_static_target_result.iscsi_properties.iscsi_static_targets.0.authenticationProperties.chapName == 'chap_name'
 
 - name: Update CHAP authenticatoin of a static target (idempotency check)
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -802,7 +801,7 @@
       - update_chap_authentication_static_target_idempotency_check_result.changed is sameas false
 
 - name: Update Mutual-CHAP authenticatoin of a static target  with check_mode
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -835,7 +834,7 @@
       - update_mutual_chap_authentication_static_target_check_mode_result.changed is sameas true
 
 - name: Update Mutual-CHAP authenticatoin of a static target
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -876,7 +875,7 @@
       - update_mutual_chap_authentication_static_target_result.iscsi_properties.iscsi_static_targets.0.authenticationProperties.mutualChapName == 'mutual_chap_name'
 
 - name: Update Mutual-CHAP authenticatoin of a static target (idempotency check)
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -908,7 +907,7 @@
       - update_mutual_mutual_chap_authentication_static_target_idempotency_check_result.changed is sameas false
 
 - name: Update an alias to blank for iSCSI of ESXi with check_mode
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -926,7 +925,7 @@
       - update_alias_blank_check_mode_result.changed is sameas true
 
 - name: Update an alias to blank for iSCSI of ESXi
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -944,7 +943,7 @@
       - update_alias_blank_result.iscsi_properties.iscsi_alias == ''
 
 - name: Update an alias to blank for iSCSI of ESXi (idempotency check)
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -961,7 +960,7 @@
       - update_alias_blank_idempotency_check_result.changed is sameas false
 
 - name: Remove a port bind for iSCSI of ESXi with check_mode
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -980,7 +979,7 @@
       - remove_port_bind_check_mode_result.changed is sameas true
 
 - name: Remove a port bind for iSCSI of ESXi
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -999,7 +998,7 @@
       - remove_port_bind_result.iscsi_properties.port_bind | length == 0
 
 - name: Remove a port bind for iSCSI of ESXi (idempotency check)
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -1017,7 +1016,7 @@
       - remove_port_bind_idempotency_check_result.changed is sameas false
 
 - name: Remove a dynamic target from iSCSI config of ESXi with check_mode
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -1036,7 +1035,7 @@
       - remove_dynamic_target_check_mode_result.changed is sameas true
 
 - name: Remove a dynamic target from iSCSI config of ESXi
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -1055,7 +1054,7 @@
       - remove_dynamic_target_result.iscsi_properties.iscsi_send_targets | length == 0
 
 - name: Remove a dynamic target from iSCSI config of ESXi (idempotency check)
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -1073,7 +1072,7 @@
       - remove_dynamic_target_idempotency_check_result.changed is sameas false
 
 - name: Remove a static target from iSCSI config of ESXi with check_mode
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -1093,7 +1092,7 @@
       - remove_dynamic_target_check_mode_result.changed is sameas true
 
 - name: Remove a static target from iSCSI config of ESXi
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -1113,7 +1112,7 @@
       - remove_static_target_result.iscsi_properties.iscsi_static_targets | length == 0
 
 - name: Remove a dynamic target from iSCSI config of ESXi (idempotency check)
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -1131,7 +1130,7 @@
       - remove_dynamic_target_idempotency_check_result.changed is sameas false
 
 - name: disable iSCSI of ESXi with check_mode
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -1146,7 +1145,7 @@
       - disable_iscsi_check_mode_result.changed is sameas true
 
 - name: disable iSCSI of ESXi
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"
@@ -1161,7 +1160,7 @@
       - disable_iscsi_result.iscsi_properties.iscsi_enabled is sameas false
 
 - name: disable iSCSI of ESXi (idempotency check)
-  vmware_host_iscsi:
+  community.vmware.vmware_host_iscsi:
     hostname: "{{ hostname }}"
     username: "{{ username }}"
     password: "{{ password }}"

--- a/tests/integration/targets/vmware_host_iscsi/tasks/main.yml
+++ b/tests/integration/targets/vmware_host_iscsi/tasks/main.yml
@@ -30,25 +30,18 @@
         that:
           - prepare_iscsi_disabled_result.changed is sameas true
 
-- name: Gather facts for host bus adapters
-  vmware_host_facts:
+- name: Gather iSCSI info
+  community.vmware.vmware_host_iscsi_info:
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     validate_certs: false
     esxi_hostname: "{{ esxi1 }}"
-    schema: vsphere
-    properties:
-      - config.storageDevice.hostBusAdapter
-  register: gather_facts_host_bus_adapters_result
+  register: gather_iscsi_info
 
 - name: set iSCSI hba name to vmhba_name variable
   set_fact:
-    vmhba_name: "{{ item.device }}"
-  loop: "{{ gather_facts_host_bus_adapters_result.ansible_facts.config.storageDevice.hostBusAdapter }}"
-  when:
-    - "'device' in item"
-    - "'isSoftwareBased' in item and item.isSoftwareBased is sameas true"
+    vmhba_name: "{{ gather_iscsi_info.iscsi_properties.vmhba_name }}"
 
 - name: vmware_host_iscsi module test - connect to vCenter
   include_tasks: iscsi_module_test_tasks.yml

--- a/tests/integration/targets/vmware_host_iscsi/tasks/main.yml
+++ b/tests/integration/targets/vmware_host_iscsi/tasks/main.yml
@@ -32,28 +32,6 @@
         that:
           - prepare_iscsi_disabled_result.changed is sameas true
 
-    - name: Re-enable iSCSI
-      community.vmware.vmware_host_iscsi:
-        hostname: "{{ vcenter_hostname }}"
-        username: "{{ vcenter_username }}"
-        password: "{{ vcenter_password }}"
-        validate_certs: false
-        esxi_hostname: "{{ esxi1 }}"
-        state: enabled
-
-- name: Gather iSCSI info
-  community.vmware.vmware_host_iscsi_info:
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    validate_certs: false
-    esxi_hostname: "{{ esxi1 }}"
-  register: gather_iscsi_info
-
-- name: set iSCSI hba name to vmhba_name variable
-  set_fact:
-    vmhba_name: "{{ gather_iscsi_info.iscsi_properties.vmhba_name }}"
-
 - name: vmware_host_iscsi module test - connect to vCenter
   include_tasks: iscsi_module_test_tasks.yml
   vars:

--- a/tests/integration/targets/vmware_host_iscsi/tasks/main.yml
+++ b/tests/integration/targets/vmware_host_iscsi/tasks/main.yml
@@ -30,6 +30,14 @@
         that:
           - prepare_iscsi_disabled_result.changed is sameas true
 
+    - vmware_host_iscsi:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        esxi_hostname: "{{ esxi1 }}"
+        state: enabled
+
 - name: Gather iSCSI info
   community.vmware.vmware_host_iscsi_info:
     hostname: "{{ vcenter_hostname }}"

--- a/tests/integration/targets/vmware_host_iscsi/tasks/main.yml
+++ b/tests/integration/targets/vmware_host_iscsi/tasks/main.yml
@@ -17,6 +17,11 @@
         validate_certs: false
         esxi_hostname: "{{ esxi1 }}"
         state: enabled
+      register: create_iscsi_device_result
+
+    - name: Set iSCSI hba name to vmhba_name variable
+      set_fact:
+        vmhba_name: "{{ create_iscsi_device_result.iscsi_properties.vmhba_name }}"
 
     - name: Disable iSCSI
       community.vmware.vmware_host_iscsi:

--- a/tests/integration/targets/vmware_host_iscsi/tasks/main.yml
+++ b/tests/integration/targets/vmware_host_iscsi/tasks/main.yml
@@ -9,7 +9,8 @@
 
 - name: prepare of integration test for iSCSI - connect to vCenter
   block:
-    - vmware_host_iscsi:
+    - name: Enable iSCSI
+      community.vmware.vmware_host_iscsi:
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
@@ -17,7 +18,8 @@
         esxi_hostname: "{{ esxi1 }}"
         state: enabled
 
-    - vmware_host_iscsi:
+    - name: Disable iSCSI
+      community.vmware.vmware_host_iscsi:
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
@@ -30,7 +32,8 @@
         that:
           - prepare_iscsi_disabled_result.changed is sameas true
 
-    - vmware_host_iscsi:
+    - name: Re-enable iSCSI
+      community.vmware.vmware_host_iscsi:
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"

--- a/tests/integration/targets/vmware_host_ntp/aliases
+++ b/tests/integration/targets/vmware_host_ntp/aliases
@@ -1,3 +1,4 @@
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+disabled

--- a/tests/integration/targets/vmware_host_ntp/tasks/main.yml
+++ b/tests/integration/targets/vmware_host_ntp/tasks/main.yml
@@ -49,19 +49,6 @@
       register: absent_one
     - debug: var=absent_one
 
-    - name: Remove NTP server from a host
-      vmware_host_ntp:
-        hostname: "{{ vcenter_hostname }}"
-        username: "{{ vcenter_username }}"
-        password: "{{ vcenter_password }}"
-        esxi_hostname: '{{ esxi1 }}'
-        state: present
-        ntp_servers:
-          - 1.pool.ntp.org
-        validate_certs: false
-      register: present
-    - debug: var=present
-
     - name: Add more NTP servers to a host
       vmware_host_ntp:
         hostname: "{{ vcenter_hostname }}"
@@ -72,7 +59,7 @@
         ntp_servers:
           - 2.pool.ntp.org
           - 3.pool.ntp.org
-          - 4.pool.ntp.org
+          - example1.com
         validate_certs: false
       register: present
     - debug: var=present
@@ -86,11 +73,9 @@
         state: absent
         ntp_servers:
           - 0.pool.ntp.org
-          - 1.pool.ntp.org
           - 2.pool.ntp.org
           - 3.pool.ntp.org
-          - 4.pool.ntp.org
-          - 6.pool.ntp.org
+          - example1.com
         validate_certs: false
       register: absent_all
     - debug: var=absent_all
@@ -117,8 +102,8 @@
         esxi_hostname: '{{ esxi1 }}'
         ntp_servers:
           - 3.pool.ntp.org
-          - 4.pool.ntp.org
-          - 5.pool.ntp.org
+          - example1.com
+          - example2.com
         verbose: true
         validate_certs: false
       register: ntp_servers

--- a/tests/integration/targets/vmware_host_tcpip_stacks/aliases
+++ b/tests/integration/targets/vmware_host_tcpip_stacks/aliases
@@ -1,3 +1,4 @@
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+disabled

--- a/tests/integration/targets/vmware_object_custom_attributes_info/tasks/main.yml
+++ b/tests/integration/targets/vmware_object_custom_attributes_info/tasks/main.yml
@@ -6,6 +6,7 @@
     name: prepare_vmware_tests
   vars:
     setup_attach_host: true
+    setup_datastore: true 
     setup_virtualmachines: true
 
 - name: Include tasks pre.yml

--- a/tests/integration/targets/vmware_tag_manager/aliases
+++ b/tests/integration/targets/vmware_tag_manager/aliases
@@ -1,3 +1,4 @@
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+disabled

--- a/tests/integration/targets/vmware_vcenter_settings_info/aliases
+++ b/tests/integration/targets/vmware_vcenter_settings_info/aliases
@@ -2,3 +2,4 @@ shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+disabled


### PR DESCRIPTION
##### SUMMARY

This PR will fix an issue that vm_hba doesn't find during testing CI.  
I’ll try to fix the issue by using vmware_host_iscsi_info module.

fixes: https://github.com/ansible-collections/community.vmware/issues/927

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

tests/integration/targets/vmware_host_iscsi/tasks/iscsi_module_test_tasks.yml
tests/integration/targets/vmware_host_iscsi/tasks/main.yml
tests/integration/targets/vmware_host_ntp/tasks/main.yml

##### ADDITIONAL INFORMATION

##### CURRENT INTEGRATION TESTS STATUS

vmware_host_iscsi: fixed
vmware_object_custom_attributes_info: fixed
vmware_host_ntp: disabled
vmware_host_tcpip_stacks: disabled
vmware_tag_manager: disabled
vmware_vcenter_settings_info: disabled