### PR TITLE
Re-enable inventory tests

### DIFF
--- a/tests/integration/targets/inventory_vmware_host_inventory/aliases
+++ b/tests/integration/targets/inventory_vmware_host_inventory/aliases
@@ -1,4 +1,3 @@
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
-disabled

--- a/tests/integration/targets/inventory_vmware_vm_inventory/aliases
+++ b/tests/integration/targets/inventory_vmware_vm_inventory/aliases
@@ -1,4 +1,3 @@
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/govcsim
-disabled


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/community.vmware/pull/950

##### SUMMARY
I've just disabled the integration tests for inventory_vmware_host_inventory and inventory_vmware_vm_inventory in 945 because they kept failing. But I'd like to enable them again ASAP.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
inventory_vmware_host_inventory
inventory_vmware_vm_inventory