### PR TITLE
vmware_guest_network: Fix adding NICs to powered-off VM

### DIFF
--- a/changelogs/fragments/860-vmware_guest_network.yml
+++ b/changelogs/fragments/860-vmware_guest_network.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_guest_network - Fix adding more than one NIC to a VM before powering on (https://github.com/ansible-collections/community.vmware/issues/860).

--- a/plugins/modules/vmware_guest_network.py
+++ b/plugins/modules/vmware_guest_network.py
@@ -467,7 +467,7 @@ class PyVmomiHelper(PyVmomi):
 
             nic_info_lst.append(d_item)
 
-        nic_info_lst = sorted(nic_info_lst, key=lambda d: d['mac_address'])
+        nic_info_lst = sorted(nic_info_lst, key=lambda d: d['mac_address'] if (d['mac_address'] is not None) else '00:00:00:00:00:00')
         return nic_info_lst, nics
 
     def _get_compute_resource_by_name(self, recurse=True):


### PR DESCRIPTION
##### SUMMARY
Adding several NICs to a VM might fail, apparently because [Python 3.0 changed the rules for ordering comparisons](https://docs.python.org/3/whatsnew/3.0.html#ordering-comparisons) so that comparing `None` to something fails now.

Fixes #860 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_guest_network

##### ADDITIONAL INFORMATION
Please see issue #860 for more information.
