### PR TITLE
vmware_guest_instant_clone: Remove the default of the guestinfo_vars and enable the test

### DIFF
--- a/changelogs/fragments/962-vmware_guest_instant_clone.yml
+++ b/changelogs/fragments/962-vmware_guest_instant_clone.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_guest_instant_clone - fixed an issue that the module should be required the guestinfo_vars parameter when executing (https://github.com/ansible-collections/community.vmware/pull/962).

--- a/docs/community.vmware.vmware_guest_instant_clone_module.rst
+++ b/docs/community.vmware.vmware_guest_instant_clone_module.rst
@@ -105,7 +105,6 @@ Parameters
                     <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.11.0</div>
                 </td>
                 <td>
-                        <b>Default:</b><br/><div style="color: blue">[]</div>
                 </td>
                 <td>
                         <div>Provides GuestOS Customization functionality in instant cloned VM.</div>

--- a/plugins/modules/vmware_guest_instant_clone.py
+++ b/plugins/modules/vmware_guest_instant_clone.py
@@ -129,7 +129,6 @@ options:
           - domain is used to set A fully qualified domain name (FQDN) or complete domain name for Instant Cloned Guest operating System.
         type: str
     version_added: '1.11.0'
-    default: []
     type: list
     elements: dict
   wait_vm_tools:
@@ -543,7 +542,6 @@ def main():
         wait_vm_tools_timeout=dict(type='int', default=300),
         guestinfo_vars=dict(
             type='list',
-            default=[],
             elements='dict',
             options=dict(
                 ipaddress=dict(type='str'),

--- a/tests/integration/targets/vmware_guest_instant_clone/aliases
+++ b/tests/integration/targets/vmware_guest_instant_clone/aliases
@@ -2,4 +2,3 @@ cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
 zuul/vmware/govcsim
-disabled


### PR DESCRIPTION
##### SUMMARY

The cause of the following error occurred is that the default of the guestinfo_vars parameter hadn't been removed.
https://github.com/ansible-collections/community.vmware/pull/958

This PR will fix the issue and re-enable the integration test.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

changelogs/fragments/962-vmware_guest_instant_clone.yml
docs/community.vmware.vmware_guest_instant_clone_module.rst
plugins/modules/vmware_guest_instant_clone.py
tests/integration/targets/vmware_guest_instant_clone/aliases

##### ADDITIONAL INFORMATION

tested on vCenter/ESXi 7.0.2
