### PR TITLE
tests: address the stability problem with vmware_guest

### DIFF
--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -1482,52 +1482,51 @@ class PyVmomiHelper(PyVmomi):
                 self.change_detected = True
 
         temp_version = self.params['hardware']['version']
-        if temp_version is not None:
-            if temp_version.lower() == 'latest':
-                # Check is to make sure vm_obj is not of type template
-                if vm_obj and not vm_obj.config.template:
-                    try:
-                        task = vm_obj.UpgradeVM_Task()
-                        self.wait_for_task(task)
-                        if task.info.state == 'error':
-                            return {'changed': self.change_applied, 'failed': True, 'msg': task.info.error.msg, 'op': 'upgrade'}
-                    except vim.fault.AlreadyUpgraded:
-                        # Don't fail if VM is already upgraded.
-                        pass
-            else:
+        if temp_version.lower() == 'latest':
+            # Check is to make sure vm_obj is not of type template
+            if vm_obj and not vm_obj.config.template:
                 try:
-                    temp_version = int(temp_version)
-                except ValueError:
-                    self.module.fail_json(msg="Failed to set hardware.version '%s' value as valid"
-                                          " values are either 'latest' or a number."
-                                          " Please check VMware documentation for valid VM hardware versions." % temp_version)
+                    task = vm_obj.UpgradeVM_Task()
+                    self.wait_for_task(task)
+                    if task.info.state == 'error':
+                        return {'changed': self.change_applied, 'failed': True, 'msg': task.info.error.msg, 'op': 'upgrade'}
+                except vim.fault.AlreadyUpgraded:
+                    # Don't fail if VM is already upgraded.
+                    pass
+        else:
+            try:
+                temp_version = int(temp_version)
+            except ValueError:
+                self.module.fail_json(msg="Failed to set hardware.version '%s' value as valid"
+                                      " values are either 'latest' or a number."
+                                      " Please check VMware documentation for valid VM hardware versions." % temp_version)
 
-                # Hardware version is denoted as "vmx-10"
-                version = "vmx-%02d" % temp_version
-                self.configspec.version = version
-                if vm_obj is None or self.configspec.version != vm_obj.config.version:
-                    self.change_detected = True
-                # Check is to make sure vm_obj is not of type template
-                if vm_obj and not vm_obj.config.template:
-                    # VM exists and we need to update the hardware version
-                    current_version = vm_obj.config.version
-                    # current_version = "vmx-10"
-                    version_digit = int(current_version.split("-", 1)[-1])
-                    if temp_version < version_digit:
-                        self.module.fail_json(msg="Current hardware version '%d' which is greater than the specified"
-                                              " version '%d'. Downgrading hardware version is"
-                                              " not supported. Please specify version greater"
-                                              " than the current version." % (version_digit,
-                                                                              temp_version))
-                    new_version = "vmx-%02d" % temp_version
-                    try:
-                        task = vm_obj.UpgradeVM_Task(new_version)
-                        self.wait_for_task(task)
-                        if task.info.state == 'error':
-                            return {'changed': self.change_applied, 'failed': True, 'msg': task.info.error.msg, 'op': 'upgrade'}
-                    except vim.fault.AlreadyUpgraded:
-                        # Don't fail if VM is already upgraded.
-                        pass
+            # Hardware version is denoted as "vmx-10"
+            version = "vmx-%02d" % temp_version
+            self.configspec.version = version
+            if vm_obj is None or self.configspec.version != vm_obj.config.version:
+                self.change_detected = True
+            # Check is to make sure vm_obj is not of type template
+            if vm_obj and not vm_obj.config.template:
+                # VM exists and we need to update the hardware version
+                current_version = vm_obj.config.version
+                # current_version = "vmx-10"
+                version_digit = int(current_version.split("-", 1)[-1])
+                if temp_version < version_digit:
+                    self.module.fail_json(msg="Current hardware version '%d' which is greater than the specified"
+                                          " version '%d'. Downgrading hardware version is"
+                                          " not supported. Please specify version greater"
+                                          " than the current version." % (version_digit,
+                                                                          temp_version))
+                new_version = "vmx-%02d" % temp_version
+                try:
+                    task = vm_obj.UpgradeVM_Task(new_version)
+                    self.wait_for_task(task)
+                    if task.info.state == 'error':
+                        return {'changed': self.change_applied, 'failed': True, 'msg': task.info.error.msg, 'op': 'upgrade'}
+                except vim.fault.AlreadyUpgraded:
+                    # Don't fail if VM is already upgraded.
+                    pass
 
         secure_boot = self.params['hardware']['secure_boot']
         if secure_boot is not None:
@@ -3166,7 +3165,7 @@ def main():
                 num_cpus=dict(type='int'),
                 scsi=dict(type='str', choices=['buslogic', 'lsilogic', 'lsilogicsas', 'paravirtual']),
                 secure_boot=dict(type='bool'),
-                version=dict(type='str'),
+                version=dict(type='str', default='14'),
                 virt_based_security=dict(type='bool'),
                 iommu=dict(type='bool')
             )),

--- a/tests/integration/targets/prepare_vmware_tests/tasks/setup_virtualmachines.yml
+++ b/tests/integration/targets/prepare_vmware_tests/tasks/setup_virtualmachines.yml
@@ -16,7 +16,7 @@
       scsi: paravirtual
     cdrom:
       type: iso
-      iso_path: "[{{ ro_datastore }}] fedora.iso"
+      iso_path: "[{{ ro_datastore }}] freebsd13.iso"
     networks:
     - name: VM Network
   with_items: '{{ virtual_machines }}'
@@ -40,7 +40,7 @@
       scsi: paravirtual
     cdrom:
       type: iso
-      iso_path: "[{{ ro_datastore }}] fedora.iso"
+      iso_path: "[{{ ro_datastore }}] freebsd13.iso"
     networks:
     - name: VM Network
   with_items: '{{ virtual_machines_in_cluster }}'

--- a/tests/integration/targets/vmware_first_class_disk/aliases
+++ b/tests/integration/targets/vmware_first_class_disk/aliases
@@ -1,4 +1,4 @@
 cloud/vcenter
 needs/target/prepare_vmware_tests
-zuul/vmware/vcenter_1esxi_with_nested
+zuul/vmware/vcenter_1esxi
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest/aliases
+++ b/tests/integration/targets/vmware_guest/aliases
@@ -1,4 +1,4 @@
 cloud/vcenter
 needs/target/prepare_vmware_tests
-zuul/vmware/vcenter_1esxi_with_nested
+zuul/vmware/vcenter_1esxi
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest/tasks/cdrom_d1_c1_f0.yml
+++ b/tests/integration/targets/vmware_guest/tasks/cdrom_d1_c1_f0.yml
@@ -43,7 +43,7 @@
     datacenter: "{{ dc1 }}"
     cdrom:
       type: iso
-      iso_path: "[{{ ro_datastore }}] fedora.iso"
+      iso_path: "[{{ ro_datastore }}] freebsd13.iso"
     state: present
   register: cdrom_vm
 
@@ -137,7 +137,7 @@
       datastore: "{{ rw_datastore }}"
     cdrom:
       type: iso
-      iso_path: "[{{ ro_datastore }}] fedora.iso"
+      iso_path: "[{{ ro_datastore }}] freebsd13.iso"
   register: cdrom_vm
 
 - debug: var=cdrom_vm

--- a/tests/integration/targets/vmware_guest/tasks/cdrom_d1_c1_f1.yml
+++ b/tests/integration/targets/vmware_guest/tasks/cdrom_d1_c1_f1.yml
@@ -63,7 +63,7 @@
       controller_number: 0
       unit_number: 1
       type: iso
-      iso_path: "[{{ ro_datastore }}] fedora.iso"
+      iso_path: "[{{ ro_datastore }}] freebsd13.iso"
     - controller_type: ide
       controller_number: 1
       unit_number: 0
@@ -155,7 +155,7 @@
       controller_number: 3
       unit_number: 1
       type: iso
-      iso_path: "[{{ ro_datastore }}] fedora.iso"
+      iso_path: "[{{ ro_datastore }}] freebsd13.iso"
     state: present
   register: cdrom_vm
 
@@ -231,7 +231,7 @@
       controller_number: 0
       unit_number: 0
       type: iso
-      iso_path: "[{{ ro_datastore }}] fedora.iso"
+      iso_path: "[{{ ro_datastore }}] freebsd13.iso"
     - controller_type: ide
       controller_number: 1
       unit_number: 0

--- a/tests/integration/targets/vmware_guest/tasks/template_d1_c1_f0.yml
+++ b/tests/integration/targets/vmware_guest/tasks/template_d1_c1_f0.yml
@@ -19,7 +19,7 @@
       scsi: paravirtual
     cdrom:
       type: iso
-      iso_path: "[{{ ro_datastore }}] fedora.iso"
+      iso_path: "[{{ ro_datastore }}] freebsd13.iso"
     networks:
     - name: VM Network
 

--- a/tests/integration/targets/vmware_guest_disk_info/aliases
+++ b/tests/integration/targets/vmware_guest_disk_info/aliases
@@ -1,4 +1,4 @@
 cloud/vcenter
 needs/target/prepare_vmware_tests
-zuul/vmware/vcenter_1esxi_with_nested
+zuul/vmware/vcenter_1esxi
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest_instant_clone/aliases
+++ b/tests/integration/targets/vmware_guest_instant_clone/aliases
@@ -1,5 +1,5 @@
 cloud/vcenter
 needs/target/prepare_vmware_tests
-zuul/vmware/vcenter_1esxi_with_nested
+zuul/vmware/vcenter_1esxi
 zuul/vmware/govcsim
 disabled

--- a/tests/integration/targets/vmware_guest_network/aliases
+++ b/tests/integration/targets/vmware_guest_network/aliases
@@ -1,4 +1,4 @@
 cloud/vcenter
 needs/target/prepare_vmware_tests
-zuul/vmware/vcenter_1esxi_with_nested
+zuul/vmware/vcenter_1esxi
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest_network/tasks/main.yml
+++ b/tests/integration/targets/vmware_guest_network/tasks/main.yml
@@ -34,7 +34,7 @@
         scsi: paravirtual
       cdrom:
         type: iso
-        iso_path: "[{{ ro_datastore }}] fedora.iso"
+        iso_path: "[{{ ro_datastore }}] freebsd13.iso"
       networks:
       - name: VM Network
 

--- a/tests/integration/targets/vmware_guest_powerstate/aliases
+++ b/tests/integration/targets/vmware_guest_powerstate/aliases
@@ -1,4 +1,4 @@
 cloud/vcenter
 needs/target/prepare_vmware_tests
-zuul/vmware/vcenter_1esxi_with_nested
+zuul/vmware/vcenter_1esxi
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest_powerstate/tasks/main.yml
+++ b/tests/integration/targets/vmware_guest_powerstate/tasks/main.yml
@@ -29,7 +29,7 @@
       scsi: paravirtual
     cdrom:
       type: iso
-      iso_path: "[{{ ro_datastore }}] fedora.iso"
+      iso_path: "[{{ ro_datastore }}] freebsd13.iso"
     networks:
     - name: VM Network
 

--- a/tests/integration/targets/vmware_guest_screenshot/aliases
+++ b/tests/integration/targets/vmware_guest_screenshot/aliases
@@ -1,4 +1,4 @@
 cloud/vcenter
 needs/target/prepare_vmware_tests
-zuul/vmware/vcenter_1esxi_with_nested
+zuul/vmware/vcenter_1esxi
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest_tools_wait/aliases
+++ b/tests/integration/targets/vmware_guest_tools_wait/aliases
@@ -1,3 +1,3 @@
 cloud/vcenter
 needs/target/prepare_vmware_tests
-zuul/vmware/vcenter_1esxi_with_nested
+zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_guest_tools_wait/tasks/main.yml
+++ b/tests/integration/targets/vmware_guest_tools_wait/tasks/main.yml
@@ -34,7 +34,7 @@
         scsi: paravirtual
       cdrom:
         type: iso
-        iso_path: "[{{ ro_datastore }}] fedora.iso"
+        iso_path: "[{{ ro_datastore }}] freebsd13.iso"
       networks:
       - name: VM Network
 

--- a/tests/integration/targets/vmware_vm_inventory/aliases
+++ b/tests/integration/targets/vmware_vm_inventory/aliases
@@ -1,2 +1,3 @@
 cloud/vcenter
-zuul/vmware/vcenter_1esxi_with_nested
+needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_1esxi


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/994
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1001
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1000

##### ISSUE TYPE

It seems we've got much better results if we use FreeBSD13 for our
guest VMs.

This commit re-enables
https://github.com/ansible-collections/community.vmware/pull/957.

Also, ensures vmware_vm_inventory get access to prepare_vmware_tests.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->


<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

tests