### PR TITLE
vmware_host_service_manager: Change startup policy without defining state

### DIFF
--- a/changelogs/fragments/916-vmware_host_service_manager.yml
+++ b/changelogs/fragments/916-vmware_host_service_manager.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_host_service_manager - Introducing a new state "unchanged" to allow defining startup policy without defining service state or automatically starting it (https://github.com/ansible-collections/community.vmware/issues/916).

--- a/plugins/modules/vmware_host_service_manager.py
+++ b/plugins/modules/vmware_host_service_manager.py
@@ -41,7 +41,7 @@ options:
     - Desired state of service.
     - "State value 'start' and 'present' has same effect."
     - "State value 'stop' and 'absent' has same effect."
-    - State value C(unchanged) is added in version 1.14.0.
+    - State value C(unchanged) is added in version 1.14.0 to allow defining startup policy without defining or changing service state.
     choices: [ absent, present, restart, start, stop, unchanged ]
     type: str
     default: 'start'

--- a/plugins/modules/vmware_host_service_manager.py
+++ b/plugins/modules/vmware_host_service_manager.py
@@ -41,7 +41,7 @@ options:
     - Desired state of service.
     - "State value 'start' and 'present' has same effect."
     - "State value 'stop' and 'absent' has same effect."
-    choices: [ absent, present, restart, start, stop ]
+    choices: [ absent, present, restart, start, stop, unchanged ]
     type: str
     default: 'start'
   service_policy:
@@ -201,7 +201,7 @@ def main():
     argument_spec.update(
         cluster_name=dict(type='str', required=False),
         esxi_hostname=dict(type='str', required=False),
-        state=dict(type='str', default='start', choices=['absent', 'present', 'restart', 'start', 'stop']),
+        state=dict(type='str', default='start', choices=['absent', 'present', 'restart', 'start', 'stop', 'unchanged']),
         service_name=dict(type='str', required=True),
         service_policy=dict(type='str', choices=['automatic', 'off', 'on']),
     )

--- a/plugins/modules/vmware_host_service_manager.py
+++ b/plugins/modules/vmware_host_service_manager.py
@@ -41,6 +41,7 @@ options:
     - Desired state of service.
     - "State value 'start' and 'present' has same effect."
     - "State value 'stop' and 'absent' has same effect."
+    - State value C(unchanged) is added in version 1.14.0.
     choices: [ absent, present, restart, start, stop, unchanged ]
     type: str
     default: 'start'


### PR DESCRIPTION
##### SUMMARY
When setting the service startup policy using the vmware_host_service_manager module, you have to specify the service state if you don't want to start the service, which is the default behavior. Changing the default for `state` would be a breaking change so this PR introduces a new state `unchanged` that will not change the service state.

Fixes #916

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_host_service_manager

##### ADDITIONAL INFORMATION
Please see the issue this PR is trying to fix, I don't think I have any additional information apart from this.
