### PR TITLE
vmware_tag_manager: Fix and re-enable integration tests

### DIFF
--- a/tests/integration/targets/vmware_tag_manager/aliases
+++ b/tests/integration/targets/vmware_tag_manager/aliases
@@ -1,4 +1,3 @@
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
-disabled

--- a/tests/integration/targets/vmware_tag_manager/tasks/cleanup.yml
+++ b/tests/integration/targets/vmware_tag_manager/tasks/cleanup.yml
@@ -1,16 +1,3 @@
-- name: Get Tags
-  community.vmware.vmware_tag_info:
-    hostname: '{{ vcenter_hostname }}'
-    username: '{{ vcenter_username }}'
-    password: '{{ vcenter_password }}'
-    validate_certs: false
-  
-- set_fact:
-    tag_category_id: "{{ item.tag_category_id }}"
-  loop: "{{ tag_results.tag_info|community.general.json_query(query) }}"
-  vars:
-    query: "[?tag_name==`{{ tag_one }}`]"
-
 - name: Delete Tags
   vmware_tag:
     hostname: '{{ vcenter_hostname }}'
@@ -18,9 +5,8 @@
     password: '{{ vcenter_password }}'
     validate_certs: false
     tag_name: "{{ tag_one }}"
-    category_id: "{{ tag_category_id }}"
+    category_id: "{{ cat_one_id }}"
     state: absent
-  when: tag_category_id is defined
   register: delete_tag
 
 - name: Delete Categories

--- a/tests/integration/targets/vmware_tag_manager/tasks/cleanup.yml
+++ b/tests/integration/targets/vmware_tag_manager/tasks/cleanup.yml
@@ -1,14 +1,27 @@
+- name: Get Tags
+  community.vmware.vmware_tag_info:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    validate_certs: false
+  
+- set_fact:
+    tag_category_id: "{{ item.tag_category_id }}"
+  loop: "{{ tag_results.tag_info|community.general.json_query(query) }}"
+  vars:
+    query: "[?tag_name==`{{ tag_one }}`]"
+
 - name: Delete Tags
   vmware_tag:
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
     validate_certs: false
-    tag_name: "{{ item }}"
+    tag_name: "{{ tag_one }}"
+    category_id: "{{ tag_category_id }}"
     state: absent
+  when: tag_category_id is defined
   register: delete_tag
-  with_items:
-    - "{{ tag_one }}"
 
 - name: Delete Categories
   vmware_category:
@@ -16,8 +29,6 @@
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
     validate_certs: false
-    category_name: "{{ item }}"
+    category_name: "{{ cat_one }}"
     state: absent
   register: delete_categories
-  with_items:
-    - "{{ cat_one }}"

--- a/tests/integration/targets/vmware_tag_manager/tasks/main.yml
+++ b/tests/integration/targets/vmware_tag_manager/tasks/main.yml
@@ -13,8 +13,21 @@
     cat_one: category_1003
     tag_one: tag:1003
 
-- include: cleanup.yml
 - block:
+  - name: Create first category
+    vmware_category:
+      hostname: '{{ vcenter_hostname }}'
+      username: '{{ vcenter_username }}'
+      password: '{{ vcenter_password }}'
+      validate_certs: false
+      category_name: "{{ cat_one }}"
+      category_cardinality: 'multiple'
+      state: present
+    register: category_one_create
+
+  - name: Set category one id
+    set_fact: cat_one_id={{ category_one_create['category_results']['category_id'] }}
+
   - include: tag_manager_dict.yml
   always:
   - include: cleanup.yml

--- a/tests/integration/targets/vmware_tag_manager/tasks/tag_manager_dict.yml
+++ b/tests/integration/targets/vmware_tag_manager/tasks/tag_manager_dict.yml
@@ -4,145 +4,131 @@
 
 # Testcase for https://github.com/ansible/ansible/issues/65765
 
-  - name: Create first category
-    vmware_category:
-      hostname: '{{ vcenter_hostname }}'
-      username: '{{ vcenter_username }}'
-      password: '{{ vcenter_password }}'
-      validate_certs: false
-      category_name: "{{ cat_one }}"
-      category_cardinality: 'multiple'
-      state: present
-    register: category_one_create
+- name: Create tag with colon in name
+  vmware_tag:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    validate_certs: false
+    tag_name: "{{ tag_one }}"
+    category_id: "{{ cat_one_id }}"
+    state: present
+  register: tag_one_create
 
-  - name: Set category one id
-    set_fact: cat_one_id={{ category_one_create['category_results']['category_id'] }}
+- name: Check tag is created
+  assert:
+    that:
+      - tag_one_create.changed
 
-  - name: Create tag with colon in name
-    vmware_tag:
-      hostname: '{{ vcenter_hostname }}'
-      username: '{{ vcenter_username }}'
-      password: '{{ vcenter_password }}'
-      validate_certs: false
-      tag_name: "{{ tag_one }}"
-      category_id: "{{ cat_one_id }}"
-      state: present
-    register: tag_one_create
+- name: Get VM Facts
+  vmware_vm_info:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    validate_certs: false
+  register: vm_info
 
-  - name: Check tag is created
-    assert:
-      that:
-        - tag_one_create.changed
+- set_fact:
+    vm_name: "{{ vm_info['virtual_machines'][0]['guest_name'] }}"
+    vm_moid: "{{ vm_info['virtual_machines'][0]['moid'] }}"
 
-  - name: Get VM Facts
-    vmware_vm_info:
-      hostname: '{{ vcenter_hostname }}'
-      username: '{{ vcenter_username }}'
-      password: '{{ vcenter_password }}'
-      validate_certs: false
-    register: vm_info
+- name: Assign tag to given virtual machine
+  vmware_tag_manager:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    validate_certs: false
+    tag_names:
+      - category: "{{ cat_one }}"
+        tag: "{{ tag_one }}"
+    object_name: "{{ vm_name }}"
+    object_type: VirtualMachine
+    state: add
+  register: vm_tag_info
 
-  - set_fact:
-      vm_name: "{{ vm_info['virtual_machines'][0]['guest_name'] }}"
-      vm_moid: "{{ vm_info['virtual_machines'][0]['moid'] }}"
+- name: Assign tag to rw_datastore
+  vmware_tag_manager:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    validate_certs: false
+    tag_names:
+      - category: "{{ cat_one }}"
+        tag: "{{ tag_one }}"
+    object_name: "{{ rw_datastore }}"
+    object_type: Datastore
+    state: add
+  register: datastore_tag_info
 
-  - name: Assign tag to given virtual machine
-    vmware_tag_manager:
-      hostname: '{{ vcenter_hostname }}'
-      username: '{{ vcenter_username }}'
-      password: '{{ vcenter_password }}'
-      validate_certs: false
-      tag_names:
-        - category: "{{ cat_one }}"
-          tag: "{{ tag_one }}"
-      object_name: "{{ vm_name }}"
-      object_type: VirtualMachine
-      state: add
-    register: vm_tag_info
+- name: Check if we assigned correct tags
+  assert:
+    that:
+      - vm_tag_info.changed
+      - datastore_tag_info.changed
 
-  - name: Assign tag to rw_datastore
-    vmware_tag_manager:
-      hostname: '{{ vcenter_hostname }}'
-      username: '{{ vcenter_username }}'
-      password: '{{ vcenter_password }}'
-      validate_certs: false
-      tag_names:
-        - category: "{{ cat_one }}"
-          tag: "{{ tag_one }}"
-      object_name: "{{ rw_datastore }}"
-      object_type: Datastore
-      state: add
-    register: datastore_tag_info
+- name: Remove tag to given virtual machine
+  vmware_tag_manager:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    validate_certs: false
+    tag_names:
+      - category: "{{ cat_one }}"
+        tag: "{{ tag_one }}"
+    object_name: "{{ vm_name }}"
+    object_type: VirtualMachine
+    state: remove
+  register: vm_tag_info
 
-  - name: Check if we assigned correct tags
-    assert:
-      that:
-        - vm_tag_info.changed
-        - datastore_tag_info.changed
+- name: Assign tag to given virtual machine using moid
+  vmware_tag_manager:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    validate_certs: false
+    tag_names:
+      - category: "{{ cat_one }}"
+        tag: "{{ tag_one }}"
+    moid: "{{ vm_moid }}"
+    object_type: VirtualMachine
+    state: add
+  register: vm_tag_info
 
-  - name: Remove tag to given virtual machine
-    vmware_tag_manager:
-      hostname: '{{ vcenter_hostname }}'
-      username: '{{ vcenter_username }}'
-      password: '{{ vcenter_password }}'
-      validate_certs: false
-      tag_names:
-        - category: "{{ cat_one }}"
-          tag: "{{ tag_one }}"
-      object_name: "{{ vm_name }}"
-      object_type: VirtualMachine
-      state: remove
-    register: vm_tag_info
+- name: Check if we assigned correct tags
+  assert:
+    that:
+      - vm_tag_info.changed
 
-  - name: Assign tag to given virtual machine using moid
-    vmware_tag_manager:
-      hostname: '{{ vcenter_hostname }}'
-      username: '{{ vcenter_username }}'
-      password: '{{ vcenter_password }}'
-      validate_certs: false
-      tag_names:
-        - category: "{{ cat_one }}"
-          tag: "{{ tag_one }}"
-      moid: "{{ vm_moid }}"
-      object_type: VirtualMachine
-      state: add
-    register: vm_tag_info
+- name: Remove tag to datastore
+  vmware_tag_manager:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    validate_certs: false
+    tag_names:
+      - category: "{{ cat_one }}"
+        tag: "{{ tag_one }}"
+    object_name: "{{ rw_datastore }}"
+    object_type: Datastore
+    state: remove
+  register: datastore_tag_info
 
-  - name: Check if we assigned correct tags
-    assert:
-      that:
-        - vm_tag_info.changed
+- name: Remove tag to given virtual machine
+  vmware_tag_manager:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    validate_certs: false
+    tag_names:
+      - category: "{{ cat_one }}"
+        tag: "{{ tag_one }}"
+    object_name: "{{ vm_name }}"
+    object_type: VirtualMachine
+    state: remove
+  register: vm_tag_info
 
-  - name: Remove tag to datastore
-    vmware_tag_manager:
-      hostname: '{{ vcenter_hostname }}'
-      username: '{{ vcenter_username }}'
-      password: '{{ vcenter_password }}'
-      validate_certs: false
-      tag_names:
-        - category: "{{ cat_one }}"
-          tag: "{{ tag_one }}"
-      object_name: "{{ rw_datastore }}"
-      object_type: Datastore
-      state: remove
-    register: datastore_tag_info
-
-  - name: Remove tag to given virtual machine
-    vmware_tag_manager:
-      hostname: '{{ vcenter_hostname }}'
-      username: '{{ vcenter_username }}'
-      password: '{{ vcenter_password }}'
-      validate_certs: false
-      tag_names:
-        - category: "{{ cat_one }}"
-          tag: "{{ tag_one }}"
-      object_name: "{{ vm_name }}"
-      object_type: VirtualMachine
-      state: remove
-    register: vm_tag_info
-
-  - name: Check if we removed correct tag
-    assert:
-      that:
-        - vm_tag_info.changed
-        - datastore_tag_info.changed
+- name: Check if we removed correct tag
+  assert:
+    that:
+      - vm_tag_info.changed
+      - datastore_tag_info.changed


### PR DESCRIPTION
Depends-on https://github.com/ansible-collections/community.vmware/pull/945

##### SUMMARY
We've disabled the integration tests for `vmware_tag_manager` in PR #930 to get the CI pipeline working again. This PR enables them again.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_tag_manager

##### ADDITIONAL INFORMATION
see [here](https://github.com/ansible-collections/community.vmware/pull/930#issuecomment-875569564)
