### PR TITLE
[WIP] vmware_vcenter_settings: The module can't set a value when the value is bool

### DIFF
--- a/changelogs/fragments/981-vmware_vcenter_settings.yml
+++ b/changelogs/fragments/981-vmware_vcenter_settings.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_vcenter_settings - fixed an issue that the value converts to integer when it is bool (https://github.com/ansible-collections/community.vmware/pull/981).

--- a/plugins/modules/vmware_vcenter_settings.py
+++ b/plugins/modules/vmware_vcenter_settings.py
@@ -516,7 +516,7 @@ class VmwareVcenterSettings(PyVmomi):
         result['diff'] = {}
 
         advanced_settings = self.params['advanced_settings']
-        changed_advanced_settings = option_diff(advanced_settings, self.option_manager.setting, False)
+        changed_advanced_settings = option_diff(advanced_settings, self.option_manager.setting)
 
         if changed_advanced_settings:
             changed = True


### PR DESCRIPTION
##### SUMMARY

The module has a bug that the value converts to integer when the configuration has bool.  
To solve the issue, truthy_strings_as_bool argument should be True for option_diff method.

fixes: https://github.com/ansible-collections/community.vmware/issues/980

By the way, the processing was implemented by @mariolenz, I believe.  
https://github.com/ansible-collections/community.vmware/blob/634ec3b9862e07cf7b390a6c1680d15348af0c33/plugins/modules/vmware_vcenter_settings.py#L519

If you don't mind, could you please tell me why the argument is False?  
(Maybe I'm understanding wrong, but...)

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

changelogs/fragments/981-vmware_vcenter_settings.yml
plugins/modules/vmware_vcenter_settings.py

##### ADDITIONAL INFORMATION

tested on vCenter/ESXi 7.0.2