### PR TITLE
vmware_guest: Update documentation about "Resources" example

### DIFF
--- a/docs/community.vmware.vmware_guest_module.rst
+++ b/docs/community.vmware.vmware_guest_module.rst
@@ -1943,7 +1943,6 @@ Parameters
                     </div>
                 </td>
                 <td>
-                        <b>Default:</b><br/><div style="color: blue">"Resources"</div>
                 </td>
                 <td>
                         <div>Use the given resource pool for virtual machine operation.</div>

--- a/docs/community.vmware.vmware_guest_module.rst
+++ b/docs/community.vmware.vmware_guest_module.rst
@@ -1943,6 +1943,7 @@ Parameters
                     </div>
                 </td>
                 <td>
+                        <b>Default:</b><br/><div style="color: blue">"Resources"</div>
                 </td>
                 <td>
                         <div>Use the given resource pool for virtual machine operation.</div>

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -390,6 +390,7 @@ options:
     - Use the given resource pool for virtual machine operation.
     - This parameter is case sensitive.
     - Resource pool should be child of the selected host parent.
+    - When not specified I(Resources) is taken as default value.
     type: str
   wait_for_ip_address:
     description:


### PR DESCRIPTION
Document the vmware default resource pool name "Resources" in case this module is used in a loop and must be specified

##### SUMMARY
Adds vmware default catch-all resource pool name 'Resources'

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
vmware_guest

##### ADDITIONAL INFORMATION
Simplify how vmware handles this variable when undefined (or defined in a loop and operator needs to use the proper default)
