### PR TITLE
functional tests run on Ansible 2.11 now

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The collection includes the VMware modules and plugins supported by Ansible VMwa
 <!--start requires_ansible-->
 ## Ansible version compatibility
 
-This collection has been tested against following Ansible core version: **>=2.9.23**.
+This collection has been tested against Ansible 2.11.
 
 Plugins and modules within a collection may be tested with only specific Ansible versions.
 A collection may contain metadata that identifies these versions.


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/989

We are now running the integration tests on Ansible 2.11.