### PR TITLE
doc: Add a note about free ESXi license

### DIFF
--- a/docs/docsite/rst/vmware_scenarios/vmware_requirements.rst
+++ b/docs/docsite/rst/vmware_scenarios/vmware_requirements.rst
@@ -7,6 +7,15 @@ VMware Prerequisites
 .. contents::
    :local:
 
+ESXi License
+============
+
+Access to the vSphere API is governed by the various vSphere Editions which provides both read and write access to the API.
+If you are using vSphere Hypervisor (free edition of ESXi), the vSphere API will only be available as read-only.
+All modules requires API write access to perform various actions. Hence, a free ESXi license will not be supported.
+Please check `this blog post <https://blogs.vmware.com/vsphere/2012/02/introduction-to-the-vsphere-api-part-1.html>`_ for more details.
+
+
 Installing SSL Certificates
 ===========================
 

--- a/plugins/doc_fragments/vmware.py
+++ b/plugins/doc_fragments/vmware.py
@@ -12,6 +12,8 @@ __metaclass__ = type
 class ModuleDocFragment(object):
     # Parameters for VMware modules
     DOCUMENTATION = r'''
+notes:
+  - All modules requires API write access and hence is not supported on a free ESXi license.
 options:
     hostname:
       description:
@@ -66,6 +68,8 @@ options:
 
     # This doc fragment is specific to vcenter modules like vcenter_license
     VCENTER_DOCUMENTATION = r'''
+notes:
+  - All modules requires API write access and hence is not supported on a free ESXi license.
 options:
     hostname:
       description:

--- a/plugins/modules/vmware_target_canonical_facts.py
+++ b/plugins/modules/vmware_target_canonical_facts.py
@@ -27,7 +27,6 @@ description:
 author:
 - Joseph Callen (@jcpowermac)
 - Abhijeet Kasurde (@Akasurde)
-notes:
 requirements:
     - Tested on vSphere 5.5 and 6.5
     - PyVmomi installed

--- a/plugins/modules/vmware_target_canonical_info.py
+++ b/plugins/modules/vmware_target_canonical_info.py
@@ -17,7 +17,6 @@ description:
 author:
 - Joseph Callen (@jcpowermac)
 - Abhijeet Kasurde (@Akasurde)
-notes:
 requirements:
     - Tested on vSphere 5.5 and 6.5
     - PyVmomi installed


### PR DESCRIPTION
##### SUMMARY

All modules require API write access, which is not provided
in a free ESXi license. Added a note in all the modules so
that users will find it easily.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/vmware_scenarios/vmware_requirements.rst
plugins/doc_fragments/vmware.py
plugins/modules/vmware_target_canonical_facts.py
plugins/modules/vmware_target_canonical_info.py
