### PR TITLE
Add option to mark cloned vm as template vmware_guest_cross_vc_clone

### DIFF
--- a/plugins/modules/vmware_guest_cross_vc_clone.py
+++ b/plugins/modules/vmware_guest_cross_vc_clone.py
@@ -94,6 +94,11 @@ options:
       - Destination resource pool.
       - If not provided, the destination host's parent's resource pool will be used.
     type: str
+  is_template:
+    description:
+      - Specifies whether or not the new virtual machine should be marked as a template.
+    type: bool
+    default: False
   state:
     description:
       - The state of Virtual Machine deployed.
@@ -311,6 +316,7 @@ class CrossVCCloneManager(PyVmomi):
         self.clone_spec.config = self.config_spec
         self.clone_spec.powerOn = True if self.params['state'].lower() == 'poweredon' else False
         self.clone_spec.location = self.relocate_spec
+        self.clone_spec.template = self.params['is_template']
 
 
 def main():
@@ -333,6 +339,7 @@ def main():
         destination_vcenter_validate_certs=dict(type='bool', default=False),
         destination_vm_folder=dict(type='str', required=True),
         destination_resource_pool=dict(type='str', default=None),
+        is_template=(dict(type='bool', default=False)),
         state=dict(type='str', default='present',
                    choices=['present', 'poweredon'])
     )


### PR DESCRIPTION
With this change it is possible to clone a template and mark it as a template.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This change adds a new parameter (is_template). 
Since this module can also be used to clone templates it makes sense to have an option to also mark it as a template. Otherwise it will create a virtual machine from the cloned vm/template.

I chose is_template as the param name to be consistent with the vmware_guest module.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_guest_cross_vc_clone

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
