### PR TITLE
vmware_vm_inventory: Remove erroneous condition

### DIFF
--- a/changelogs/fragments/975_vmware_vm_inventory.yml
+++ b/changelogs/fragments/975_vmware_vm_inventory.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- vmware_vm_inventory - remove erroneous ``ansible_host`` condition (https://github.com/ansible-collections/community.vmware/issues/975).

--- a/plugins/inventory/vmware_vm_inventory.py
+++ b/plugins/inventory/vmware_vm_inventory.py
@@ -823,10 +823,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         if not compose:
             compose['ansible_host'] = 'guest.ipAddress'
 
-        if not compose.get('ansible_host', None):
-            raise AnsibleError('"ansible_host" not found in "compose". '
-                               'Without this inventory will be useless.')
-
         self._set_composite_vars(compose, host_properties, host, strict=strict)
         # Complex groups based on jinja2 conditionals, hosts that meet the conditional are added to group
         self._add_host_to_composed_groups(self.get_option('groups'), host_properties, host, strict=strict)


### PR DESCRIPTION
##### SUMMARY

Inventory failed erroneously if ansible_host is not
present. This is not true for all conditions (VM poweredoff,
Bad VM configuration etc.)

Fix removes this erroneous condition.

Fixes: #975

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/975_vmware_vm_inventory.yml
plugins/inventory/vmware_vm_inventory.py
