### PR TITLE
tests: ensure we can create 'VM Network'

### DIFF
--- a/tests/integration/targets/prepare_vmware_tests/tasks/setup_attach_hosts.yml
+++ b/tests/integration/targets/prepare_vmware_tests/tasks/setup_attach_hosts.yml
@@ -23,6 +23,16 @@
 # be visible by the external switch port. Depending on the
 # antispoofing policy in place, the switch may just decide to block
 # the port.
+- name: Remove any potential existing "VM Network" on vSwitch0
+  vmware_portgroup:
+    esxi_hostname: '{{ item }}'
+    switch: vSwitch0
+    portgroup: VM Network
+    validate_certs: false
+    state: absent
+  ignore_errors: true
+  with_items: "{{ esxi_hosts }}"
+
 - name: Add an isolated VMware vSwitch
   vmware_vswitch:
     hostname: '{{ item }}'

--- a/tests/integration/targets/prepare_vmware_tests/tasks/teardown_with_esxi.yml
+++ b/tests/integration/targets/prepare_vmware_tests/tasks/teardown_with_esxi.yml
@@ -67,16 +67,6 @@
   - isolated_vSwitch
   - vSwitch0
 
-- name: Remove any potential existing "VM Network" on vSwitch0
-  vmware_portgroup:
-    esxi_hostname: '{{ item }}'
-    switch: vSwitch0
-    portgroup: VM Network
-    validate_certs: false
-    state: absent
-  ignore_errors: true
-  with_items: "{{ esxi_hosts }}"
-
 - name: Remove the vSwitches
   vmware_vswitch:
     hostname: '{{ item }}'

--- a/tests/integration/targets/vmware_cluster_info/aliases
+++ b/tests/integration/targets/vmware_cluster_info/aliases
@@ -1,3 +1,3 @@
 cloud/vcenter
 needs/target/prepare_vmware_tests
-zuul/vmware/vcenter_1esxi
+zuul/vmware/vcenter_only


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/community.vmware/pull/961
Depends-On: https://github.com/ansible-collections/community.vmware/pull/967

##### SUMMARY

When we start our tests, VM Network is on vSwitch0. This is
configuration is conflicting when we want to create the same portgroup
on the `isolate_vSwitch0`.
So far, we avoided the conflict because the teardown_with_esxi.yml
playbook was called at the end of the first target and cleaning up the
portgroup.

This is not the case anymore because:
- we randomize¹ the target execution order
- the vmware_cluster_info target does not attach the ESXi host and so
  the teardown was not working as expected.

This commit introduces the following changes:

- alway clean up VM Network from vSwitch0 before we try to recreate
  it on the `isolated_vSwitch0`.
- move vmware_cluster_info in zuul/vmware/vcenter_only where it belongs

e.g: https://9c9a368b55965ac55f2a-ed9c4798e4685666d9a6cb7090f28276.ssl.cf1.rackcdn.com/964/067b5af56b5bda9e4f0542663bbf4560d1899f17/check/ansible-test-cloud-integration-vcenter7_1esxi-python36-stable210_1_of_2/0075174/job-output.txt

¹: well it's a round robin and it remains deterministic

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

CI