### PR TITLE
Delete old changelog fragments

### DIFF
--- a/changelogs/fragments/112-vmware_dvs_host.yml
+++ b/changelogs/fragments/112-vmware_dvs_host.yml
@@ -1,3 +1,0 @@
-minor_changes:
-  - vmware_dvs_host - implement adding pNICs to LAGs (https://github.com/ansible-collections/community.vmware/issues/112).
- 

--- a/changelogs/fragments/738-vmware_content_deploy_xxx.yml
+++ b/changelogs/fragments/738-vmware_content_deploy_xxx.yml
@@ -1,9 +1,0 @@
----
-bugfixes:
-- vmware_content_deploy_xxx - honors folder specified by fully qualified path name.
-- vmware_content_deploy_xxx - deploys to recommended datastore in specified datastore_cluster.
-- vmware_content_deploy_ovf_template - no longer requires host, datastore, resource_pool.
-minor_changes:
-- vmware - find_folder_by_fqpn added to support specifying folders by their fully qualified path name, defined as I(datacenter)/I(folder_type)/subfolder1/subfolder2/.
-- vmware - folder field default changed from None to vm.
-- vmware_content_deploy_ovf_template - storage_provisioning default changed from None to thin, in keeping with VMware best practices for flash storage.

--- a/changelogs/fragments/796-vmware_guest_instant_clone.yml
+++ b/changelogs/fragments/796-vmware_guest_instant_clone.yml
@@ -1,3 +1,0 @@
-minor_changes:
-  - vmware_guest_instant_clone - added the the guestinfo_vars parameter to provide GuestOS Customization functionality in instant cloned VM (https://github.com/ansible-collections/community.vmware/pull/796).
- 

--- a/changelogs/fragments/816-vmware_guest.yml
+++ b/changelogs/fragments/816-vmware_guest.yml
@@ -1,4 +1,0 @@
-minor_changes:
-- vmware_guest - New parameter ``secure_boot`` to manage (U)EFI secure boot on VMs (https://github.com/ansible-collections/community.vmware/pull/816).
-- vmware_guest - New parameter ``vvtd`` to manage Intel Virtualization Technology for Directed I/O on VMs (https://github.com/ansible-collections/community.vmware/pull/816).
-- vmware_guest - Make the requirements for Virtualization Based Security explicit (https://github.com/ansible-collections/community.vmware/pull/816).

--- a/changelogs/fragments/817-vmware_vm_inventory-support-proxy.yml
+++ b/changelogs/fragments/817-vmware_vm_inventory-support-proxy.yml
@@ -1,3 +1,0 @@
-minor_changes:
-  - vmware_vm_inventory - support api access via proxy (https://github.com/ansible-collections/community.vmware/pull/817).
-  - vmware_host_inventory - support api access via proxy (https://github.com/ansible-collections/community.vmware/pull/817).

--- a/changelogs/fragments/819-vmware_vcenter_settings-advanced_setting.yml
+++ b/changelogs/fragments/819-vmware_vcenter_settings-advanced_setting.yml
@@ -1,2 +1,0 @@
-minor_changes:
-- vmware_vcenter_settings.py - Add advanced_settings parameter (https://github.com/ansible-collections/community.vmware/pull/819).

--- a/changelogs/fragments/821-vmware_guest_powerstate.yml
+++ b/changelogs/fragments/821-vmware_guest_powerstate.yml
@@ -1,3 +1,0 @@
-minor_changes:
-  - vmware_guest_powerstate - Add an option that answers whether it was copied or moved the vm if the vm is blocked (https://github.com/ansible-collections/community.vmware/pull/821).
-  - vmware - add processing to answer if the answer question is occurred in starting the vm (https://github.com/ansible-collections/community.vmware/pull/821).

--- a/changelogs/fragments/828_vmware_host_vmnic_info.yml
+++ b/changelogs/fragments/828_vmware_host_vmnic_info.yml
@@ -1,2 +1,0 @@
-minor_changes:
-- vmware_host_vmnic_info - add LLDP information to output when applicable (https://github.com/ansible-collections/community.vmware/pull/828).

--- a/changelogs/fragments/831-vmware_guest-hostname.yml
+++ b/changelogs/fragments/831-vmware_guest-hostname.yml
@@ -1,2 +1,0 @@
-bugfixes:
-  - vmware_guest - Use hostname parameter in customization only if value is not None (https://github.com/ansible-collections/community.vmware/issues/655)

--- a/changelogs/fragments/833-vmware_dvswitch-network_policy.yml
+++ b/changelogs/fragments/833-vmware_dvswitch-network_policy.yml
@@ -1,3 +1,0 @@
-minor_changes:
-- vmware_dvswitch - Implement network_policy parameter with suboptions promiscuous, forged_transmits and mac_changes (https://github.com/ansible-collections/community.vmware/issues/833).
-- vmware_dvswitch - Dynamically check the DVS versions vCenter supports (https://github.com/ansible-collections/community.vmware/issues/839).

--- a/changelogs/fragments/834-vmware_host_tcpip_stacks.yml
+++ b/changelogs/fragments/834-vmware_host_tcpip_stacks.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - vmware_host_tcpip_stacks - added ipv6_gateway parameter and nsx_overlay as an alias of vxlan (https://github.com/ansible-collections/community.vmware/pull/834).

--- a/changelogs/fragments/838_vmware_host_custom_attributes.yml
+++ b/changelogs/fragments/838_vmware_host_custom_attributes.yml
@@ -1,2 +1,0 @@
-minor_changes:
-- vmware_host_custom_attributes - new module (https://github.com/ansible-collections/community.vmware/pull/838).

--- a/changelogs/fragments/848_vmware_rest_client_add_support_for_proxy.yml
+++ b/changelogs/fragments/848_vmware_rest_client_add_support_for_proxy.yml
@@ -1,2 +1,0 @@
-minor_changes:
-- vmware_rest_client - support proxy feature for module using this API (https://github.com/ansible-collections/community.vmware/pull/848).

--- a/changelogs/fragments/851-vmware_object_custom_attributes_info.yml
+++ b/changelogs/fragments/851-vmware_object_custom_attributes_info.yml
@@ -1,2 +1,0 @@
-major_changes:
-  - vmware_object_custom_attributes_info - added a new module to gather custom attributes of an object (https://github.com/ansible-collections/community.vmware/pull/851).

--- a/changelogs/fragments/855_vmware_host_inventory.yml
+++ b/changelogs/fragments/855_vmware_host_inventory.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - vmware_host_inventory - added ability for username to be a vault encrypted variable, and updated documentation to reflect ability for username and password to be vaulted. (https://github.com/ansible-collections/community.vmware/issues/854).

--- a/changelogs/fragments/855_vmware_vm_inventory.yml
+++ b/changelogs/fragments/855_vmware_vm_inventory.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - vmware_vm_inventory - added ability for username to be a vault encrypted variable, and updated documentation to reflect ability for username and password to be vaulted. (https://github.com/ansible-collections/community.vmware/issues/854).

--- a/changelogs/fragments/858_vmware_vmotion_add_destination_datacenter_parameter.yml
+++ b/changelogs/fragments/858_vmware_vmotion_add_destination_datacenter_parameter.yml
@@ -1,2 +1,0 @@
-bugfixes:
-- vmware_vmotion - implement new parameter named destination_datacenter to fix failure to move storage when datastores are shared across datacenters (https://github.com/ansible-collections/community.vmware/issues/858)

--- a/changelogs/fragments/867-vmware.yml
+++ b/changelogs/fragments/867-vmware.yml
@@ -1,2 +1,0 @@
-bugfixes:
-  - vmware - fix that the return value should be returned None if moId doesn't exist of a virtual machine (https://github.com/ansible-collections/community.vmware/pull/867).

--- a/changelogs/fragments/872-vmware_host_passthrough.yml
+++ b/changelogs/fragments/872-vmware_host_passthrough.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - vmware_host_passthrough - added a new module to enable or disable passthrough of PCI devices with ESXi host has (https://github.com/ansible-collections/community.vmware/pull/872).

--- a/changelogs/fragments/874-vmware_object_role_permission_info-principal_permissions.yml
+++ b/changelogs/fragments/874-vmware_object_role_permission_info-principal_permissions.yml
@@ -1,2 +1,0 @@
-minor_changes:
-- vmware_object_role_permission_info - added principal to provide list of individual permissions on specified entity (https://github.com/ansible-collections/community.vmware/issues/868).

--- a/changelogs/fragments/878_vmware_guest_controller.yml
+++ b/changelogs/fragments/878_vmware_guest_controller.yml
@@ -1,2 +1,0 @@
-minor_changes:
-- vmware_guest_controller - added bus_sharing property to scsi controllers (https://github.com/ansible-collections/community.vmware/pull/878).

--- a/changelogs/fragments/879-vmware_object_custom_attributes_info.yml
+++ b/changelogs/fragments/879-vmware_object_custom_attributes_info.yml
@@ -1,3 +1,0 @@
-minor_changes:
-  - vmware - added a new method to search Managed Object based on moid and object type (https://github.com/ansible-collections/community.vmware/pull/879).
-  - vmware_object_custom_attributes_info - added a new parameter to support moid (https://github.com/ansible-collections/community.vmware/pull/879).

--- a/changelogs/fragments/904-vmware_guest_instant_clone.yml
+++ b/changelogs/fragments/904-vmware_guest_instant_clone.yml
@@ -1,3 +1,0 @@
-minor_changes:
-  - vmware_guest_instant_clone - added a new option to wait until the vmware tools start (https://github.com/ansible-collections/community.vmware/pull/904).
-  - vmware_guest_instant_clone - added a reboot processing to reflect the customization parameters to an instant clone vm (https://github.com/ansible-collections/community.vmware/pull/904).


### PR DESCRIPTION
@Akasurde @goneri It looks like there are a lot of old changelog fragments from before the 1.12 release. Shouldn't we delete them?