### PR TITLE
Adding requirement that the free ESXi version is not supported to cre…

### DIFF
--- a/docs/community.vmware.vmware_guest_module.rst
+++ b/docs/community.vmware.vmware_guest_module.rst
@@ -27,7 +27,7 @@ The below requirements are needed on the host that executes this module.
 
 - python >= 2.6
 - PyVmomi
-
+- You will also need a paid version of ESXi Essentials or a licensed version VMware VCenter. The free version of ESXi is NOT supported.
 
 Parameters
 ----------


### PR DESCRIPTION
If you attempt to create VMs using the free version of ESXi with the vmware_guest  VMware ansible module  you will receive this error:

`fatal: [localhost]: FAILED! => {"changed": false, "msg": "Failed to create virtual machine due to product versioning restrictions: Current license or ESXi version prohibits execution of the requested operation."}`

By seeing this requirement (see diff) in the docs it should hopefully save other users time.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Right now the current vmware_guest docs do not mention that a paid version of ESXi is needed to create VMs using Ansible. This wasted my time, hopefully this helps save time for others.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

My free ESXi info:
`7.0.0 (Build 15843807)`

Ansible info:
```
root@ansible-server:/home/ian/ansible/esxi# ansible --version
ansible 2.9.6
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3/dist-packages/ansible
  executable location = /usr/bin/ansible
  python version = 3.8.10 (default, Jun  2 2021, 10:49:15) [GCC 9.4.0]
```


