### PR TITLE
Add a new module vmware_vm_config_option

### DIFF
--- a/changelogs/fragments/993-vmware_vm_config_option.yml
+++ b/changelogs/fragments/993-vmware_vm_config_option.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - vmware_vm_config_option - add new module to get ESXi supported config option keys(hardware versions), supported guest IDs and VM recommended config options for specified guest ID (https://github.com/ansible-collections/community.vmware/issues/993).
+  - vm_device_helper - move NIC device types from vmware_guest module to vm_device_helper (https://github.com/ansible-collections/community.vmware/pull/998).

--- a/changelogs/fragments/993-vmware_vm_config_option.yml
+++ b/changelogs/fragments/993-vmware_vm_config_option.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_vm_config_option - add new module to get ESXi supported config option keys(hardware versions), supported guest IDs and VM recommended config options for specified guest ID (https://github.com/ansible-collections/community.vmware/issues/993).

--- a/plugins/module_utils/vm_device_helper.py
+++ b/plugins/module_utils/vm_device_helper.py
@@ -35,21 +35,21 @@ class PyVmomiDeviceHelper(object):
             'lsilogic': vim.vm.device.VirtualLsiLogicController,
             'paravirtual': vim.vm.device.ParaVirtualSCSIController,
             'buslogic': vim.vm.device.VirtualBusLogicController,
-            'lsilogicsas': vim.vm.device.VirtualLsiLogicSASController,
+            'lsilogicsas': vim.vm.device.VirtualLsiLogicSASController
         }
         self.sata_device_type = vim.vm.device.VirtualAHCIController
         self.nvme_device_type = vim.vm.device.VirtualNVMEController
         self.usb_device_type = {
             'usb2': vim.vm.device.VirtualUSBController,
-            'usb3': vim.vm.device.VirtualUSBXHCIController,
+            'usb3': vim.vm.device.VirtualUSBXHCIController
         }
         self.nic_device_type = {
             'pcnet32': vim.vm.device.VirtualPCNet32,
             'vmxnet2': vim.vm.device.VirtualVmxnet2,
             'vmxnet3': vim.vm.device.VirtualVmxnet3,
             'e1000': vim.vm.device.VirtualE1000,
-            'e1000e': vim.vm.device.VirtualE1000e(),
-            'sriov': vim.vm.device.VirtualSriovEthernetCard()
+            'e1000e': vim.vm.device.VirtualE1000e,
+            'sriov': vim.vm.device.VirtualSriovEthernetCard
         }
 
     def create_scsi_controller(self, scsi_type, bus_number, bus_sharing='noSharing'):

--- a/plugins/module_utils/vm_device_helper.py
+++ b/plugins/module_utils/vm_device_helper.py
@@ -315,3 +315,60 @@ class PyVmomiDeviceHelper(object):
         else:
             self.module.fail_json(msg='"%s" attribute should be an'
                                   ' integer value.' % name)
+
+    def create_nvdimm_controller(self):
+        nvdimm_ctl = vim.vm.device.VirtualDeviceSpec()
+        nvdimm_ctl.operation = vim.vm.device.VirtualDeviceSpec.Operation.add
+        nvdimm_ctl.device = vim.vm.device.VirtualNVDIMMController()
+        nvdimm_ctl.device.deviceInfo = vim.Description()
+        nvdimm_ctl.device.key = -randint(27000, 27999)
+
+        return nvdimm_ctl
+
+    @staticmethod
+    def is_nvdimm_controller(device):
+        return isinstance(device, vim.vm.device.VirtualNVDIMMController)
+
+    def create_nvdimm_device(self, nvdimm_ctl_dev_key, pmem_profile_id, nvdimm_dev_size_mb=1024):
+        nvdimm_dev_spec = vim.vm.device.VirtualDeviceSpec()
+        nvdimm_dev_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.add
+        nvdimm_dev_spec.fileOperation = vim.vm.device.VirtualDeviceSpec.FileOperation.create
+        nvdimm_dev_spec.device = vim.vm.device.VirtualNVDIMM()
+        nvdimm_dev_spec.device.controllerKey = nvdimm_ctl_dev_key
+        nvdimm_dev_spec.device.key = -randint(28000, 28999)
+        nvdimm_dev_spec.device.capacityInMB = nvdimm_dev_size_mb
+        nvdimm_dev_spec.device.deviceInfo = vim.Description()
+        nvdimm_dev_spec.device.backing = vim.vm.device.VirtualNVDIMM.BackingInfo()
+        profile = vim.vm.DefinedProfileSpec()
+        profile.profileId = pmem_profile_id
+        nvdimm_dev_spec.profile = [profile]
+
+        return nvdimm_dev_spec
+
+    @staticmethod
+    def is_nvdimm_device(device):
+        return isinstance(device, vim.vm.device.VirtualNVDIMM)
+
+    def find_nvdimm_by_label(self, nvdimm_label, nvdimm_devices):
+        nvdimm_dev = None
+        for nvdimm in nvdimm_devices:
+            if nvdimm.deviceInfo.label == nvdimm_label:
+                nvdimm_dev = nvdimm
+
+        return nvdimm_dev
+
+    def remove_nvdimm(self, nvdimm_device):
+        nvdimm_spec = vim.vm.device.VirtualDeviceSpec()
+        nvdimm_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.remove
+        nvdimm_spec.fileOperation = vim.vm.device.VirtualDeviceSpec.FileOperation.destroy
+        nvdimm_spec.device = nvdimm_device
+
+        return nvdimm_spec
+
+    def update_nvdimm_config(self, nvdimm_device, nvdimm_size):
+        nvdimm_spec = vim.vm.device.VirtualDeviceSpec()
+        nvdimm_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.edit
+        nvdimm_spec.device = nvdimm_device
+        nvdimm_device.capacityInMB = nvdimm_size
+
+        return nvdimm_spec

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -1706,8 +1706,9 @@ class PyVmomiHelper(PyVmomi):
             return device_list
 
         for device in vm.config.hardware.device:
-            if isinstance(device, self.device_helper.nic_device_type.values()):
-                device_list.append(device)
+            for device_type in self.device_helper.nic_device_type.values():
+                if isinstance(device, device_type):
+                    device_list.append(device)
 
         return device_list
 

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -314,6 +314,33 @@ options:
             - C(controller_type), C(controller_number) and C(unit_number) are required when creating or reconfiguring VMs
               with multiple types of disk controllers and disks.
             - When creating new VM, the first configured disk in the C(disk) list will be "Hard Disk 1".
+  nvdimm:
+    description:
+    - Add or remove a virtual NVDIMM device to the virtual machine.
+    - VM virtual hardware version must be 14 or higher on vSphere 6.7 or later.
+    - Verify that guest OS of the virtual machine supports PMem before adding virtual NVDIMM device.
+    - Verify that you have the I(Datastore.Allocate) space privilege on the virtual machine.
+    - Make sure that the host or the cluster on which the virtual machine resides has available PMem resources.
+    - To add or remove virtual NVDIMM device to the existing virtual machine, it must be in power off state.
+    type: dict
+    version_added: '1.13.0'
+    suboptions:
+        state:
+             type: str
+             description:
+             - Valid value is C(present) or C(absent).
+             - If set to C(absent), then the NVDIMM device with specified C(label) will be removed.
+             choices: ['present', 'absent']
+        size_mb:
+            type: int
+            description: Virtual NVDIMM device size in MB.
+            default: 1024
+        label:
+             type: str
+             description:
+             - The label of the virtual NVDIMM device to be removed or configured, e.g., "NVDIMM 1".
+             - 'This parameter is required when C(state) is set to C(absent), or C(present) to reconfigure NVDIMM device
+               size. When add a new device, please do not set C(label).'
   cdrom:
     description:
     - A list of CD-ROM configurations for the virtual machine. Added in version 2.9.
@@ -967,6 +994,29 @@ EXAMPLES = r'''
       device_type: vmxnet3
   delegate_to: localhost
   register: deploy_vm
+
+- name: Create a VM with NVDIMM device
+  community.vmware.vmware_guest:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    folder: /DC1/vm/
+    name: test_vm_nvdimm
+    state: poweredoff
+    guest_id: centos7_64Guest
+    datastore: datastore1
+    hardware:
+      memory_mb: 512
+      num_cpus: 4
+      version: 14
+    networks:
+    - name: VM Network
+      device_type: vmxnet3
+    nvdimm:
+      state: present
+      size_mb: 2048
+  delegate_to: localhost
+  register: deploy_vm
 '''
 
 RETURN = r'''
@@ -1006,6 +1056,7 @@ from ansible_collections.community.vmware.plugins.module_utils.vmware import (
     quote_obj_name,
 )
 from ansible_collections.community.vmware.plugins.module_utils.vm_device_helper import PyVmomiDeviceHelper
+from ansible_collections.community.vmware.plugins.module_utils.vmware_spbm import SPBM
 
 
 class PyVmomiCache(object):
@@ -1570,6 +1621,84 @@ class PyVmomiHelper(PyVmomi):
 
     def get_vm_sata_devices(self, vm=None):
         return self.get_device_by_type(vm=vm, type=vim.vm.device.VirtualAHCIController)
+
+    def get_vm_nvdimm_ctl_device(self, vm=None):
+        return self.get_device_by_type(vm=vm, type=vim.vm.device.VirtualNVDIMMController)
+
+    def get_vm_nvdimm_devices(self, vm=None):
+        return self.get_device_by_type(vm=vm, type=vim.vm.device.VirtualNVDIMM)
+
+    def configure_nvdimm(self, vm_obj):
+        """
+        Manage virtual NVDIMM device to the virtual machine
+        Args:
+            vm_obj: virtual machine object
+        """
+        if self.params['nvdimm']['state']:
+            # Label is required when remove device
+            if self.params['nvdimm']['state'] == 'absent' and not self.params['nvdimm']['label']:
+                self.module.fail_json(msg="Please specify the label of virtual NVDIMM device using 'label' parameter"
+                                          " when state is set to 'absent'.")
+            # Reconfigure device requires VM in power off state
+            if vm_obj and not vm_obj.config.template:
+                if vm_obj.runtime.powerState != vim.VirtualMachinePowerState.poweredOff:
+                    self.module.fail_json(msg="VM is not in power off state, can not do virtual NVDIMM configuration.")
+
+            nvdimm_ctl_exists = False
+            if vm_obj and not vm_obj.config.template:
+                # Get existing NVDIMM controller
+                nvdimm_ctl = self.get_vm_nvdimm_ctl_device(vm=vm_obj)
+                if len(nvdimm_ctl) != 0:
+                    nvdimm_ctl_exists = True
+                    nvdimm_ctl_key = nvdimm_ctl[0].key
+                    if self.params['nvdimm']['label'] is not None:
+                        nvdimm_devices = self.get_vm_nvdimm_devices(vm=vm_obj)
+                        if len(nvdimm_devices) != 0:
+                            existing_nvdimm_dev = self.device_helper.find_nvdimm_by_label(
+                                nvdimm_label=self.params['nvdimm']['label'],
+                                nvdimm_devices=nvdimm_devices
+                            )
+                            if existing_nvdimm_dev is not None:
+                                if self.params['nvdimm']['state'] == 'absent':
+                                    nvdimm_remove_spec = self.device_helper.remove_nvdimm(
+                                        nvdimm_device=existing_nvdimm_dev
+                                    )
+                                    self.change_detected = True
+                                    self.configspec.deviceChange.append(nvdimm_remove_spec)
+                                else:
+                                    if existing_nvdimm_dev.capacityInMB < self.params['nvdimm']['size_mb']:
+                                        nvdimm_config_spec = self.device_helper.update_nvdimm_config(
+                                            nvdimm_device=existing_nvdimm_dev,
+                                            nvdimm_size=self.params['nvdimm']['size_mb']
+                                        )
+                                        self.change_detected = True
+                                        self.configspec.deviceChange.append(nvdimm_config_spec)
+                                    elif existing_nvdimm_dev.capacityInMB > self.params['nvdimm']['size_mb']:
+                                        self.module.fail_json(msg="Can not change NVDIMM device size to %s MB, which is"
+                                                                  " smaller than the current size %s MB."
+                                                                  % (self.params['nvdimm']['size_mb'],
+                                                                     existing_nvdimm_dev.capacityInMB))
+            # New VM or existing VM without label specified, add new NVDIMM device
+            if vm_obj is None or (vm_obj and not vm_obj.config.template and self.params['nvdimm']['label'] is None):
+                if self.params['nvdimm']['state'] == 'present':
+                    # Get host default PMem storage policy
+                    storage_profile_name = "Host-local PMem Default Storage Policy"
+                    spbm = SPBM(self.module)
+                    pmem_profile = spbm.find_storage_profile_by_name(profile_name=storage_profile_name)
+                    if pmem_profile is None:
+                        self.module.fail_json(msg="Can not find PMem storage policy with name '%s'." % storage_profile_name)
+                    if not nvdimm_ctl_exists:
+                        nvdimm_ctl_spec = self.device_helper.create_nvdimm_controller()
+                        self.configspec.deviceChange.append(nvdimm_ctl_spec)
+                        nvdimm_ctl_key = nvdimm_ctl_spec.device.key
+
+                    nvdimm_dev_spec = self.device_helper.create_nvdimm_device(
+                        nvdimm_ctl_dev_key=nvdimm_ctl_key,
+                        pmem_profile_id=pmem_profile.profileId.uniqueId,
+                        nvdimm_dev_size_mb=self.params['nvdimm']['size_mb']
+                    )
+                    self.change_detected = True
+                    self.configspec.deviceChange.append(nvdimm_dev_spec)
 
     def get_vm_network_interfaces(self, vm=None):
         device_list = []
@@ -2736,6 +2865,7 @@ class PyVmomiHelper(PyVmomi):
         self.configure_disks(vm_obj=vm_obj)
         self.configure_network(vm_obj=vm_obj)
         self.configure_cdrom(vm_obj=vm_obj)
+        self.configure_nvdimm(vm_obj=vm_obj)
 
         # Find if we need network customizations (find keys in dictionary that requires customizations)
         network_changes = False
@@ -2886,7 +3016,9 @@ class PyVmomiHelper(PyVmomi):
                     is_customization_ok = self.wait_for_customization(vm=vm, timeout=self.params['wait_for_customization_timeout'])
                     if not is_customization_ok:
                         vm_facts = self.gather_facts(vm)
-                        return {'changed': self.change_applied, 'failed': True, 'instance': vm_facts, 'op': 'customization'}
+                        return {'changed': self.change_applied, 'failed': True,
+                                'msg': 'Customization failed. For detailed information see warnings',
+                                'instance': vm_facts, 'op': 'customization'}
 
             vm_facts = self.gather_facts(vm)
             return {'changed': self.change_applied, 'failed': False, 'instance': vm_facts}
@@ -2912,6 +3044,7 @@ class PyVmomiHelper(PyVmomi):
         self.configure_disks(vm_obj=self.current_vm_obj)
         self.configure_network(vm_obj=self.current_vm_obj)
         self.configure_cdrom(vm_obj=self.current_vm_obj)
+        self.configure_nvdimm(vm_obj=self.current_vm_obj)
         self.customize_advanced_settings(vm_obj=self.current_vm_obj, config_spec=self.configspec)
         self.customize_customvalues(vm_obj=self.current_vm_obj)
         self.configure_resource_alloc_info(vm_obj=self.current_vm_obj)
@@ -3041,7 +3174,8 @@ class PyVmomiHelper(PyVmomi):
             is_customization_ok = self.wait_for_customization(vm=self.current_vm_obj, timeout=self.params['wait_for_customization_timeout'])
             if not is_customization_ok:
                 return {'changed': self.change_applied, 'failed': True,
-                        'msg': 'Wait for customization failed due to timeout', 'op': 'wait_for_customize_exist'}
+                        'msg': 'Customization failed. For detailed information see warnings',
+                        'op': 'wait_for_customize_exist'}
 
         return {'changed': self.change_applied, 'failed': False}
 
@@ -3140,6 +3274,15 @@ def main():
                 unit_number=dict(type='int'),
             )
         ),
+        nvdimm=dict(
+            type='dict',
+            default={},
+            options=dict(
+                state=dict(type='str', choices=['present', 'absent']),
+                label=dict(type='str'),
+                size_mb=dict(type='int', default=1024),
+            )
+        ),
         cdrom=dict(type='raw', default=[]),
         hardware=dict(
             type='dict',
@@ -3217,9 +3360,7 @@ def main():
                                ['name', 'uuid'],
                            ],
                            )
-
     result = {'failed': False, 'changed': False}
-
     pyv = PyVmomiHelper(module)
 
     # Check requirements for virtualization based security

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -314,33 +314,6 @@ options:
             - C(controller_type), C(controller_number) and C(unit_number) are required when creating or reconfiguring VMs
               with multiple types of disk controllers and disks.
             - When creating new VM, the first configured disk in the C(disk) list will be "Hard Disk 1".
-  nvdimm:
-    description:
-    - Add or remove a virtual NVDIMM device to the virtual machine.
-    - VM virtual hardware version must be 14 or higher on vSphere 6.7 or later.
-    - Verify that guest OS of the virtual machine supports PMem before adding virtual NVDIMM device.
-    - Verify that you have the I(Datastore.Allocate) space privilege on the virtual machine.
-    - Make sure that the host or the cluster on which the virtual machine resides has available PMem resources.
-    - To add or remove virtual NVDIMM device to the existing virtual machine, it must be in power off state.
-    type: dict
-    version_added: '1.13.0'
-    suboptions:
-        state:
-             type: str
-             description:
-             - Valid value is C(present) or C(absent).
-             - If set to C(absent), then the NVDIMM device with specified C(label) will be removed.
-             choices: ['present', 'absent']
-        size_mb:
-            type: int
-            description: Virtual NVDIMM device size in MB.
-            default: 1024
-        label:
-             type: str
-             description:
-             - The label of the virtual NVDIMM device to be removed or configured, e.g., "NVDIMM 1".
-             - 'This parameter is required when C(state) is set to C(absent), or C(present) to reconfigure NVDIMM device
-               size. When add a new device, please do not set C(label).'
   cdrom:
     description:
     - A list of CD-ROM configurations for the virtual machine. Added in version 2.9.
@@ -994,29 +967,6 @@ EXAMPLES = r'''
       device_type: vmxnet3
   delegate_to: localhost
   register: deploy_vm
-
-- name: Create a VM with NVDIMM device
-  community.vmware.vmware_guest:
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    folder: /DC1/vm/
-    name: test_vm_nvdimm
-    state: poweredoff
-    guest_id: centos7_64Guest
-    datastore: datastore1
-    hardware:
-      memory_mb: 512
-      num_cpus: 4
-      version: 14
-    networks:
-    - name: VM Network
-      device_type: vmxnet3
-    nvdimm:
-      state: present
-      size_mb: 2048
-  delegate_to: localhost
-  register: deploy_vm
 '''
 
 RETURN = r'''
@@ -1056,7 +1006,6 @@ from ansible_collections.community.vmware.plugins.module_utils.vmware import (
     quote_obj_name,
 )
 from ansible_collections.community.vmware.plugins.module_utils.vm_device_helper import PyVmomiDeviceHelper
-from ansible_collections.community.vmware.plugins.module_utils.vmware_spbm import SPBM
 
 
 class PyVmomiCache(object):
@@ -1622,94 +1571,13 @@ class PyVmomiHelper(PyVmomi):
     def get_vm_sata_devices(self, vm=None):
         return self.get_device_by_type(vm=vm, type=vim.vm.device.VirtualAHCIController)
 
-    def get_vm_nvdimm_ctl_device(self, vm=None):
-        return self.get_device_by_type(vm=vm, type=vim.vm.device.VirtualNVDIMMController)
-
-    def get_vm_nvdimm_devices(self, vm=None):
-        return self.get_device_by_type(vm=vm, type=vim.vm.device.VirtualNVDIMM)
-
-    def configure_nvdimm(self, vm_obj):
-        """
-        Manage virtual NVDIMM device to the virtual machine
-        Args:
-            vm_obj: virtual machine object
-        """
-        if self.params['nvdimm']['state']:
-            # Label is required when remove device
-            if self.params['nvdimm']['state'] == 'absent' and not self.params['nvdimm']['label']:
-                self.module.fail_json(msg="Please specify the label of virtual NVDIMM device using 'label' parameter"
-                                          " when state is set to 'absent'.")
-            # Reconfigure device requires VM in power off state
-            if vm_obj and not vm_obj.config.template:
-                if vm_obj.runtime.powerState != vim.VirtualMachinePowerState.poweredOff:
-                    self.module.fail_json(msg="VM is not in power off state, can not do virtual NVDIMM configuration.")
-
-            nvdimm_ctl_exists = False
-            if vm_obj and not vm_obj.config.template:
-                # Get existing NVDIMM controller
-                nvdimm_ctl = self.get_vm_nvdimm_ctl_device(vm=vm_obj)
-                if len(nvdimm_ctl) != 0:
-                    nvdimm_ctl_exists = True
-                    nvdimm_ctl_key = nvdimm_ctl[0].key
-                    if self.params['nvdimm']['label'] is not None:
-                        nvdimm_devices = self.get_vm_nvdimm_devices(vm=vm_obj)
-                        if len(nvdimm_devices) != 0:
-                            existing_nvdimm_dev = self.device_helper.find_nvdimm_by_label(
-                                nvdimm_label=self.params['nvdimm']['label'],
-                                nvdimm_devices=nvdimm_devices
-                            )
-                            if existing_nvdimm_dev is not None:
-                                if self.params['nvdimm']['state'] == 'absent':
-                                    nvdimm_remove_spec = self.device_helper.remove_nvdimm(
-                                        nvdimm_device=existing_nvdimm_dev
-                                    )
-                                    self.change_detected = True
-                                    self.configspec.deviceChange.append(nvdimm_remove_spec)
-                                else:
-                                    if existing_nvdimm_dev.capacityInMB < self.params['nvdimm']['size_mb']:
-                                        nvdimm_config_spec = self.device_helper.update_nvdimm_config(
-                                            nvdimm_device=existing_nvdimm_dev,
-                                            nvdimm_size=self.params['nvdimm']['size_mb']
-                                        )
-                                        self.change_detected = True
-                                        self.configspec.deviceChange.append(nvdimm_config_spec)
-                                    elif existing_nvdimm_dev.capacityInMB > self.params['nvdimm']['size_mb']:
-                                        self.module.fail_json(msg="Can not change NVDIMM device size to %s MB, which is"
-                                                                  " smaller than the current size %s MB."
-                                                                  % (self.params['nvdimm']['size_mb'],
-                                                                     existing_nvdimm_dev.capacityInMB))
-            # New VM or existing VM without label specified, add new NVDIMM device
-            if vm_obj is None or (vm_obj and not vm_obj.config.template and self.params['nvdimm']['label'] is None):
-                if self.params['nvdimm']['state'] == 'present':
-                    # Get host default PMem storage policy
-                    storage_profile_name = "Host-local PMem Default Storage Policy"
-                    spbm = SPBM(self.module)
-                    pmem_profile = spbm.find_storage_profile_by_name(profile_name=storage_profile_name)
-                    if pmem_profile is None:
-                        self.module.fail_json(msg="Can not find PMem storage policy with name '%s'." % storage_profile_name)
-                    if not nvdimm_ctl_exists:
-                        nvdimm_ctl_spec = self.device_helper.create_nvdimm_controller()
-                        self.configspec.deviceChange.append(nvdimm_ctl_spec)
-                        nvdimm_ctl_key = nvdimm_ctl_spec.device.key
-
-                    nvdimm_dev_spec = self.device_helper.create_nvdimm_device(
-                        nvdimm_ctl_dev_key=nvdimm_ctl_key,
-                        pmem_profile_id=pmem_profile.profileId.uniqueId,
-                        nvdimm_dev_size_mb=self.params['nvdimm']['size_mb']
-                    )
-                    self.change_detected = True
-                    self.configspec.deviceChange.append(nvdimm_dev_spec)
-
     def get_vm_network_interfaces(self, vm=None):
         device_list = []
         if vm is None:
             return device_list
 
-        nw_device_types = (vim.vm.device.VirtualPCNet32, vim.vm.device.VirtualVmxnet2,
-                           vim.vm.device.VirtualVmxnet3, vim.vm.device.VirtualE1000,
-                           vim.vm.device.VirtualE1000e, vim.vm.device.VirtualSriovEthernetCard)
         for device in vm.config.hardware.device:
-            if isinstance(device, nw_device_types):
+            if isinstance(device, self.device_helper.nic_device_type.values()):
                 device_list.append(device)
 
         return device_list
@@ -1774,12 +1642,10 @@ class PyVmomiHelper(PyVmomi):
                     self.module.fail_json(msg="'ip' is required if 'netmask' is"
                                               " specified under VM network list.")
 
-            validate_device_types = ['pcnet32', 'vmxnet2', 'vmxnet3', 'e1000', 'e1000e', 'sriov']
-            if 'device_type' in network and network['device_type'] not in validate_device_types:
-                self.module.fail_json(msg="Device type specified '%s' is not valid."
-                                          " Please specify correct device"
-                                          " type from ['%s']." % (network['device_type'],
-                                                                  "', '".join(validate_device_types)))
+            if 'device_type' in network and network['device_type'] not in self.device_helper.nic_device_type.keys():
+                self.module.fail_json(msg="Device type specified '%s' is not valid. Please specify correct device type"
+                                          " from ['%s']." % (network['device_type'],
+                                                             "', '".join(self.device_helper.nic_device_type.keys())))
 
             if 'mac' in network and not is_mac(network['mac']):
                 self.module.fail_json(msg="Device MAC address '%s' is invalid."
@@ -1834,11 +1700,11 @@ class PyVmomiHelper(PyVmomi):
                     nic.device.deviceInfo.summary = network_name
                     nic_change_detected = True
                 if 'device_type' in network_devices[key]:
-                    device = self.device_helper.get_device(network_devices[key]['device_type'], network_name)
-                    device_class = type(device)
-                    if not isinstance(nic.device, device_class):
-                        self.module.fail_json(msg="Changing the device type is not possible when interface is already present. "
-                                                  "The failing device type is %s" % network_devices[key]['device_type'])
+                    device = self.device_helper.nic_device_type.get(network_devices[key]['device_type'])
+                    if not isinstance(nic.device, device):
+                        self.module.fail_json(msg="Changing the device type is not possible when interface is already"
+                                                  " present. The failing device type is %s"
+                                                  % network_devices[key]['device_type'])
                 # Changing mac address has no effect when editing interface
                 if 'mac' in network_devices[key] and nic.device.macAddress != current_net_devices[key].macAddress:
                     self.module.fail_json(msg="Changing MAC address has not effect when interface is already present. "
@@ -2870,7 +2736,6 @@ class PyVmomiHelper(PyVmomi):
         self.configure_disks(vm_obj=vm_obj)
         self.configure_network(vm_obj=vm_obj)
         self.configure_cdrom(vm_obj=vm_obj)
-        self.configure_nvdimm(vm_obj=vm_obj)
 
         # Find if we need network customizations (find keys in dictionary that requires customizations)
         network_changes = False
@@ -3021,9 +2886,7 @@ class PyVmomiHelper(PyVmomi):
                     is_customization_ok = self.wait_for_customization(vm=vm, timeout=self.params['wait_for_customization_timeout'])
                     if not is_customization_ok:
                         vm_facts = self.gather_facts(vm)
-                        return {'changed': self.change_applied, 'failed': True,
-                                'msg': 'Customization failed. For detailed information see warnings',
-                                'instance': vm_facts, 'op': 'customization'}
+                        return {'changed': self.change_applied, 'failed': True, 'instance': vm_facts, 'op': 'customization'}
 
             vm_facts = self.gather_facts(vm)
             return {'changed': self.change_applied, 'failed': False, 'instance': vm_facts}
@@ -3049,7 +2912,6 @@ class PyVmomiHelper(PyVmomi):
         self.configure_disks(vm_obj=self.current_vm_obj)
         self.configure_network(vm_obj=self.current_vm_obj)
         self.configure_cdrom(vm_obj=self.current_vm_obj)
-        self.configure_nvdimm(vm_obj=self.current_vm_obj)
         self.customize_advanced_settings(vm_obj=self.current_vm_obj, config_spec=self.configspec)
         self.customize_customvalues(vm_obj=self.current_vm_obj)
         self.configure_resource_alloc_info(vm_obj=self.current_vm_obj)
@@ -3179,8 +3041,7 @@ class PyVmomiHelper(PyVmomi):
             is_customization_ok = self.wait_for_customization(vm=self.current_vm_obj, timeout=self.params['wait_for_customization_timeout'])
             if not is_customization_ok:
                 return {'changed': self.change_applied, 'failed': True,
-                        'msg': 'Customization failed. For detailed information see warnings',
-                        'op': 'wait_for_customize_exist'}
+                        'msg': 'Wait for customization failed due to timeout', 'op': 'wait_for_customize_exist'}
 
         return {'changed': self.change_applied, 'failed': False}
 
@@ -3279,15 +3140,6 @@ def main():
                 unit_number=dict(type='int'),
             )
         ),
-        nvdimm=dict(
-            type='dict',
-            default={},
-            options=dict(
-                state=dict(type='str', choices=['present', 'absent']),
-                label=dict(type='str'),
-                size_mb=dict(type='int', default=1024),
-            )
-        ),
         cdrom=dict(type='raw', default=[]),
         hardware=dict(
             type='dict',
@@ -3365,7 +3217,9 @@ def main():
                                ['name', 'uuid'],
                            ],
                            )
+
     result = {'failed': False, 'changed': False}
+
     pyv = PyVmomiHelper(module)
 
     # Check requirements for virtualization based security

--- a/plugins/modules/vmware_vm_config_option.py
+++ b/plugins/modules/vmware_vm_config_option.py
@@ -18,6 +18,7 @@ description: >
    for specified guest OS ID.
 author:
 - Diane Wang (@Tomorrow9) <dianew@vmware.com>
+version_added: '1.13.0'
 notes:
 - Tested on vSphere 6.5
 - Tested on vSphere 6.7

--- a/plugins/modules/vmware_vm_config_option.py
+++ b/plugins/modules/vmware_vm_config_option.py
@@ -1,0 +1,301 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright: (c) 2021, Ansible Project
+# Copyright: (c) 2021, VMware, Inc. All Rights Reserved.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = r'''
+---
+module: vmware_vm_config_option
+short_description: Return supported guest ID list and VM recommended config option for specific guest OS
+description:
+- Return the config option keys supported for creation.
+- Return the guest ID list supported by ESXi host for the most recent virtual hardware supported.
+- Return the VM recommended config option for specific guest OS.
+- Required Privileges: System.View
+author:
+- Diane Wang (@Tomorrow9)
+notes:
+- Tested on vSphere 6.5, 6.7
+- Known issue on vSphere 7.0 (https://github.com/vmware/pyvmomi/issues/915)
+requirements:
+- python >= 2.6
+- PyVmomi
+options:
+  datacenter:
+    description:
+    - The datacenter name used to get specified cluster or host.
+    - This parameter is case sensitive.
+    default: ha-datacenter
+    type: str
+  cluster_name:
+    description:
+    - Name of the cluster.
+    - If C(esxi_hostname) is not given, this parameter is required.
+    required: false
+    type: str
+  esxi_hostname:
+    description:
+    - ESXi hostname.
+    - Obtain VM configure options on this ESXi host.
+    - If C(cluster_name) is not given, this parameter is required.
+    required: false
+    type: str
+  get_config_option_keys
+    description:
+    - 'Return the list of VM config option keys supported for creation and the default config option key on the
+      specified entity.'
+    type: bool
+    default: false
+  get_guest_os_ids:
+    description:
+    - Return the list of guest OS IDs supported on the specified entity.
+    - 'If C(config_option_key) is set, will return the corresponding guest OS ID list supported, or will return the
+      guest OS ID list for the default config option key.'
+    type: bool
+    default: false
+  get_config_option:
+    description:
+    - 'Return the dict of VM recommended config options for guest ID specified by C(guest_id) with config key specified
+      by C(config_option_key) or by default.'
+    - When set to True, C(guest_id) must be set.
+    type: bool
+    default: false
+  guest_id:
+    description:
+    - The guest OS ID from the returned list when C(get_guest_os_ids) is set to C(True), e.g., 'rhel8_64Guest'.
+    - This parameter must be set when C(get_config_option) is set to C(True).
+    required: false
+    type: str
+  config_option_key:
+    description:
+    - The config option key from the returned list when C(get_config_option_keys) is set to C(True), e.g., 'vmx-19'.
+    type: str
+    required: false 
+extends_documentation_fragment:
+- community.vmware.vmware.documentation
+'''
+
+EXAMPLES = r'''
+- name: Get supported guest ID list on given ESXi host for with default hardware version
+  community.vmware.vmware_vm_config_option:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    esxi_hostname: "{{ esxi_hostname }}"
+    get_guest_os_ids: True
+  delegate_to: localhost
+
+- name: Get VM recommended config option for Windows 10 guest OS on given ESXi host
+  community.vmware.vmware_vm_config_option:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    esxi_hostname: "{{ esxi_hostname }}"
+    get_config_option: True
+    guest_id: "windows9_64Guest"
+  delegate_to: localhost
+'''
+
+RETURN = r'''
+instance:
+    description: metadata about the VM recommended configuration
+    returned: always
+    type: dict
+    sample: None
+'''
+
+HAS_PYVMOMI = False
+try:
+    from pyVmomi import vim, vmodl
+    HAS_PYVMOMI = True
+except ImportError:
+    pass
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_native
+from ansible_collections.community.vmware.plugins.module_utils.vmware import find_obj, vmware_argument_spec, PyVmomi
+from ansible_collections.community.vmware.plugins.module_utils.vm_device_helper import PyVmomiDeviceHelper
+
+
+class VmConfigOption(PyVmomi):
+    def __init__(self, module):
+        super(VmConfigOption, self).__init__(module)
+        self.device_helper = PyVmomiDeviceHelper(self.module)
+        self.ctl_device_type = self.device_helper.scsi_device_type.copy()
+        self.ctl_device_type.update({'sata': self.device_helper.sata_device_type,
+                                     'nvme': self.device_helper.nvme_device_type}
+                                    )
+        self.ctl_device_type.update(self.device_helper.usb_device_type)
+        self.ctl_device_type.update(self.device_helper.nic_device_type)
+
+    def get_config_option_keys(self, env_browser):
+        support_create = []
+        default_config = ''
+        try:
+            desc = env_browser.QueryConfigOptionDescriptor()
+        except vmodl.RuntimeFault as runtime_fault:
+            self.module.fail_json(msg=to_native(runtime_fault.msg))
+        except Exception as generic_fault:
+            self.module.fail_json(msg="Failed to obtain VM config option descriptor due to fault: %s" % generic_fault)
+        if desc:
+            for option_desc in desc:
+                if option_desc.createSupported:
+                    support_create = support_create + [option_desc.key]
+                if option_desc.defaultConfigOption:
+                    default_config = option_desc.key
+
+        return support_create, default_config
+
+    def get_config_option_by_spec(self, env_browser, guest_id=[], host=None, key=''):
+        vm_config_option = None
+        config_query_spec = vim.EnvironmentBrowser.ConfigOptionQuerySpec(guestId=guest_id, host=host, key=key)
+        try:
+            vm_config_option = env_browser.QueryConfigOptionEx(spec=config_query_spec)
+        except vmodl.RuntimeFault as runtime_fault:
+            self.module.fail_json(msg=to_native(runtime_fault.msg))
+        except Exception as generic_fault:
+            self.module.fail_json(msg="Failed to obtain VM config options due to fault: %s" % generic_fault)
+
+        return vm_config_option
+
+    def get_config_option_recommended(self, guest_os_desc, hwv_version=''):
+        guest_os_option_dict = {}
+        if guest_os_desc and len(guest_os_desc) != 0:
+            default_disk_ctl = default_ethernet = default_cdrom_ctl = default_usb_ctl = ''
+            for name, type in self.ctl_device_type.items():
+                if type == guest_os_desc[0].recommendedDiskController:
+                    default_disk_ctl = name
+                if type == guest_os_desc[0].recommendedEthernetCard:
+                    default_ethernet = name
+                if type == guest_os_desc[0].recommendedCdromController:
+                    default_cdrom_ctl = name
+                if type == guest_os_desc[0].recommendedUSBController:
+                    default_usb_ctl = name
+            guest_os_option_dict = {
+                'Hardware version': hwv_version,
+                'Guest ID': guest_os_desc[0].id,
+                'Guest fullname': guest_os_desc[0].fullName,
+                'Default CPU cores per socket': guest_os_desc[0].numRecommendedCoresPerSocket,
+                'Default CPU socket': guest_os_desc[0].numRecommendedPhysicalSockets,
+                'Default memory in MB': guest_os_desc[0].recommendedMemMB,
+                'Default firmware': guest_os_desc[0].recommendedFirmware,
+                'Default secure boot': guest_os_desc[0].defaultSecureBoot,
+                'Support secure boot': guest_os_desc[0].supportsSecureBoot,
+                'Default disk controller': default_disk_ctl,
+                'Default disk size in MB': guest_os_desc[0].recommendedDiskSizeMB,
+                'Default network adapter': default_ethernet,
+                'Default CDROM controller': default_cdrom_ctl,
+                'Default USB controller': default_usb_ctl
+            }
+
+        return guest_os_option_dict
+
+    def get_guest_id_list(self, guest_os_desc):
+        gos_id_list = []
+        if guest_os_desc:
+            for gos_desc in guest_os_desc.guestOSDescriptor:
+                gos_id_list = gos_id_list + [gos_desc.id]
+
+        return gos_id_list
+
+    def get_config_option_for_guest(self):
+        results = {}
+        guest_id = []
+        host = None
+        datacenter_name = self.params.get('datacenter')
+        cluster_name = self.params.get('cluster_name')
+        esxi_host_name = self.params.get('esxi_hostname')
+        if self.params.get('guest_id'):
+            guest_id = [self.params.get('guest_id')]
+
+        if not self.params.get('get_config_option_keys') and not self.params.get('get_guest_os_ids') \
+                and not self.params.get('get_config_option'):
+            self.module.exit_json(msg="Please set at least one of these parameters 'get_config_option_keys',"
+                                      " 'get_guest_os_ids', 'get_config_option' to True to get the desired info.")
+        if self.params.get('get_config_option') and len(guest_id) == 0:
+            self.module.fail_json(msg="Please set 'guest_id' when 'get_config_option' is set to True,"
+                                      " to get the VM recommended config option for specific guest OS.")
+
+        # Get the datacenter object
+        datacenter = find_obj(self.content, [vim.Datacenter], datacenter_name)
+        if not datacenter:
+            self.module.fail_json(msg='Unable to find datacenter "%s"' % datacenter_name)
+        # Get the cluster object
+        if cluster_name:
+            cluster = find_obj(self.content, [vim.ComputeResource], cluster_name, folder=datacenter)
+            if not cluster:
+                self.module.fail_json(msg='Unable to find cluster "%s"' % cluster_name)
+        # If host is given, get the cluster object using the host
+        elif esxi_host_name:
+            host = find_obj(self.content, [vim.HostSystem], esxi_host_name, folder=datacenter)
+            if not host:
+                self.module.fail_json(msg='Unable to find host "%s"' % esxi_host_name)
+            cluster = host.parent
+        # Define the environment browser object the ComputeResource presents
+        env_browser = cluster.environmentBrowser
+        if env_browser is None:
+            self.module.fail_json(msg="The environmentBrowser of the ComputeResource is None, so can not get the"
+                                      " desired config option info, please check your vSphere environment.")
+        # Get config option keys list
+        support_create_list, default_config = self.get_config_option_keys(env_browser=env_browser)
+        if self.params.get('get_config_option_keys'):
+            results.update({'Supported hardware versions': support_create_list,
+                            'Default hardware version': default_config})
+
+        if self.params.get('get_guest_os_ids') or self.params.get('get_config_option'):
+            # Get supported guest ID list
+            config_option_key = self.params.get('config_option_key', '')
+            if config_option_key and len(support_create_list) != 0 and config_option_key not in support_create_list:
+                self.module.fail_json(msg="Specified config option key '%s' is not in the supported create list: %s"
+                                          % (config_option_key, support_create_list))
+            vm_config_option_all = self.get_config_option_by_spec(env_browser=env_browser, host=host,
+                                                                  key=config_option_key)
+            supported_gos_list = self.get_guest_id_list(guest_os_desc=vm_config_option_all)
+            if self.params.get('get_guest_os_ids'):
+                info_key = 'Supported guest IDs for %s' % vm_config_option_all.version
+                results.update({info_key: supported_gos_list})
+
+            if self.params.get('get_config_option') and len(guest_id) != 0:
+                if supported_gos_list and guest_id[0] not in supported_gos_list:
+                    self.module.fail_json(msg="Specified guest ID '%s' is not in the supported guest ID list: '%s'"
+                                              % (guest_id[0], supported_gos_list))
+                vm_config_option_guest = self.get_config_option_by_spec(env_browser=env_browser, host=host,
+                                                                        guest_id=guest_id, key=config_option_key)
+                guest_os_options = vm_config_option_guest.guestOSDescriptor
+                guest_os_option_dict = self.get_config_option_recommended(guest_os_desc=guest_os_options,
+                                                                          hwv_version=vm_config_option_guest.version)
+                results.update({'Recommended config options': guest_os_option_dict})
+
+        self.module.exit_json(changed=False, failed=False, instance=results)
+
+
+def main():
+    argument_spec = vmware_argument_spec()
+    argument_spec.update(
+        datacenter=dict(type='str', default='ha-datacenter'),
+        cluster_name=dict(type='str', required=False),
+        esxi_hostname=dict(type='str', required=False),
+        get_config_option_keys=dict(type='bool', default=False),
+        get_guest_os_ids=dict(type='bool', default=False),
+        get_config_option=dict(type='bool', default=False),
+        guest_id=dict(type='str', required=False),
+        config_option_key=dict(type='str', required=False),
+    )
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        required_one_of=[
+            ['cluster_name', 'esxi_hostname'],
+        ]
+    )
+    vm_config_option_guest = VmConfigOption(module)
+    vm_config_option_guest.get_config_option_for_guest()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/vmware_vm_config_option.py
+++ b/plugins/modules/vmware_vm_config_option.py
@@ -18,7 +18,7 @@ description: >
    for specified guest OS ID.
 author:
 - Diane Wang (@Tomorrow9) <dianew@vmware.com>
-version_added: '1.14.0'
+version_added: '1.15.0'
 notes:
 - Tested on vSphere 6.5
 - Tested on vSphere 6.7

--- a/plugins/modules/vmware_vm_config_option.py
+++ b/plugins/modules/vmware_vm_config_option.py
@@ -18,7 +18,7 @@ description: >
    for specified guest OS ID.
 author:
 - Diane Wang (@Tomorrow9) <dianew@vmware.com>
-version_added: '1.13.0'
+version_added: '1.14.0'
 notes:
 - Tested on vSphere 6.5
 - Tested on vSphere 6.7

--- a/plugins/modules/vmware_vm_config_option.py
+++ b/plugins/modules/vmware_vm_config_option.py
@@ -12,19 +12,20 @@ DOCUMENTATION = r'''
 ---
 module: vmware_vm_config_option
 short_description: Return supported guest ID list and VM recommended config option for specific guest OS
-description:
-- Return the config option keys supported for creation.
-- Return the guest ID list supported by ESXi host for the most recent virtual hardware supported.
-- Return the VM recommended config option for specific guest OS.
-- Required Privileges: System.View
+description: >
+   This module is used for getting the hardware versions supported for creation, the guest ID list supported by ESXi
+   host for the most recent virtual hardware supported or specified hardware version, the VM recommended config options
+   for specified guest OS ID.
 author:
-- Diane Wang (@Tomorrow9)
+- Diane Wang (@Tomorrow9) <dianew@vmware.com>
 notes:
-- Tested on vSphere 6.5, 6.7
+- Tested on vSphere 6.5
+- Tested on vSphere 6.7
 - Known issue on vSphere 7.0 (https://github.com/vmware/pyvmomi/issues/915)
 requirements:
 - python >= 2.6
 - PyVmomi
+- System.View privilege
 options:
   datacenter:
     description:
@@ -36,48 +37,45 @@ options:
     description:
     - Name of the cluster.
     - If C(esxi_hostname) is not given, this parameter is required.
-    required: false
     type: str
   esxi_hostname:
     description:
     - ESXi hostname.
     - Obtain VM configure options on this ESXi host.
     - If C(cluster_name) is not given, this parameter is required.
-    required: false
     type: str
-  get_config_option_keys
+  get_hardware_versions:
     description:
-    - 'Return the list of VM config option keys supported for creation and the default config option key on the
-      specified entity.'
+    - Return the list of VM hardware versions supported for creation and the default hardware version on the
+      specified entity.
     type: bool
     default: false
   get_guest_os_ids:
     description:
     - Return the list of guest OS IDs supported on the specified entity.
-    - 'If C(config_option_key) is set, will return the corresponding guest OS ID list supported, or will return the
-      guest OS ID list for the default config option key.'
+    - If C(hardware_version) is set, will return the corresponding guest OS ID list supported, or will return the
+      guest OS ID list for the default hardware version.
     type: bool
     default: false
-  get_config_option:
+  get_config_options:
     description:
-    - 'Return the dict of VM recommended config options for guest ID specified by C(guest_id) with config key specified
-      by C(config_option_key) or by default.'
+    - Return the dict of VM recommended config options for guest ID specified by C(guest_id) with hardware version
+      specified by C(hardware_version) or the default hardware version.
     - When set to True, C(guest_id) must be set.
     type: bool
     default: false
   guest_id:
     description:
     - The guest OS ID from the returned list when C(get_guest_os_ids) is set to C(True), e.g., 'rhel8_64Guest'.
-    - This parameter must be set when C(get_config_option) is set to C(True).
-    required: false
+    - This parameter must be set when C(get_config_options) is set to C(True).
     type: str
-  config_option_key:
+  hardware_version:
     description:
-    - The config option key from the returned list when C(get_config_option_keys) is set to C(True), e.g., 'vmx-19'.
+    - The hardware version from the returned list when C(get_hardware_versions) is set to C(True), e.g., 'vmx-19'.
     type: str
-    required: false 
 extends_documentation_fragment:
 - community.vmware.vmware.documentation
+
 '''
 
 EXAMPLES = r'''
@@ -96,7 +94,7 @@ EXAMPLES = r'''
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     esxi_hostname: "{{ esxi_hostname }}"
-    get_config_option: True
+    get_config_options: True
     guest_id: "windows9_64Guest"
   delegate_to: localhost
 '''
@@ -133,7 +131,7 @@ class VmConfigOption(PyVmomi):
         self.ctl_device_type.update(self.device_helper.usb_device_type)
         self.ctl_device_type.update(self.device_helper.nic_device_type)
 
-    def get_config_option_keys(self, env_browser):
+    def get_hardware_versions(self, env_browser):
         support_create = []
         default_config = ''
         try:
@@ -151,8 +149,10 @@ class VmConfigOption(PyVmomi):
 
         return support_create, default_config
 
-    def get_config_option_by_spec(self, env_browser, guest_id=[], host=None, key=''):
+    def get_config_option_by_spec(self, env_browser, guest_id=None, host=None, key=''):
         vm_config_option = None
+        if guest_id is None:
+            guest_id = []
         config_query_spec = vim.EnvironmentBrowser.ConfigOptionQuerySpec(guestId=guest_id, host=host, key=key)
         try:
             vm_config_option = env_browser.QueryConfigOptionEx(spec=config_query_spec)
@@ -213,12 +213,12 @@ class VmConfigOption(PyVmomi):
         if self.params.get('guest_id'):
             guest_id = [self.params.get('guest_id')]
 
-        if not self.params.get('get_config_option_keys') and not self.params.get('get_guest_os_ids') \
-                and not self.params.get('get_config_option'):
-            self.module.exit_json(msg="Please set at least one of these parameters 'get_config_option_keys',"
-                                      " 'get_guest_os_ids', 'get_config_option' to True to get the desired info.")
-        if self.params.get('get_config_option') and len(guest_id) == 0:
-            self.module.fail_json(msg="Please set 'guest_id' when 'get_config_option' is set to True,"
+        if not self.params.get('get_hardware_versions') and not self.params.get('get_guest_os_ids') \
+                and not self.params.get('get_config_options'):
+            self.module.exit_json(msg="Please set at least one of these parameters 'get_hardware_versions',"
+                                      " 'get_guest_os_ids', 'get_config_options' to True to get the desired info.")
+        if self.params.get('get_config_options') and len(guest_id) == 0:
+            self.module.fail_json(msg="Please set 'guest_id' when 'get_config_options' is set to True,"
                                       " to get the VM recommended config option for specific guest OS.")
 
         # Get the datacenter object
@@ -241,31 +241,31 @@ class VmConfigOption(PyVmomi):
         if env_browser is None:
             self.module.fail_json(msg="The environmentBrowser of the ComputeResource is None, so can not get the"
                                       " desired config option info, please check your vSphere environment.")
-        # Get config option keys list
-        support_create_list, default_config = self.get_config_option_keys(env_browser=env_browser)
-        if self.params.get('get_config_option_keys'):
+        # Get supported hardware versions list
+        support_create_list, default_config = self.get_hardware_versions(env_browser=env_browser)
+        if self.params.get('get_hardware_versions'):
             results.update({'Supported hardware versions': support_create_list,
                             'Default hardware version': default_config})
 
-        if self.params.get('get_guest_os_ids') or self.params.get('get_config_option'):
+        if self.params.get('get_guest_os_ids') or self.params.get('get_config_options'):
             # Get supported guest ID list
-            config_option_key = self.params.get('config_option_key', '')
-            if config_option_key and len(support_create_list) != 0 and config_option_key not in support_create_list:
-                self.module.fail_json(msg="Specified config option key '%s' is not in the supported create list: %s"
-                                          % (config_option_key, support_create_list))
+            hardware_version = self.params.get('hardware_version', '')
+            if hardware_version and len(support_create_list) != 0 and hardware_version not in support_create_list:
+                self.module.fail_json(msg="Specified hardware version '%s' is not in the supported create list: %s"
+                                          % (hardware_version, support_create_list))
             vm_config_option_all = self.get_config_option_by_spec(env_browser=env_browser, host=host,
-                                                                  key=config_option_key)
+                                                                  key=hardware_version)
             supported_gos_list = self.get_guest_id_list(guest_os_desc=vm_config_option_all)
             if self.params.get('get_guest_os_ids'):
                 info_key = 'Supported guest IDs for %s' % vm_config_option_all.version
                 results.update({info_key: supported_gos_list})
 
-            if self.params.get('get_config_option') and len(guest_id) != 0:
+            if self.params.get('get_config_options') and len(guest_id) != 0:
                 if supported_gos_list and guest_id[0] not in supported_gos_list:
                     self.module.fail_json(msg="Specified guest ID '%s' is not in the supported guest ID list: '%s'"
                                               % (guest_id[0], supported_gos_list))
                 vm_config_option_guest = self.get_config_option_by_spec(env_browser=env_browser, host=host,
-                                                                        guest_id=guest_id, key=config_option_key)
+                                                                        guest_id=guest_id, key=hardware_version)
                 guest_os_options = vm_config_option_guest.guestOSDescriptor
                 guest_os_option_dict = self.get_config_option_recommended(guest_os_desc=guest_os_options,
                                                                           hwv_version=vm_config_option_guest.version)
@@ -278,13 +278,13 @@ def main():
     argument_spec = vmware_argument_spec()
     argument_spec.update(
         datacenter=dict(type='str', default='ha-datacenter'),
-        cluster_name=dict(type='str', required=False),
-        esxi_hostname=dict(type='str', required=False),
-        get_config_option_keys=dict(type='bool', default=False),
+        cluster_name=dict(type='str'),
+        esxi_hostname=dict(type='str'),
+        get_hardware_versions=dict(type='bool', default=False),
         get_guest_os_ids=dict(type='bool', default=False),
-        get_config_option=dict(type='bool', default=False),
-        guest_id=dict(type='str', required=False),
-        config_option_key=dict(type='str', required=False),
+        get_config_options=dict(type='bool', default=False),
+        guest_id=dict(type='str'),
+        hardware_version=dict(type='str'),
     )
     module = AnsibleModule(
         argument_spec=argument_spec,

--- a/tests/integration/targets/vmware_vm_config_option/aliases
+++ b/tests/integration/targets/vmware_vm_config_option/aliases
@@ -1,0 +1,4 @@
+cloud/vcenter
+needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_1esxi
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_vm_config_option/tasks/main.yml
+++ b/tests/integration/targets/vmware_vm_config_option/tasks/main.yml
@@ -17,7 +17,7 @@
         password: "{{ vcenter_password }}"
         datacenter: "{{ dc1 }}"
         esxi_hostname: "{{ esxi_hosts[0] }}"
-        get_hardware_versions: True
+        get_hardware_versions: true
       register: config_option_keys_1
 
     - debug:
@@ -31,7 +31,7 @@
         password: "{{ vcenter_password }}"
         datacenter: "{{ dc1 }}"
         cluster_name: "{{ ccr1 }}"
-        get_hardware_versions: True
+        get_hardware_versions: true
       register: config_option_keys_2
 
     - debug:
@@ -47,9 +47,9 @@
         password: "{{ vcenter_password }}"
         datacenter: "{{ dc1 }}"
         esxi_hostname: "{{ esxi_hosts[0] }}"
-        get_guest_os_ids: True
+        get_guest_os_ids: true
       register: guest_ids_1
-      ignore_errors: True
+      ignore_errors: true
 
     - debug:
         var: guest_ids_1
@@ -73,10 +73,10 @@
             password: "{{ vcenter_password }}"
             datacenter: "{{ dc1 }}"
             esxi_hostname: "{{ esxi_hosts[0] }}"
-            get_guest_os_ids: True
+            get_guest_os_ids: true
             hardware_version: "{{ config_option_keys_1['instance']['Supported hardware versions'][0] }}"
           register: guest_ids_2
-          ignore_errors: True
+          ignore_errors: true
 
         - debug:
             var: guest_ids_2
@@ -101,10 +101,10 @@
         password: "{{ vcenter_password }}"
         datacenter: "{{ dc1 }}"
         esxi_hostname: "{{ esxi_hosts[0] }}"
-        get_config_options: True
+        get_config_options: true
         guest_id: "rhel6_64Guest"
       register: recommended_configs
-      ignore_errors: True
+      ignore_errors: true
 
     - debug:
         var: recommended_configs

--- a/tests/integration/targets/vmware_vm_config_option/tasks/main.yml
+++ b/tests/integration/targets/vmware_vm_config_option/tasks/main.yml
@@ -1,0 +1,117 @@
+# Test code for the vmware_vm_config_option module.
+# Copyright: (c) 2021, VMware, Inc. All Rights Reserved.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_attach_host: true
+
+- when: vcsim is not defined
+  block:
+    - name: get list of config option keys from ESXi host
+      community.vmware.vmware_vm_config_option:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        datacenter: "{{ dc1 }}"
+        esxi_hostname: "{{ esxi_hosts[0] }}"
+        get_config_option_keys: True
+      register: config_option_keys_1
+
+    - debug:
+        var: config_option_keys_1
+
+    - name: get list of config option keys from cluster
+      community.vmware.vmware_vm_config_option:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        datacenter: "{{ dc1 }}"
+        cluster_name: "{{ ccr1 }}"
+        get_config_option_keys: True
+      register: config_option_keys_2
+
+    - debug:
+        var: config_option_keys_2
+
+    # Ignore errors due to there is known issue on vSphere 7.0.x
+    # https://github.com/vmware/pyvmomi/issues/915
+    - name: get list of supported guest IDs from ESXi host
+      community.vmware.vmware_vm_config_option:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        datacenter: "{{ dc1 }}"
+        esxi_hostname: "{{ esxi_hosts[0] }}"
+        get_guest_os_ids: True
+      register: guest_ids_1
+      ignore_errors: True
+
+    - debug:
+        var: guest_ids_1
+
+    - name: check guest ID list returned when task not failed
+      assert:
+        that:
+          - "'instance' in guest_ids_1"
+      when:
+        - "'failed' in guest_ids_1"
+        - not guest_ids_1.failed
+
+    - block:
+        # Ignore errors due to there is known issue on vSphere 7.0.x
+        # https://github.com/vmware/pyvmomi/issues/915
+        - name: get list of supported guest IDs from ESXi host with config option key
+          community.vmware.vmware_vm_config_option:
+            validate_certs: false
+            hostname: "{{ vcenter_hostname }}"
+            username: "{{ vcenter_username }}"
+            password: "{{ vcenter_password }}"
+            datacenter: "{{ dc1 }}"
+            esxi_hostname: "{{ esxi_hosts[0] }}"
+            get_guest_os_ids: True
+            config_option_key: "{{ config_option_keys_1['instance']['Supported hardware versions'][0] }}"
+          register: guest_ids_2
+          ignore_errors: True
+
+        - debug:
+            var: guest_ids_2
+        - name: check guest ID list returned when task not failed
+          assert:
+            that:
+              - "'instance' in guest_ids_2"
+          when:
+            - "'failed' in guest_ids_2"
+            - not guest_ids_2.failed
+      when:
+        - "'instance' in config_option_keys_1"
+        - "'Supported hardware versions' in config_option_keys_1['instance']"
+
+    # Ignore errors due to there is known issue on vSphere 7.0.x
+    # https://github.com/vmware/pyvmomi/issues/915
+    - name: get dict of recommended configs for specified guest ID from ESXi host
+      community.vmware.vmware_vm_config_option:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        datacenter: "{{ dc1 }}"
+        esxi_hostname: "{{ esxi_hosts[0] }}"
+        get_config_option: True
+        guest_id: "rhel6_64Guest"
+      register: recommended_configs
+      ignore_errors: True
+
+    - debug:
+        var: recommended_configs
+    - name: check guest ID list returned when task not failed
+      assert:
+        that:
+          - "'instance' in recommended_configs"
+      when:
+        - "'failed' in recommended_configs"
+        - not recommended_configs.failed

--- a/tests/integration/targets/vmware_vm_config_option/tasks/main.yml
+++ b/tests/integration/targets/vmware_vm_config_option/tasks/main.yml
@@ -17,7 +17,7 @@
         password: "{{ vcenter_password }}"
         datacenter: "{{ dc1 }}"
         esxi_hostname: "{{ esxi_hosts[0] }}"
-        get_config_option_keys: True
+        get_hardware_versions: True
       register: config_option_keys_1
 
     - debug:
@@ -31,7 +31,7 @@
         password: "{{ vcenter_password }}"
         datacenter: "{{ dc1 }}"
         cluster_name: "{{ ccr1 }}"
-        get_config_option_keys: True
+        get_hardware_versions: True
       register: config_option_keys_2
 
     - debug:
@@ -74,7 +74,7 @@
             datacenter: "{{ dc1 }}"
             esxi_hostname: "{{ esxi_hosts[0] }}"
             get_guest_os_ids: True
-            config_option_key: "{{ config_option_keys_1['instance']['Supported hardware versions'][0] }}"
+            hardware_version: "{{ config_option_keys_1['instance']['Supported hardware versions'][0] }}"
           register: guest_ids_2
           ignore_errors: True
 
@@ -101,7 +101,7 @@
         password: "{{ vcenter_password }}"
         datacenter: "{{ dc1 }}"
         esxi_hostname: "{{ esxi_hosts[0] }}"
-        get_config_option: True
+        get_config_options: True
         guest_id: "rhel6_64Guest"
       register: recommended_configs
       ignore_errors: True


### PR DESCRIPTION
Signed-off-by: dianew <dianew@vmware.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This module can be used to:
1. get the config options keys list (support for creation hardware versions and default hardware version),
2. get the list of supported guest IDs for specified hardware version or default version,
3. get the basic recommended VM config options for specified guest ID with specified hardware version or default version. 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #993 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_vm_config_option

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
TASK [debug] *****************************************************************************************************************************
ok: [localhost] => {
    "vm_default_config": {
        "changed": false,
        "failed": false,
        "instance": {
            "Default hardware version": "vmx-14",
            "Recommended config options": {
                "Default CDROM controller": "sata",
                "Default CPU cores per socket": 1,
                "Default CPU socket": 1,
                "Default USB controller": "",
                "Default disk controller": "paravirtual",
                "Default disk size in MB": 16384,
                "Default firmware": "bios",
                "Default memory in MB": 2048,
                "Default network adapter": "vmxnet3",
                "Default secure boot": true,
                "Guest ID": "rhel7_64Guest",
                "Guest fullname": "Red Hat Enterprise Linux 7 (64-bit)",
                "Hardware version": "vmx-14",
                "Support secure boot": true
            },
            "Supported guest IDs for vmx-14": [
                "amazonlinux2_64Guest",
                "windows9Server64Guest",
                "windows8Server64Guest",
                "windows7Server64Guest",
                "winLonghorn64Guest",
                "winLonghornGuest",
                "winNetEnterprise64Guest",
                "winNetEnterpriseGuest",
                "winNetDatacenter64Guest",
                "winNetDatacenterGuest",
                "winNetStandard64Guest",
                "winNetStandardGuest",
                "winNetWebGuest",
                "winNetBusinessGuest",
                "windows9_64Guest",
                "windows9Guest",
                "windows8_64Guest",
                "windows8Guest",
                "windows7_64Guest",
                "windows7Guest",
                "winVista64Guest",
                "winVistaGuest",
                "winXPPro64Guest",
                "winXPProGuest",
                "win2000AdvServGuest",
                "win2000ServGuest",
                "win2000ProGuest",
                "winNTGuest",
                "win98Guest",
                "win95Guest",
                "win31Guest",
                "dosGuest",
                "vmwarePhoton64Guest",
                "rhel8_64Guest",
                "rhel7_64Guest",
                "rhel6_64Guest",
                "rhel6Guest",
                "rhel5_64Guest",
                "rhel5Guest",
                "rhel4_64Guest",
                "rhel4Guest",
                "rhel3_64Guest",
                "rhel3Guest",
                "rhel2Guest",
                "sles15_64Guest",
                "sles12_64Guest",
                "sles11_64Guest",
                "sles11Guest",
                "sles10_64Guest",
                "sles10Guest",
                "sles64Guest",
                "slesGuest",
                "centos8_64Guest",
                "centos7_64Guest",
                "centos6_64Guest",
                "centos6Guest",
                "centos64Guest",
                "centosGuest",
                "debian10_64Guest",
                "debian10Guest",
                "debian9_64Guest",
                "debian9Guest",
                "debian8_64Guest",
                "debian8Guest",
                "debian7_64Guest",
                "debian7Guest",
                "debian6_64Guest",
                "debian6Guest",
                "debian5_64Guest",
                "debian5Guest",
                "debian4_64Guest",
                "debian4Guest",
                "opensuse64Guest",
                "opensuseGuest",
                "asianux8_64Guest",
                "asianux7_64Guest",
                "asianux4_64Guest",
                "asianux4Guest",
                "asianux3_64Guest",
                "asianux3Guest",
                "fedora64Guest",
                "fedoraGuest",
                "oesGuest",
                "oracleLinux8_64Guest",
                "oracleLinux7_64Guest",
                "oracleLinux6_64Guest",
                "oracleLinux6Guest",
                "oracleLinux64Guest",
                "oracleLinuxGuest",
                "ubuntu64Guest",
                "ubuntuGuest",
                "coreos64Guest",
                "other4xLinux64Guest",
                "other4xLinuxGuest",
                "other3xLinux64Guest",
                "other3xLinuxGuest",
                "other26xLinux64Guest",
                "other26xLinuxGuest",
                "other24xLinux64Guest",
                "other24xLinuxGuest",
                "otherLinux64Guest",
                "otherLinuxGuest",
                "darwin18_64Guest",
                "darwin17_64Guest",
                "darwin16_64Guest",
                "darwin15_64Guest",
                "darwin14_64Guest",
                "darwin13_64Guest",
                "darwin12_64Guest",
                "darwin11_64Guest",
                "darwin11Guest",
                "darwin10_64Guest",
                "darwin10Guest",
                "darwin64Guest",
                "darwinGuest",
                "freebsd12_64Guest",
                "freebsd12Guest",
                "freebsd11_64Guest",
                "freebsd11Guest",
                "freebsd64Guest",
                "freebsdGuest",
                "os2Guest",
                "netware6Guest",
                "netware5Guest",
                "solaris11_64Guest",
                "solaris10_64Guest",
                "solaris10Guest",
                "solaris9Guest",
                "solaris8Guest",
                "openServer6Guest",
                "openServer5Guest",
                "unixWare7Guest",
                "eComStation2Guest",
                "eComStationGuest",
                "otherGuest64",
                "otherGuest",
                "vmkernel65Guest",
                "vmkernel6Guest",
                "vmkernel5Guest",
                "vmkernelGuest"
            ],
            "Supported hardware versions": [
                "vmx-04",
                "vmx-07",
                "vmx-08",
                "vmx-09",
                "vmx-10",
                "vmx-11",
                "vmx-12",
                "vmx-13",
                "vmx-14",
                "vmx-15"
            ]
        }
    }
}
```
