### PR TITLE
Improve prepare_vmware_tests

### DIFF
--- a/tests/integration/targets/prepare_vmware_tests/tasks/move_host_out_of_cluster.yml
+++ b/tests/integration/targets/prepare_vmware_tests/tasks/move_host_out_of_cluster.yml
@@ -5,13 +5,9 @@
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     validate_certs: false
-    esxi_hostname: "{{ esxi_hosts.1 }}"
+    esxi_hostname: "{{ item }}"
     state: present
-  register: enter_maintenance_mode_result
-
-- assert:
-    that:
-      - enter_maintenance_mode_result.changed is sameas true
+  with_items: "{{ esxi_hosts }}"
 
 - name: Move ESXi out of Cluster
   vmware_host:
@@ -21,13 +17,9 @@
     validate_certs: false
     datacenter: "{{ dc1 }}"
     folder: "{{ dc1 }}/host"
-    esxi_hostname: "{{ esxi_hosts.1 }}"
+    esxi_hostname: "{{ item }}"
     state: reconnect
-  register: move_esxi_out_of_cluster_result
-
-- assert:
-    that:
-      - move_esxi_out_of_cluster_result.changed is sameas true
+  with_items: "{{ esxi_hosts }}"
 
 - name: Exit maintenance mode
   vmware_maintenancemode:
@@ -35,10 +27,6 @@
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     validate_certs: false
-    esxi_hostname: "{{ esxi_hosts.1 }}"
+    esxi_hostname: "{{ item }}"
     state: absent
-  register: exit_maintenance_mode_result
-
-- assert:
-    that:
-      - exit_maintenance_mode_result.changed is sameas true
+  with_items: "{{ esxi_hosts }}"

--- a/tests/integration/targets/prepare_vmware_tests/tasks/move_host_out_of_cluster.yml
+++ b/tests/integration/targets/prepare_vmware_tests/tasks/move_host_out_of_cluster.yml
@@ -8,6 +8,7 @@
     esxi_hostname: "{{ item }}"
     state: present
   with_items: "{{ esxi_hosts }}"
+  ignore_errors: true
 
 - name: Move ESXi out of Cluster
   vmware_host:
@@ -20,6 +21,7 @@
     esxi_hostname: "{{ item }}"
     state: reconnect
   with_items: "{{ esxi_hosts }}"
+  ignore_errors: true
 
 - name: Exit maintenance mode
   vmware_maintenancemode:
@@ -30,3 +32,4 @@
     esxi_hostname: "{{ item }}"
     state: absent
   with_items: "{{ esxi_hosts }}"
+  ignore_errors: true

--- a/tests/integration/targets/prepare_vmware_tests/tasks/teardown_with_esxi.yml
+++ b/tests/integration/targets/prepare_vmware_tests/tasks/teardown_with_esxi.yml
@@ -87,7 +87,7 @@
   with_items: "{{ esxi_hosts }}"
   ignore_errors: true
 
-- name: Remove ESXi Hosts to vCenter
+- name: Remove ESXi Hosts from vCenter
   vmware_host:
     datacenter_name: '{{ dc1 }}'
     cluster_name: '{{ ccr1 }}'
@@ -98,41 +98,7 @@
   with_items: "{{ esxi_hosts }}"
   ignore_errors: true
 
-- name: Exit maintenance on hosts to allow deletion of vCLS VMs
-  vmware_maintenancemode:
-    hostname: "{{ item }}"
-    username: "{{ esxi_user }}"
-    password: "{{ esxi_password }}"
-    esxi_hostname: "{{ item }}"
-    timeout: 3600
-    state: absent
-  with_items: "{{ esxi_hosts }}"
-  delegate_to: localhost
-
-- name: Gather all remaining VMs on hosts
-  vmware_vm_info:
-    hostname: '{{ item }}'
-    username: '{{ esxi_user }}'
-    password: '{{ esxi_password }}'
-  delegate_to: localhost
-  register: vminfo
-  with_items: "{{ esxi_hosts }}"
-
-- name: Remove remaining any vCLS VMs
-  vmware_guest:
-    hostname: "{{ item.0.item }}"
-    username: '{{ esxi_user }}'
-    password: '{{ esxi_password }}'
-    uuid: "{{ item.1.uuid }}"
-    force: true
-    state: absent
-  delegate_to: localhost
-  with_subelements:
-    - "{{ vminfo.results }}"
-    - virtual_machines
-  when: "'vCLS' in item.1.guest_name"
-
-- name: Umount NFS datastores to ESXi (1/2)
+- name: Umount NFS datastores from ESXi (1/2)
   vmware_host_datastore:
       hostname: '{{ item }}'
       username: '{{ esxi_user }}'
@@ -141,7 +107,7 @@
       state: absent
   with_items: "{{ esxi_hosts }}"
 
-- name: Umount NFS datastores to ESXi (2/2)
+- name: Umount NFS datastores from ESXi (2/2)
   vmware_host_datastore:
       hostname: '{{ item }}'
       username: '{{ esxi_user }}'

--- a/tests/integration/targets/prepare_vmware_tests/tasks/teardown_with_esxi.yml
+++ b/tests/integration/targets/prepare_vmware_tests/tasks/teardown_with_esxi.yml
@@ -87,6 +87,28 @@
   with_items: "{{ esxi_hosts }}"
   ignore_errors: true
 
+- include_tasks: move_host_out_of_cluster.yml
+
+- name: Umount NFS datastores from ESXi (1/2)
+  vmware_host_datastore:
+      hostname: '{{ item }}'
+      username: '{{ esxi_user }}'
+      password: '{{ esxi_password }}'
+      datastore_name: '{{ ro_datastore }}'
+      state: absent
+  with_items: "{{ esxi_hosts }}"
+  ignore_errors: true
+
+- name: Umount NFS datastores from ESXi (2/2)
+  vmware_host_datastore:
+      hostname: '{{ item }}'
+      username: '{{ esxi_user }}'
+      password: '{{ esxi_password }}'
+      datastore_name: '{{ rw_datastore }}'
+      state: absent
+  with_items: "{{ esxi_hosts }}"
+  ignore_errors: true
+
 - name: Remove ESXi Hosts from vCenter
   vmware_host:
     datacenter_name: '{{ dc1 }}'
@@ -97,21 +119,3 @@
     state: absent
   with_items: "{{ esxi_hosts }}"
   ignore_errors: true
-
-- name: Umount NFS datastores from ESXi (1/2)
-  vmware_host_datastore:
-      hostname: '{{ item }}'
-      username: '{{ esxi_user }}'
-      password: '{{ esxi_password }}'
-      datastore_name: '{{ ro_datastore }}'
-      state: absent
-  with_items: "{{ esxi_hosts }}"
-
-- name: Umount NFS datastores from ESXi (2/2)
-  vmware_host_datastore:
-      hostname: '{{ item }}'
-      username: '{{ esxi_user }}'
-      password: '{{ esxi_password }}'
-      datastore_name: '{{ rw_datastore }}'
-      state: absent
-  with_items: "{{ esxi_hosts }}"

--- a/tests/integration/targets/vmware_resource_pool/tasks/main.yml
+++ b/tests/integration/targets/vmware_resource_pool/tasks/main.yml
@@ -8,6 +8,7 @@
     setup_attach_host: true
     setup_resource_pool: true
 
+# Tests on cluster
 - name: set the vmware_resource_pool module default values
   module_defaults:
     vmware_resource_pool:
@@ -216,6 +217,7 @@
           - resource_result_014.changed is sameas false
           - resource_result_014.resource_pool_config is defined
 
+# Tests on ESXi host
 - name: set the vmware_resource_pool module default values without cluster parameter
   module_defaults:
     vmware_resource_pool:
@@ -227,6 +229,36 @@
       esxi_hostname: "{{ esxi2 }}"
 
   block:
+    # Remove ESXi host from cluster for tests
+    - name: Enter maintenance mode
+      vmware_maintenancemode:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        esxi_hostname: "{{ esxi2 }}"
+        state: present
+
+    - name: Move ESXi out of Cluster
+      vmware_host:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        datacenter: "{{ dc1 }}"
+        folder: "{{ dc1 }}/host"
+        esxi_hostname: "{{ esxi2 }}"
+        state: reconnect
+
+    - name: Exit maintenance mode
+      vmware_maintenancemode:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        esxi_hostname: "{{ esxi2 }}"
+        state: absent
+
     - name: add resource pool to ESXi with check_mode
       vmware_resource_pool:
         resource_pool: test_resource_015

--- a/tests/integration/targets/vmware_resource_pool/tasks/main.yml
+++ b/tests/integration/targets/vmware_resource_pool/tasks/main.yml
@@ -7,7 +7,6 @@
   vars:
     setup_attach_host: true
     setup_resource_pool: true
-    move_host_out_of_cluster: true
 
 - name: set the vmware_resource_pool module default values
   module_defaults:

--- a/tests/integration/targets/vmware_resource_pool/tasks/main.yml
+++ b/tests/integration/targets/vmware_resource_pool/tasks/main.yml
@@ -6,7 +6,6 @@
     name: prepare_vmware_tests
   vars:
     setup_attach_host: true
-    setup_datastore: true
     setup_resource_pool: true
     move_host_out_of_cluster: true
 


### PR DESCRIPTION
Depends-on https://github.com/ansible/ansible-zuul-jobs/pull/989

##### SUMMARY
This might cause problems:

https://github.com/ansible-collections/community.vmware/blob/418b090f528aed924c685ce963e5de17e2082328/tests/integration/targets/prepare_vmware_tests/tasks/teardown_with_esxi.yml#L90-L110

If removing the ESXi host succeeds, exiting maintenance mode fails because the host isn't known to vCenter any more.

Fixes https://github.com/ansible-collections/community.vmware/issues/952

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tests/integration/targets/prepare_vmware_tests/tasks/teardown_with_esxi.yml

##### ADDITIONAL INFORMATION
Removing all ESXi hosts from the cluster befor removing them from vCenter avoids problems with vCLS VMs. Unfortunatelly, this change broke the `vmware_resource_pool` integration tests so I had to fix this, too.