### PR TITLE
vmware_guest: Provide a meaningful message when customization failed

### DIFF
--- a/changelogs/fragments/933-vmware_guest_add_msg_customization_failed.yml
+++ b/changelogs/fragments/933-vmware_guest_add_msg_customization_failed.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_guest - add message for `deploy_vm` method when it fails with timeout error while customizing the VM (https://github.com/ansible-collections/community.vmware/pull/933).

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -2891,7 +2891,9 @@ class PyVmomiHelper(PyVmomi):
                     is_customization_ok = self.wait_for_customization(vm=vm, timeout=self.params['wait_for_customization_timeout'])
                     if not is_customization_ok:
                         vm_facts = self.gather_facts(vm)
-                        return {'changed': self.change_applied, 'failed': True, 'instance': vm_facts, 'op': 'customization'}
+                        return {'changed': self.change_applied, 'failed': True,
+                                'msg': 'Customization failed. For detailed information see warnings',
+                                'instance': vm_facts, 'op': 'customization'}
 
             vm_facts = self.gather_facts(vm)
             return {'changed': self.change_applied, 'failed': False, 'instance': vm_facts}
@@ -3046,7 +3048,8 @@ class PyVmomiHelper(PyVmomi):
             is_customization_ok = self.wait_for_customization(vm=self.current_vm_obj, timeout=self.params['wait_for_customization_timeout'])
             if not is_customization_ok:
                 return {'changed': self.change_applied, 'failed': True,
-                        'msg': 'Wait for customization failed due to timeout', 'op': 'wait_for_customize_exist'}
+                        'msg': 'Customization failed. For detailed information see warnings',
+                        'op': 'wait_for_customize_exist'}
 
         return {'changed': self.change_applied, 'failed': False}
 


### PR DESCRIPTION
Fix result message of PyVmomiHelper.wait_for_customization when it returns failed:True.

##### SUMMARY
Added 'msg' to return value when 'wait_for_customization' failed in `deploy_vm()`
Changed 'msg' when 'wait_for_customization' failed in `customize_exist_vm()`

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/vmware_guest.py

##### ADDITIONAL INFORMATION
For every result with `result['failed']==True` we must have a 'msg' or we get an error while attempting to get it from result dict at end of main() function. Other cases in this module provide 'failed':True with 'msg'. 

Moreover, current 'msg' for customization existing vm was not correct because `wait_for_customization()` can return False not only due to timeout but also due to `"Customization failed with error {%s}:{%s}"`. Because of backward compatibility we cannot change its return type from bool to dict and only way to know error message is to see output of `module.warn`.

To reproduce the `KeyError` while getting 'msg' try to run clone any windows-machine with something like
``` yaml
customization:
  autologon: true
  autologoncount: 3000
wait_for_customization: yes
wait_for_customization_timeout: 60 # little timeout for getting customization error
```