### PR TITLE
vsphere_file: Update `file` example

### DIFF
--- a/plugins/modules/vsphere_file.py
+++ b/plugins/modules/vsphere_file.py
@@ -105,7 +105,7 @@ EXAMPLES = r'''
     datacenter: DC1 Someplace
     datastore: datastore1
     path: some/remote/file
-    state: touch
+    state: file
   delegate_to: localhost
   ignore_errors: true
 


### PR DESCRIPTION


##### SUMMARY
There is module called **community.vmware.vsphere_file** . There is one task _Query a file on a datastore_  to get information of already existing file on vsphere. But In Documentation there mentioned **state : touch** . But state:touch is used to create new blank file on vsphere,not to get existing file information. In order to Query a file the state attribute value should `file` not touch.   

 **state :  file**

Correct code :

- name: Query a file on a datastore
  community.vmware.vsphere_file:
    host: '{{ vhost }}'
    username: '{{ vuser }}'
    password: '{{ vpass }}'
    datacenter: DC1 Someplace
    datastore: datastore1
    path: some/remote/file
    **state: file**
  delegate_to: localhost
  ignore_errors: true




Fixes #1029 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
community.vmware.vsphere_file


