### PR TITLE
vmware_portgroup: Improve parameter sanity

### DIFF
--- a/changelogs/fragments/955-vmware_portgroup.yml
+++ b/changelogs/fragments/955-vmware_portgroup.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- vmware_portgroup - Disable traffic shaping without defining ``traffic_shaping.average_bandwidth``, ``traffic_shaping.burst_size`` and ``traffic_shaping.peak_bandwidth`` (https://github.com/ansible-collections/community.vmware/issues/955).

--- a/plugins/modules/vmware_portgroup.py
+++ b/plugins/modules/vmware_portgroup.py
@@ -296,12 +296,13 @@ class VMwareHostPortGroup(PyVmomi):
             self.sec_mac_changes = None
         if self.params['traffic_shaping']:
             self.ts_enabled = self.params['traffic_shaping'].get('enabled')
-            for value in ['average_bandwidth', 'peak_bandwidth', 'burst_size']:
-                if not self.params['traffic_shaping'].get(value):
-                    self.module.fail_json(msg="traffic_shaping.%s is a required parameter if traffic_shaping is enabled." % value)
-            self.ts_average_bandwidth = self.params['traffic_shaping'].get('average_bandwidth')
-            self.ts_peak_bandwidth = self.params['traffic_shaping'].get('peak_bandwidth')
-            self.ts_burst_size = self.params['traffic_shaping'].get('burst_size')
+            if self.ts_enabled is True:
+                for value in ['average_bandwidth', 'peak_bandwidth', 'burst_size']:
+                    if not self.params['traffic_shaping'].get(value):
+                        self.module.fail_json(msg="traffic_shaping.%s is a required parameter if traffic_shaping is enabled." % value)
+                self.ts_average_bandwidth = self.params['traffic_shaping'].get('average_bandwidth')
+                self.ts_peak_bandwidth = self.params['traffic_shaping'].get('peak_bandwidth')
+                self.ts_burst_size = self.params['traffic_shaping'].get('burst_size')
         else:
             self.ts_enabled = None
             self.ts_average_bandwidth = None
@@ -641,11 +642,6 @@ class VMwareHostPortGroup(PyVmomi):
                     changed = True
                     changed_list.append("Traffic shaping")
                     host_results['traffic_shaping_previous'] = False
-                elif self.ts_enabled is False:
-                    changed = True
-                    changed_list.append("Traffic shaping")
-                    host_results['traffic_shaping_previous'] = True
-                    spec.policy.shapingPolicy.enabled = False
                 elif self.ts_enabled is None:
                     spec.policy.shapingPolicy = None
                     changed = True

--- a/tests/integration/targets/vmware_portgroup/tasks/main.yml
+++ b/tests/integration/targets/vmware_portgroup/tasks/main.yml
@@ -110,7 +110,7 @@
 
     - assert:
         that:
-          - delete_portgroup_with_traffic_shaping_result.changed
+          - disable_traffic_shaping_result.changed
 
     - name: Integration test a PortGroup name with special characters
       block:

--- a/tests/integration/targets/vmware_portgroup/tasks/main.yml
+++ b/tests/integration/targets/vmware_portgroup/tasks/main.yml
@@ -72,6 +72,46 @@
         that:
           - pg_info.changed
 
+    - name: Create portgroup with traffic shaping
+      vmware_portgroup:
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        vswitch: '{{ switch1 }}'
+        portgroup: 'pg_ts'
+        cluster_name: "{{ ccr1 }}"
+        traffic_shaping:
+          enabled: true
+          average_bandwidth: 100000
+          peak_bandwidth: 100000
+          burst_size: 102400
+        validate_certs: false
+        state: present
+      register: create_portgroup_with_traffic_shaping_result
+
+    - assert:
+        that:
+          - create_portgroup_with_traffic_shaping_result.changed
+
+    # Issue 955
+    - name: Disable traffic shaping
+      vmware_portgroup:
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        vswitch: '{{ switch1 }}'
+        portgroup: 'pg_ts'
+        cluster_name: "{{ ccr1 }}"
+        traffic_shaping:
+          enabled: false
+        validate_certs: false
+        state: present
+      register: disable_traffic_shaping_result
+
+    - assert:
+        that:
+          - delete_portgroup_with_traffic_shaping_result.changed
+
     - name: Integration test a PortGroup name with special characters
       block:
         - name: Create Switch with special characters


### PR DESCRIPTION
##### SUMMARY
It doesn't really make sense that vmware_portgroup requires `traffic_shaping.average_bandwidth`, `traffic_shaping.peak_bandwidth` and `traffic_shaping.burst_size` if people want to _disable_ traffic shaping.

Fixes #955

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_portgroup

##### ADDITIONAL INFORMATION
See #955 for more information.