### PR TITLE
vmware: Change to use from isinstance to type in if condition

### DIFF
--- a/changelogs/fragments/983-vmware.yml
+++ b/changelogs/fragments/983-vmware.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware - changed to use from isinstance to type in the if condition of option_diff method (https://github.com/ansible-collections/community.vmware/pull/983).

--- a/plugins/module_utils/vmware.py
+++ b/plugins/module_utils/vmware.py
@@ -1048,11 +1048,11 @@ def option_diff(options, current_options, truthy_strings_as_bool=True):
     for option_key, option_value in options.items():
         if truthy_strings_as_bool and is_boolean(option_value):
             option_value = VmomiSupport.vmodlTypes['bool'](is_truthy(option_value))
-        elif isinstance(option_value, int):
+        elif type(option_value) is int:
             option_value = VmomiSupport.vmodlTypes['int'](option_value)
-        elif isinstance(option_value, float):
+        elif type(option_value) is float:
             option_value = VmomiSupport.vmodlTypes['float'](option_value)
-        elif isinstance(option_value, str):
+        elif type(option_value) is str:
             option_value = VmomiSupport.vmodlTypes['string'](option_value)
 
         if option_key not in current_options_dict or current_options_dict[option_key] != option_value:

--- a/tests/unit/module_utils/test_vmware.py
+++ b/tests/unit/module_utils/test_vmware.py
@@ -229,6 +229,7 @@ def test_connect_to_api_validate_certs(monkeypatch, fake_ansible_module):
         pwd='Esxi@123$%',
         user='Administrator@vsphere.local')
 
+
 @pytest.mark.parametrize("test_options, test_current_options, test_truthy_strings_as_bool", [
     ({"data": True}, [], True),
     ({"data": 1}, [], True),

--- a/tests/unit/module_utils/test_vmware.py
+++ b/tests/unit/module_utils/test_vmware.py
@@ -229,11 +229,15 @@ def test_connect_to_api_validate_certs(monkeypatch, fake_ansible_module):
         pwd='Esxi@123$%',
         user='Administrator@vsphere.local')
 
-@pytest.mark.parametrize("test_options, test_current_options", [
-    ({"data": True}, []),
-    ({"data": 1}, []),
-    ({"data": 1.2}, []),
-    ({"data": 'string'}, []),
+@pytest.mark.parametrize("test_options, test_current_options, test_truthy_strings_as_bool", [
+    ({"data": True}, [], True),
+    ({"data": 1}, [], True),
+    ({"data": 1.2}, [], True),
+    ({"data": 'string'}, [], True),
+    ({"data": True}, [], False),
+    ({"data": 1}, [], False),
+    ({"data": 1.2}, [], False),
+    ({"data": 'string'}, [], False),
 ])
-def test_option_diff(test_options, test_current_options):
-    assert option_diff(test_options, test_current_options)[0].value == test_options["data"]
+def test_option_diff(test_options, test_current_options, test_truthy_strings_as_bool):
+    assert option_diff(test_options, test_current_options, test_truthy_strings_as_bool)[0].value == test_options["data"]

--- a/tests/unit/module_utils/test_vmware.py
+++ b/tests/unit/module_utils/test_vmware.py
@@ -13,6 +13,7 @@ import pytest
 pyvmomi = pytest.importorskip('pyVmomi')
 
 from ansible_collections.community.vmware.tests.unit.compat import mock
+from ansible_collections.community.vmware.plugins.module_utils.vmware import option_diff
 
 import ansible_collections.community.vmware.plugins.module_utils.vmware as vmware_module_utils
 
@@ -227,3 +228,12 @@ def test_connect_to_api_validate_certs(monkeypatch, fake_ansible_module):
         port=443,
         pwd='Esxi@123$%',
         user='Administrator@vsphere.local')
+
+@pytest.mark.parametrize("test_options, test_current_options", [
+    ({"data": True}, []),
+    ({"data": 1}, []),
+    ({"data": 1.2}, []),
+    ({"data": 'string'}, []),
+])
+def test_option_diff(test_options, test_current_options):
+    assert option_diff(test_options, test_current_options)[0].value == test_options["data"]


### PR DESCRIPTION
Depends-on https://github.com/ansible-collections/community.vmware/pull/991
Depends-on https://github.com/ansible-collections/community.vmware/pull/977

##### SUMMARY

I think that the isinstance shouldn't use in the evaluation formula for bool because it occurs mistaking evaluation.  
For example:

```python
if isinstance(True, int): # <= is judged as a True
    pass
```

The cause of mistaking evaluation is that bool type is implemented as an integer sub-class.  
Please see the following:

* https://docs.python.org/3/library/functions.html#isinstance
* https://docs.python.org/3/c-api/bool.html

When using the isinstance, the vmware_vcenter_settings module doesn't work well.  
Because bool will be converted to an integer by the following processing.  
https://github.com/ansible-collections/community.vmware/blob/634ec3b9862e07cf7b390a6c1680d15348af0c33/plugins/module_utils/vmware.py#L1051-L1052

Also see: https://github.com/ansible-collections/community.vmware/pull/981

So, I think that type should use, not the isinstance.  
https://docs.python.org/3/library/functions.html#type

This PR will change to use from isinstance to type. 
fixes: https://github.com/ansible-collections/community.vmware/issues/980

What do you think?

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

changelogs/fragments/983-vmware.yml
plugins/module_utils/vmware.py

##### ADDITIONAL INFORMATION

tested on vCenter/ESXi 7.0.2
