### PR TITLE
vmware_guest_powerstate: handle 'present' state

### DIFF
--- a/changelogs/fragments/powerstate.yml
+++ b/changelogs/fragments/powerstate.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- vmware_guest_powerstate - handle 'present' state as 'poweredon' (https://github.com/ansible-collections/community.vmware/pull/1033).

--- a/plugins/module_utils/vmware.py
+++ b/plugins/module_utils/vmware.py
@@ -918,6 +918,8 @@ def set_vm_power_state(content, vm, state, force, timeout=0, answers=None):
     requested states. force is forceful
     """
     facts = gather_vm_facts(content, vm)
+    if state == 'present':
+        state = 'poweredon'
     expected_state = state.replace('_', '').replace('-', '').lower()
     current_state = facts['hw_power_status'].lower()
     result = dict(


### PR DESCRIPTION
##### SUMMARY

set_vm_powerstate does not consider 'present' state.
This fix updates 'present' state to 'poweredon' state for
`vmware_guest_powerstate`.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/powerstate.yml
plugins/module_utils/vmware.py
