### PR TITLE
Revert "tests: disable vmware_guest_instant_clone for now (#958)"

### DIFF
--- a/tests/integration/targets/vmware_guest_instant_clone/aliases
+++ b/tests/integration/targets/vmware_guest_instant_clone/aliases
@@ -2,4 +2,3 @@ cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
 zuul/vmware/govcsim
-disabled


### PR DESCRIPTION
Depends-on https://github.com/ansible-collections/community.vmware/pull/967

This reverts commit 1c84ecae6591273016b3e42e93310aa0ed878593.