### PR TITLE
vmware_vcenter_settings_info: Fix an issue that Python error has occurred when the schema is vsphere

### DIFF
--- a/changelogs/fragments/1050-vmware_vcenter_settings_info.yml
+++ b/changelogs/fragments/1050-vmware_vcenter_settings_info.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_vcenter_settings_info - fix to return all VCSA settings when setting vsphere to the schema and not specifying the properties (https://github.com/ansible-collections/community.vmware/pull/1050).

--- a/plugins/modules/vmware_vcenter_settings_info.py
+++ b/plugins/modules/vmware_vcenter_settings_info.py
@@ -181,11 +181,15 @@ class VmwareVcenterSettingsInfo(PyVmomi):
                 if key in exists_vcenter_config:
                     result[value] = setting.value
         else:
-            for property in self.properties:
-                if property in exists_vcenter_config:
+            if self.properties:
+                for property in self.properties:
+                    if property in exists_vcenter_config:
+                        result[property] = exists_vcenter_config[property]
+                    else:
+                        self.module.fail_json(msg="Propety '%s' not found" % property)
+            else:
+                for property in exists_vcenter_config.keys():
                     result[property] = exists_vcenter_config[property]
-                else:
-                    self.module.fail_json(msg="Propety '%s' not found" % property)
 
         self.module.exit_json(changed=False, vcenter_config_info=result)
 

--- a/tests/integration/targets/vmware_vcenter_settings_info/tasks/main.yml
+++ b/tests/integration/targets/vmware_vcenter_settings_info/tasks/main.yml
@@ -18,7 +18,7 @@
 - assert:
     that:
       - gather_info_about_vcenter_settings_result.vcenter_config_info is defined
-      - gather_info_about_vcenter_settings_result.vcenter_config_info | length == 34
+      - gather_info_about_vcenter_settings_result.vcenter_config_info | length == 32
 
 - name: "Get a list of information about vCenter settings by specifying the properties"
   community.vmware.vmware_vcenter_settings_info:

--- a/tests/integration/targets/vmware_vcenter_settings_info/tasks/main.yml
+++ b/tests/integration/targets/vmware_vcenter_settings_info/tasks/main.yml
@@ -8,7 +8,7 @@
     setup_attach_host: true
 
 - name: "Gather info about vCenter settings"
-  vmware_vcenter_settings_info:
+  community.vmware.vmware_vcenter_settings_info:
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
@@ -18,10 +18,10 @@
 - assert:
     that:
       - gather_info_about_vcenter_settings_result.vcenter_config_info is defined
-      - gather_info_about_vcenter_settings_result.vcenter_config_info | length == 32
+      - gather_info_about_vcenter_settings_result.vcenter_config_info | length == 34
 
 - name: "Get a list of information about vCenter settings by specifying the properties"
-  vmware_vcenter_settings_info:
+  community.vmware.vmware_vcenter_settings_info:
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
@@ -38,3 +38,16 @@
       - get_list_of_info_about_vcenter_settings_result.vcenter_config_info['config.workflow.port'] is defined
       - get_list_of_info_about_vcenter_settings_result.vcenter_config_info['config.log.level'] is defined
       - get_list_of_info_about_vcenter_settings_result.vcenter_config_info['vpxd.locale'] is defined
+
+- name: "Gather all vCenter settings"
+  community.vmware.vmware_vcenter_settings_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    schema: vsphere
+  register: all_vcenter_settings_result
+
+- assert:
+    that:
+      - all_vcenter_settings_result.vcenter_config_info['config.vmacore.threadPool.TaskMax'] is defined


### PR DESCRIPTION
##### SUMMARY

This PR will fix to return all VCSA settings when setting vsphere to the schema and not specifying the properties.

fixes: https://github.com/ansible-collections/community.vmware/issues/1049

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

changelogs/fragments/1050-vmware_vcenter_settings_info.yml
plugins/modules/vmware_vcenter_settings_info.py
tests/integration/targets/vmware_vcenter_settings_info/tasks/main.yml

##### ADDITIONAL INFORMATION

tested on VCSA/ESXi 7.0