### PR TITLE
vmware_host_datastore: The right error message doesn't be displayed

### DIFF
--- a/changelogs/fragments/976-vmware_host_datastore.yml
+++ b/changelogs/fragments/976-vmware_host_datastore.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_host_datastore - fixed an issue that the right error message isn't displayed (https://github.com/ansible-collections/community.vmware/pull/976).

--- a/plugins/modules/vmware_host_datastore.py
+++ b/plugins/modules/vmware_host_datastore.py
@@ -346,12 +346,11 @@ def main():
     module = AnsibleModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
-        required_together=[
-            ['nfs_server', 'nfs_path']
-        ],
         required_if=[
             ['state', 'present', ['datastore_type']],
-            ['datastore_type', 'vmfs', ['vmfs_device_name']]
+            ['datastore_type', 'vmfs', ['vmfs_device_name']],
+            ['datastore_type', 'nfs', ['nfs_server', 'nfs_path']],
+            ['datastore_type', 'nfs41', ['nfs_server', 'nfs_path']],
         ]
     )
 

--- a/plugins/modules/vmware_host_datastore.py
+++ b/plugins/modules/vmware_host_datastore.py
@@ -349,21 +349,11 @@ def main():
         required_together=[
             ['nfs_server', 'nfs_path']
         ],
+        required_if=[
+            ['state', 'present', ['datastore_type']],
+            ['datastore_type', 'vmfs', ['vmfs_device_name']]
+        ]
     )
-
-    # more complex required_if
-    if module.params['state'] == 'present':
-        if module.params['datastore_type'] == 'nfs' and not module.params['nfs_server']:
-            msg = "Missing nfs_server with datastore_type = nfs"
-            module.fail_json(msg=msg)
-
-        if module.params['datastore_type'] == 'nfs41' and not module.params['nfs_server']:
-            msg = "Missing nfs_server with datastore_type = nfs41"
-            module.fail_json(msg=msg)
-
-        if module.params['datastore_type'] == 'vmfs' and not module.params['vmfs_device_name']:
-            msg = "Missing vmfs_device_name with datastore_type = vmfs"
-            module.fail_json(msg=msg)
 
     vmware_host_datastore = VMwareHostDatastore(module)
     vmware_host_datastore.process_state()


### PR DESCRIPTION
##### SUMMARY

The following error occurs in executing the module when datastore_type parameter doesn't specify and state is present.  
In the following error, the users can't understand the cause of the error.

```
fatal: [localhost]: FAILED! => {"changed": false, "msg": "New-style module did not handle its own exit"}
```

The error message isn't the right error expression.  
So, this PR will fix to be displayed the right error message.

Also, I removed unused the following processing in the module because it can be covered required_if.

The following codes will be covered by required_if.

```python
    if module.params['state'] == 'present':
        if module.params['datastore_type'] == 'nfs' and not module.params['nfs_server']:
            msg = "Missing nfs_server with datastore_type = nfs"
            module.fail_json(msg=msg)

        if module.params['datastore_type'] == 'nfs41' and not module.params['nfs_server']:
            msg = "Missing nfs_server with datastore_type = nfs41"
            module.fail_json(msg=msg)

        if module.params['datastore_type'] == 'vmfs' and not module.params['vmfs_device_name']:
            msg = "Missing vmfs_device_name with datastore_type = vmfs"
            module.fail_json(msg=msg)
```

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

changelogs/fragments/976-vmware_host_datastore.yml
plugins/modules/vmware_host_datastore.py

##### ADDITIONAL INFORMATION

tested on vCenter/ESXi 7.0.2
