### PR TITLE
vmware_guest: clarify hw version's default is latest

### DIFF
--- a/changelogs/fragments/hardware_version_defaults_to_latest.yaml
+++ b/changelogs/fragments/hardware_version_defaults_to_latest.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- "vmware_guest - clarify that the default hardware version is latest."

--- a/changelogs/fragments/hardware_version_defaults_to_latest.yaml
+++ b/changelogs/fragments/hardware_version_defaults_to_latest.yaml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-- "vmware_guest - clarify that the default hardware version is latest."
+- vmware_guest - clarify that the default hardware version is ``latest`` (https://github.com/ansible-collections/community.vmware/pull/973).

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -190,7 +190,7 @@ options:
             type: str
             description:
             - The Virtual machine hardware versions.
-            - Default is C(latest)
+            - Default is C(latest). Defaulting to C(latest) is added in 1.15.0.
             - If set to C(latest), the specified virtual machine will be upgraded to the most current hardware version supported on the host.
             - C(latest) is added in Ansible 2.10.
             - Please check VMware documentation for correct virtual machine hardware version.


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1255

##### SUMMARY

I'm not totally sure this is the expected behaviour, but right now, the
default hardware.version is `latest`. This commit clarify this and
simplify the code a bit.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_guest