### PR TITLE
vmware_vcenter_settings_info: Fix the integration test error

### DIFF
--- a/tests/integration/targets/vmware_vcenter_settings_info/aliases
+++ b/tests/integration/targets/vmware_vcenter_settings_info/aliases
@@ -2,4 +2,3 @@ shippable/vcenter/group1
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
-disabled

--- a/tests/integration/targets/vmware_vcenter_settings_info/tasks/main.yml
+++ b/tests/integration/targets/vmware_vcenter_settings_info/tasks/main.yml
@@ -18,7 +18,7 @@
 - assert:
     that:
       - gather_info_about_vcenter_settings_result.vcenter_config_info is defined
-      - gather_info_about_vcenter_settings_result.vcenter_config_info | length == 34
+      - gather_info_about_vcenter_settings_result.vcenter_config_info | length == 32
 
 - name: "Get a list of information about vCenter settings by specifying the properties"
   vmware_vcenter_settings_info:


### PR DESCRIPTION
Depends-on https://github.com/ansible-collections/community.vmware/pull/945

##### SUMMARY

This PR will fix an issue that the vmware_vcenter_settings_info test has been occurring the error.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

tests/integration/targets/vmware_vcenter_settings_info/tasks/main.yml

##### ADDITIONAL INFORMATION

tested on vCenter 7.0.2