### PR TITLE
Deprecate vmware_guest_vnc

### DIFF
--- a/changelogs/fragments/deprecate-vmware_guest_vnc.yml
+++ b/changelogs/fragments/deprecate-vmware_guest_vnc.yml
@@ -1,0 +1,2 @@
+deprecated_features:
+  - vmware_guest_vnc -  Sphere 7.0 removed the built-in VNC server (https://docs.vmware.com/en/VMware-vSphere/7.0/rn/vsphere-esxi-vcenter-server-70-release-notes.html#productsupport).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -310,3 +310,7 @@ plugin_routing:
       deprecation:
         removal_date: 2021-12-01
         warning_text: see plugin documentation for details
+    vmware_guest_vnc:
+      deprecation:
+        removal_date: 2022-10-15
+        warning_text: see plugin documentation for details

--- a/plugins/modules/vmware_guest_vnc.py
+++ b/plugins/modules/vmware_guest_vnc.py
@@ -13,8 +13,8 @@ DOCUMENTATION = r'''
 module: vmware_guest_vnc
 deprecated:
   removed_at_date: '2022-10-15'
-  why: VNC has been removed in 7.0 U(https://docs.vmware.com/en/VMware-vSphere/7.0/rn/vsphere-esxi-vcenter-server-70-release-notes.html#productsupport).
-  alternative: Users should use the VM Console via the vSphere Client, the ESXi Host Client, or the VMware Remote Console, to connect virtual machines.
+  why: VNC has been removed in 7.0 and 2022-10-15 is the End of General Support date for 6.5 / 6.7.
+  alternative: Users should use the VM Console via the vSphere Client, the ESXi Host Client, or the VMware Remote Console to connect to virtual machines.
   removed_from_collection: 'community.vmware'
 short_description: Manages VNC remote display on virtual machines in vCenter
 description:

--- a/plugins/modules/vmware_guest_vnc.py
+++ b/plugins/modules/vmware_guest_vnc.py
@@ -15,6 +15,7 @@ deprecated:
   removed_at_date: '2022-10-15'
   why: VNC has been removed in 7.0 U(https://docs.vmware.com/en/VMware-vSphere/7.0/rn/vsphere-esxi-vcenter-server-70-release-notes.html#productsupport).
   alternative: Users should use the VM Console via the vSphere Client, the ESXi Host Client, or the VMware Remote Console, to connect virtual machines.
+  removed_from_collection: 'community.vmware'
 short_description: Manages VNC remote display on virtual machines in vCenter
 description:
   - This module can be used to enable and disable VNC remote display on virtual machine.

--- a/plugins/modules/vmware_guest_vnc.py
+++ b/plugins/modules/vmware_guest_vnc.py
@@ -13,7 +13,8 @@ DOCUMENTATION = r'''
 module: vmware_guest_vnc
 deprecated:
   removed_at_date: '2022-10-15'
-  why: In vSphere 7.0, the ESXi built-in VNC server has been removed U(https://docs.vmware.com/en/VMware-vSphere/7.0/rn/vsphere-esxi-vcenter-server-70-release-notes.html#productsupport).
+  why: VNC has been removed in 7.0 U(https://docs.vmware.com/en/VMware-vSphere/7.0/rn/vsphere-esxi-vcenter-server-70-release-notes.html#productsupport).
+  alternative: Users should use the VM Console via the vSphere Client, the ESXi Host Client, or the VMware Remote Console, to connect virtual machines.
 short_description: Manages VNC remote display on virtual machines in vCenter
 description:
   - This module can be used to enable and disable VNC remote display on virtual machine.

--- a/plugins/modules/vmware_guest_vnc.py
+++ b/plugins/modules/vmware_guest_vnc.py
@@ -11,6 +11,9 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 ---
 module: vmware_guest_vnc
+deprecated:
+  removed_at_date: '2022-10-15'
+  why: In vSphere 7.0, the ESXi built-in VNC server has been removed U(https://docs.vmware.com/en/VMware-vSphere/7.0/rn/vsphere-esxi-vcenter-server-70-release-notes.html#productsupport).
 short_description: Manages VNC remote display on virtual machines in vCenter
 description:
   - This module can be used to enable and disable VNC remote display on virtual machine.
@@ -233,6 +236,12 @@ def main():
         mutually_exclusive=[
             ['name', 'uuid', 'moid']
         ]
+    )
+
+    module.deprecate(
+        msg="The 'vmware_guest_vnc' module is deprecated because vSphere 7.0 removed the built-in VNC server",
+        date="2022-10-15",
+        collection_name="community.vmware"
     )
 
     result = dict(changed=False, failed=False)

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -224,6 +224,7 @@ plugins/modules/vmware_guest_video.py compile-2.6!skip
 plugins/modules/vmware_guest_video.py import-2.6!skip
 plugins/modules/vmware_guest_vnc.py compile-2.6!skip
 plugins/modules/vmware_guest_vnc.py import-2.6!skip
+plugins/modules/vmware_guest_vnc.py validate-modules:deprecation-mismatch
 plugins/modules/vmware_guest_vnc.py validate-modules:invalid-documentation
 plugins/modules/vmware_host_acceptance.py compile-2.6!skip
 plugins/modules/vmware_host_acceptance.py import-2.6!skip

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -224,6 +224,7 @@ plugins/modules/vmware_guest_video.py compile-2.6!skip
 plugins/modules/vmware_guest_video.py import-2.6!skip
 plugins/modules/vmware_guest_vnc.py compile-2.6!skip
 plugins/modules/vmware_guest_vnc.py import-2.6!skip
+plugins/modules/vmware_guest_vnc.py pylint:ansible-deprecated-no-version
 plugins/modules/vmware_guest_vnc.py validate-modules:deprecation-mismatch
 plugins/modules/vmware_guest_vnc.py validate-modules:invalid-documentation
 plugins/modules/vmware_host_acceptance.py compile-2.6!skip

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -224,6 +224,7 @@ plugins/modules/vmware_guest_video.py compile-2.6!skip
 plugins/modules/vmware_guest_video.py import-2.6!skip
 plugins/modules/vmware_guest_vnc.py compile-2.6!skip
 plugins/modules/vmware_guest_vnc.py import-2.6!skip
+plugins/modules/vmware_guest_vnc.py validate-modules:invalid-documentation
 plugins/modules/vmware_host_acceptance.py compile-2.6!skip
 plugins/modules/vmware_host_acceptance.py import-2.6!skip
 plugins/modules/vmware_host_active_directory.py compile-2.6!skip


### PR DESCRIPTION
##### SUMMARY
vSphere 7.0 removed the built-in VNC server (see the [release notes](https://docs.vmware.com/en/VMware-vSphere/7.0/rn/vsphere-esxi-vcenter-server-70-release-notes.html#productsupport)) so I don't see the need to have a module for this anymore.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_guest_vnc

##### ADDITIONAL INFORMATION
#28 