### PR TITLE
vmware_category: Fix the issue that the error has been occurred when 'All objects' set to associable_object_types

### DIFF
--- a/changelogs/fragments/990-vmware_category.yml
+++ b/changelogs/fragments/990-vmware_category.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_category - fixed some issues that the errors have occurred in executing the module (https://github.com/ansible-collections/community.vmware/pull/990).

--- a/plugins/modules/vmware_category.py
+++ b/plugins/modules/vmware_category.py
@@ -244,7 +244,7 @@ class VmwareCategory(VmwareRestClient):
                         # If it will not be flatten, an error occurs in the set processing.
                         obj_types_set = []
                         for category in list(associable_data.values()):
-                            if type(category) == list:
+                            if isinstance(category, list):
                                 for tmp_category in category:
                                     obj_types_set.append(tmp_category)
                             else:

--- a/plugins/modules/vmware_category.py
+++ b/plugins/modules/vmware_category.py
@@ -241,7 +241,7 @@ class VmwareCategory(VmwareRestClient):
                         break
                     else:
                         # obj_types_set should be required to be flatten.
-                        # If it will not be flatten, an error occurs in the set processing.
+                        # If it will not flatten, an error occurs in the set processing.
                         obj_types_set = []
                         for category in list(associable_data.values()):
                             if isinstance(category, list):

--- a/plugins/modules/vmware_category.py
+++ b/plugins/modules/vmware_category.py
@@ -237,19 +237,14 @@ class VmwareCategory(VmwareRestClient):
                 lower_obj_type = obj_type.lower()
                 if lower_obj_type == 'all objects':
                     if LooseVersion(self.content.about.version) < LooseVersion('7'):
-                        obj_types_set = []
                         break
-                    else:
-                        # obj_types_set should be required to be flatten.
-                        # If it will not flatten, an error occurs in the set processing.
-                        obj_types_set = []
-                        for category in list(associable_data.values()):
-                            if isinstance(category, list):
-                                for tmp_category in category:
-                                    obj_types_set.append(tmp_category)
-                            else:
-                                obj_types_set.append(category)
-                        break
+
+                    for category in list(associable_data.values()):
+                        if isinstance(category, list):
+                            obj_types_set.extend(category)
+                        else:
+                            obj_types_set.append(category)
+                    break
                 if lower_obj_type in associable_data:
                     value = associable_data.get(lower_obj_type)
                     if isinstance(value, list):

--- a/plugins/modules/vmware_category.py
+++ b/plugins/modules/vmware_category.py
@@ -155,6 +155,7 @@ from distutils.version import LooseVersion
 
 from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.community.vmware.plugins.module_utils.vmware import connect_to_api
 from ansible_collections.community.vmware.plugins.module_utils.vmware_rest_client import VmwareRestClient
 
 try:
@@ -176,6 +177,7 @@ class VmwareCategory(VmwareRestClient):
         self.global_categories = dict()
         self.category_name = self.params.get('category_name')
         self.get_all_categories()
+        self.content = connect_to_api(self.module, return_si=False)
 
     def ensure_state(self):
         """Manage internal states of categories. """
@@ -218,6 +220,7 @@ class VmwareCategory(VmwareRestClient):
             'library item': append_namespace('com.vmware.content.library.Item'),
 
             # Without Namespace
+            'datacenter': 'Datacenter',
             'distributed port group': 'DistributedVirtualPortgroup',
             'distributed switch': ['VmwareDistributedVirtualSwitch', 'DistributedVirtualSwitch'],
             'content library': 'com.vmware.content.Library',
@@ -237,7 +240,15 @@ class VmwareCategory(VmwareRestClient):
                         obj_types_set = []
                         break
                     else:
-                        obj_types_set = list(associable_data.values())
+                        # obj_types_set should be required to be flatten.
+                        # If it will not be flatten, an error occurs in the set processing.
+                        obj_types_set = []
+                        for category in list(associable_data.values()):
+                            if type(category) == list:
+                                for tmp_category in category:
+                                    obj_types_set.append(tmp_category)
+                            else:
+                                obj_types_set.append(category)
                         break
                 if lower_obj_type in associable_data:
                     value = associable_data.get(lower_obj_type)

--- a/tests/integration/targets/vmware_category/tasks/associable_obj_types.yml
+++ b/tests/integration/targets/vmware_category/tasks/associable_obj_types.yml
@@ -87,3 +87,37 @@
   assert:
     that:
       - category_change.changed
+
+# Added the test for the PR(https://github.com/ansible-collections/community.vmware/pull/990)
+- name: Create a new category with All objects
+  vmware_category:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    validate_certs: false
+    category_name: 'Sample_cate_0002'
+    category_description: 'sample description'
+    associable_object_types:
+      - All objects
+    state: present
+  register: category_change_all_objects
+
+- name: Assert change is made
+  assert:
+    that:
+      - category_change_all_objects.changed
+
+- name: Delete Sample_cate_0002 category
+  vmware_category:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    validate_certs: false
+    category_name: 'Sample_cate_0002'
+    state: absent
+  register: category_change
+
+- name: Assert change is made
+  assert:
+    that:
+      - category_change.changed


### PR DESCRIPTION
Depends-on https://github.com/ansible-collections/community.vmware/pull/991

##### SUMMARY

The vmware_category module has a bug that the version doesn't compare and obj_types_set doesn't be flattened.  
This PR will be fixed the following issues.

* Fixed the issue that VCSA version doesn't compare(added connect_to_api method to generate the content object)
* The associable_data instance hasn't Datacenter, so added it.
* The error has occurred in set processing, so added flatten processing to fix it.

fixes: https://github.com/ansible-collections/community.vmware/issues/989

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

changelogs/fragments/990-vmware_category.yml
plugins/modules/vmware_category.py
tests/integration/targets/vmware_category/tasks/associable_obj_types.yml

##### ADDITIONAL INFORMATION

tested on vCenter/ESXi 7.0.2