### PR TITLE
Revert "Revert PR 957 (#967)"

### DIFF
--- a/tests/integration/targets/vmware_first_class_disk/aliases
+++ b/tests/integration/targets/vmware_first_class_disk/aliases
@@ -1,4 +1,4 @@
 cloud/vcenter
 needs/target/prepare_vmware_tests
-zuul/vmware/vcenter_1esxi_with_nested
+zuul/vmware/vcenter_1esxi
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest/aliases
+++ b/tests/integration/targets/vmware_guest/aliases
@@ -1,4 +1,4 @@
 cloud/vcenter
 needs/target/prepare_vmware_tests
-zuul/vmware/vcenter_1esxi_with_nested
+zuul/vmware/vcenter_1esxi
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest_disk_info/aliases
+++ b/tests/integration/targets/vmware_guest_disk_info/aliases
@@ -1,4 +1,4 @@
 cloud/vcenter
 needs/target/prepare_vmware_tests
-zuul/vmware/vcenter_1esxi_with_nested
+zuul/vmware/vcenter_1esxi
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest_instant_clone/aliases
+++ b/tests/integration/targets/vmware_guest_instant_clone/aliases
@@ -1,5 +1,5 @@
 cloud/vcenter
 needs/target/prepare_vmware_tests
-zuul/vmware/vcenter_1esxi_with_nested
+zuul/vmware/vcenter_1esxi
 zuul/vmware/govcsim
 disabled

--- a/tests/integration/targets/vmware_guest_network/aliases
+++ b/tests/integration/targets/vmware_guest_network/aliases
@@ -1,4 +1,4 @@
 cloud/vcenter
 needs/target/prepare_vmware_tests
-zuul/vmware/vcenter_1esxi_with_nested
+zuul/vmware/vcenter_1esxi
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest_powerstate/aliases
+++ b/tests/integration/targets/vmware_guest_powerstate/aliases
@@ -1,4 +1,4 @@
 cloud/vcenter
 needs/target/prepare_vmware_tests
-zuul/vmware/vcenter_1esxi_with_nested
+zuul/vmware/vcenter_1esxi
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest_screenshot/aliases
+++ b/tests/integration/targets/vmware_guest_screenshot/aliases
@@ -1,4 +1,4 @@
 cloud/vcenter
 needs/target/prepare_vmware_tests
-zuul/vmware/vcenter_1esxi_with_nested
+zuul/vmware/vcenter_1esxi
 zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_guest_tools_wait/aliases
+++ b/tests/integration/targets/vmware_guest_tools_wait/aliases
@@ -1,3 +1,3 @@
 cloud/vcenter
 needs/target/prepare_vmware_tests
-zuul/vmware/vcenter_1esxi_with_nested
+zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_vm_inventory/aliases
+++ b/tests/integration/targets/vmware_vm_inventory/aliases
@@ -1,2 +1,2 @@
 cloud/vcenter
-zuul/vmware/vcenter_1esxi_with_nested
+zuul/vmware/vcenter_1esxi


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1001
Depends-on https://github.com/ansible-collections/community.vmware/pull/971

Re-enable the jobs depending on nested virt.

See: https://github.com/ansible/ansible-zuul-jobs/pull/1001

This reverts commit ddcee83f76ccfadd751a5e3be5723d44c472aed1.