### PR TITLE
vmware_deploy_ovf: Fix to display suitable the error

### DIFF
--- a/changelogs/fragments/1065-vmware_deploy_ovf.yml
+++ b/changelogs/fragments/1065-vmware_deploy_ovf.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_deploy_ovf - fixed to display suitable the error when not exist an ovf file path (https://github.com/ansible-collections/community.vmware/pull/1065).

--- a/plugins/modules/vmware_deploy_ovf.py
+++ b/plugins/modules/vmware_deploy_ovf.py
@@ -399,6 +399,12 @@ class VMwareDeployOvf(PyVmomi):
         return self.datastore, self.datacenter, self.resource_pool, self.network_mappings
 
     def get_ovf_descriptor(self):
+        # Check whether ovf/ova file exists
+        try:
+            path_exists(self.params['ovf'])
+        except ValueError as e:
+            self.module.fail_json(msg="%s" % e)
+
         if tarfile.is_tarfile(self.params['ovf']):
             self.tar = tarfile.open(self.params['ovf'])
             ovf = None


### PR DESCRIPTION
##### SUMMARY

This PR will fix to display suitable the error when not exist an ovf file path.

fixes: https://github.com/ansible-collections/community.vmware/issues/1064

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

plugins/modules/vmware_deploy_ovf.py

##### ADDITIONAL INFORMATION

tested on VCSA/ESXi 7.0