### PR TITLE
Add quiesced status in snapshot info

### DIFF
--- a/changelogs/fragments/978-vmware_guest_snapshot_info.yml
+++ b/changelogs/fragments/978-vmware_guest_snapshot_info.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_guest_snapshot_info - add quiesced status in VM snapshot info (https://github.com/ansible-collections/community.vmware/pull/978)

--- a/plugins/module_utils/vmware.py
+++ b/plugins/module_utils/vmware.py
@@ -592,7 +592,8 @@ def deserialize_snapshot_obj(obj):
             'name': obj.name,
             'description': obj.description,
             'creation_time': obj.createTime,
-            'state': obj.state}
+            'state': obj.state,
+            'quiesced': obj.quiesced}
 
 
 def list_snapshots_recursively(snapshots):

--- a/plugins/modules/vmware_guest_snapshot_info.py
+++ b/plugins/modules/vmware_guest_snapshot_info.py
@@ -105,7 +105,8 @@ guest_snapshots:
             "description": "",
             "id": 28,
             "name": "snap_0003",
-            "state": "poweredOff"
+            "state": "poweredOff",
+            "quiesced": false
         },
         "snapshots": [
             {
@@ -113,7 +114,8 @@ guest_snapshots:
                 "description": "",
                 "id": 28,
                 "name": "snap_0003",
-                "state": "poweredOff"
+                "state": "poweredOff",
+                "quiesced": false
             }
         ]
     }


### PR DESCRIPTION
Signed-off-by: dianew <dianew@vmware.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Besides below snapshot info, add `quiesced`, e.g.,
```
"guest_snapshots": {
            "current_snapshot": {
                "creation_time": "2021-07-20T09:41:48.870077+00:00",
                "description": "",
                "id": 5,
                "name": "quiesce_snapshot_1626774041",
                "state": "poweredOff",
                "quiesced": true
            },
...
```


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_guest_snapshot_info

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
