### PR TITLE
vmware_guest: fix the Windows Administrator password being set to string 'None'

### DIFF
--- a/changelogs/fragments/1017-vmware_guest-fix_administrator_password.yml
+++ b/changelogs/fragments/1017-vmware_guest-fix_administrator_password.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_guest - when ``customization.password`` is not defined, the Administrator password is made empty instead of setting it to string 'None' (https://github.com/ansible-collections/community.vmware/issues/1017).

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -680,6 +680,7 @@ options:
             type: str
             description:
             - Local administrator password.
+            - Required.
             - Specific to Windows customization.
         productid:
             type: str
@@ -2218,7 +2219,10 @@ class PyVmomiHelper(PyVmomi):
 
             ident.identification = vim.vm.customization.Identification()
 
-            if self.params['customization'].get('password', '') != '':
+            if self.params['customization'].get('password', '') is None:
+                self.module.fail_json(msg="'password' entry is required in 'customization' section")
+
+            else:
                 ident.guiUnattended.password = vim.vm.customization.Password()
                 ident.guiUnattended.password.value = str(self.params['customization']['password'])
                 ident.guiUnattended.password.plainText = True

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -2219,9 +2219,8 @@ class PyVmomiHelper(PyVmomi):
 
             ident.identification = vim.vm.customization.Identification()
 
-            if self.params['customization']['password'] is None:
-                self.module.fail_json(msg="'password' entry is required in 'customization' section")
-
+            if self.params['customization']['password'] is None or self.params['customization']['password'] == '':
+                ident.guiUnattended.password = None
             else:
                 ident.guiUnattended.password = vim.vm.customization.Password()
                 ident.guiUnattended.password.value = str(self.params['customization']['password'])

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -680,7 +680,7 @@ options:
             type: str
             description:
             - Local administrator password.
-            - Required.
+            - If not defined, the password will be set to blank (that is, no password).
             - Specific to Windows customization.
         productid:
             type: str

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -2219,7 +2219,7 @@ class PyVmomiHelper(PyVmomi):
 
             ident.identification = vim.vm.customization.Identification()
 
-            if self.params['customization'].get('password', '') is None:
+            if self.params['customization']['password'] is None:
                 self.module.fail_json(msg="'password' entry is required in 'customization' section")
 
             else:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When using Windows VM customization and not specifying a password, the Administrator password is reset to string 'None'. ~~This PR is making the parameter mandatory.~~ This PR is fixing that - when password is not defined, it is cleared (https://vdc-download.vmware.com/vmwb-repository/dcr-public/b50dcbbf-051d-4204-a3e7-e1b618c1e384/538cf2ec-b34f-4bae-a332-3820ef9e7773/vim.vm.customization.GuiUnattended.html).

Fixes: #1017 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_guest

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
