### PR TITLE
vmware_host_tcpip_stacks: Fix and re-enable integration tests

### DIFF
--- a/tests/integration/targets/vmware_host_tcpip_stacks/aliases
+++ b/tests/integration/targets/vmware_host_tcpip_stacks/aliases
@@ -1,4 +1,3 @@
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
-disabled

--- a/tests/integration/targets/vmware_host_tcpip_stacks/tasks/destroy.yml
+++ b/tests/integration/targets/vmware_host_tcpip_stacks/tasks/destroy.yml
@@ -18,12 +18,7 @@
       subnet_mask: 255.255.255.0
       tcpip_stack: provisioning
     state: absent
-  register: vmkernel_provisioning_result
-
-- name: Make sure if the provisioning vmkernel is destroyed
-  assert:
-    that:
-      - vmkernel_provisioning_result.changed is sameas true
+  ignore_errors: true
 
 - name: destroy vmkernel for vmotion
   vmware_vmkernel:
@@ -41,12 +36,7 @@
       subnet_mask: 255.255.255.0
       tcpip_stack: vmotion
     state: absent
-  register: vmkernel_vmotion_result
-
-- name: Make sure if the vmotion vmkernel is destroyed
-  assert:
-    that:
-      - vmkernel_vmotion_result.changed is sameas true
+  ignore_errors: true
 
 - name: destroy portgroups for the test
   vmware_portgroup:
@@ -58,12 +48,7 @@
     switch: "{{ switch1 }}"
     portgroup: "{{ item }}"
     state: absent
-  register: portgroups_result
+  ignore_errors: true
   loop:
     - provisioning
     - vmotion
-
-- name: Make sure if the portgroups are destroyed
-  assert:
-    that:
-      - portgroups_result.changed is sameas true

--- a/tests/integration/targets/vmware_host_tcpip_stacks/tasks/main.yml
+++ b/tests/integration/targets/vmware_host_tcpip_stacks/tasks/main.yml
@@ -11,8 +11,7 @@
 - name: include tasks pre.yml
   include_tasks: pre.yml
 
-- name: include tasks vmware_host_tcpip_stacks_tests.yml
-  include_tasks: vmware_host_tcpip_stacks_tests.yml
-
-- name: include tasks destroy.
-  include_tasks: destroy.yml
+- block:
+  - include_tasks: vmware_host_tcpip_stacks_tests.yml
+  always:
+  - include_tasks: destroy.yml

--- a/tests/integration/targets/vmware_host_tcpip_stacks/tasks/main.yml
+++ b/tests/integration/targets/vmware_host_tcpip_stacks/tasks/main.yml
@@ -6,6 +6,7 @@
     name: prepare_vmware_tests
   vars:
     setup_attach_host: true
+    setup_switch: true
 
 - name: include tasks pre.yml
   include_tasks: pre.yml


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/community.vmware/pull/972

##### SUMMARY
We've disabled the integration tests for `vmware_host_tcpip_stacks` in PR #930 to get the CI pipeline working again. This PR enables them again.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_host_tcpip_stacks

##### ADDITIONAL INFORMATION
see [here](https://github.com/ansible-collections/community.vmware/pull/930#issuecomment-875579233)

I think these tests don't always fail. It looks like the main problem is that `destroy.yml` isn't always run. If the tests fail for a temporary problem and are run again, `pre.yml` fails because `vmk1` already exists. So I think the best solution is to always run `destroy.yml`.