### PR TITLE
Fix vmware_vmkernel_ip_config integration tests

### DIFF
--- a/tests/integration/targets/vmware_vmkernel_ip_config/tasks/main.yml
+++ b/tests/integration/targets/vmware_vmkernel_ip_config/tasks/main.yml
@@ -6,6 +6,7 @@
     name: prepare_vmware_tests
   vars:
     setup_attach_host: true
+    setup_switch: true
 
 - name: "Prepare integration tests for vmware_vmkernel_ip_config module"
   block:
@@ -37,24 +38,6 @@
         validate_certs: false
         esxi_hostname: "{{ esxi1 }}"
       register: gather_vswitch_info_result
-
-    - name: "Create a new vSwitch block"
-      when:
-        - "not '{{ switch1 }}' in gather_vswitch_info_result.hosts_vswitch_info[esxi1]"
-      block:
-        - name: "Create a new vSwitch"
-          vmware_vswitch:
-            hostname: "{{ esxi1 }}"
-            username: "{{ esxi_user }}"
-            password: "{{ esxi_password }}"
-            validate_certs: false
-            esxi_hostname: "{{ esxi1 }}"
-            switch: "{{ switch1 }}"
-          register: create_new_vswitch_result
-
-        - assert:
-            that:
-              - create_new_vswitch_result.changed is sameas true
 
     - name: "Create a new port group of vSwitch"
       vmware_portgroup:


### PR DESCRIPTION
The vmware_vmkernel_ip_config integration tests fail:

```
2021-07-21 19:28:19.449213 | fedora-34 | TASK [vmware_vmkernel_ip_config : Create a new vSwitch] ************************
2021-07-21 19:28:19.449386 | fedora-34 | task path: /home/zuul/.ansible/collections/ansible_collections/community/vmware/tests/integration/targets/vmware_vmkernel_ip_config/tasks/main.yml:45
2021-07-21 19:28:19.455846 | fedora-34 | [WARNING]: conditional statements should not include jinja2 templating
2021-07-21 19:28:19.455894 | fedora-34 | delimiters such as {{ }} or {% %}. Found: not '{{ switch1 }}' in
2021-07-21 19:28:19.455899 | fedora-34 | gather_vswitch_info_result.hosts_vswitch_info[esxi1]
2021-07-21 19:28:19.463763 | fedora-34 | fatal: [testhost]: FAILED! => {
2021-07-21 19:28:19.463791 | fedora-34 |     "msg": "The conditional check 'not '{{ switch1 }}' in gather_vswitch_info_result.hosts_vswitch_info[esxi1]' failed. The error was: error while evaluating conditional (not '{{ switch1 }}' in gather_vswitch_info_result.hosts_vswitch_info[esxi1]): 'dict object' has no attribute 'esxi1.test'\n\nThe error appears to be in '/home/zuul/.ansible/collections/ansible_collections/community/vmware/tests/integration/targets/vmware_vmkernel_ip_config/tasks/main.yml': line 45, column 11, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n      block:\n        - name: \"Create a new vSwitch\"\n          ^ here\n"
2021-07-21 19:28:19.463805 | fedora-34 | }
```
[log](https://08057894eb5030a705b6-a6e1266ba6585f44f4a4038dc47792b6.ssl.cf1.rackcdn.com/936/1f822e68e01ec457ef08102167f8d9f71db3dafe/check/ansible-test-cloud-integration-vcenter7_1esxi-python36-stable211_1_of_2/42578e2/job-output.txt)

I'm not sure why this started to fail, may have something to do with running the integration tests on Ansible 2.11 now (ansible/ansible-zuul-jobs#989).