### PR TITLE
Fix shellcheck SC2230 error

### DIFF
--- a/tests/integration/targets/inventory_vmware_host_inventory/runme.sh
+++ b/tests/integration/targets/inventory_vmware_host_inventory/runme.sh
@@ -2,7 +2,7 @@
 set -eux
 
 # Envs
-export ANSIBLE_PYTHON_INTERPRETER=${ANSIBLE_TEST_PYTHON_INTERPRETER:-$(which python)}
+export ANSIBLE_PYTHON_INTERPRETER=${ANSIBLE_TEST_PYTHON_INTERPRETER:-$(command -v python)}
 export ANSIBLE_INVENTORY_ENABLED="community.vmware.vmware_host_inventory,host_list,ini"
 export ANSIBLE_CACHE_PLUGIN_CONNECTION="${PWD}/inventory_cache"
 export ANSIBLE_CACHE_PLUGIN="community.general.jsonfile"

--- a/tests/integration/targets/inventory_vmware_vm_inventory/runme.sh
+++ b/tests/integration/targets/inventory_vmware_vm_inventory/runme.sh
@@ -2,7 +2,7 @@
 set -eux
 
 # Envs
-export ANSIBLE_PYTHON_INTERPRETER=${ANSIBLE_TEST_PYTHON_INTERPRETER:-$(which python)}
+export ANSIBLE_PYTHON_INTERPRETER=${ANSIBLE_TEST_PYTHON_INTERPRETER:-$(command -v python)}
 export ANSIBLE_INVENTORY_ENABLED="community.vmware.vmware_vm_inventory,host_list,ini"
 export ANSIBLE_CACHE_PLUGIN_CONNECTION="${PWD}/inventory_cache"
 export ANSIBLE_CACHE_PLUGIN="community.general.jsonfile"


### PR DESCRIPTION
`ansible-test-sanity-docker-devel` fails:

```
ERROR: Found 2 shellcheck issue(s) which need to be resolved:
ERROR: tests/integration/targets/inventory_vmware_host_inventory/runme.sh:5:72: SC2230: which is non-standard. Use builtin 'command -v' instead.
ERROR: tests/integration/targets/inventory_vmware_vm_inventory/runme.sh:5:72: SC2230: which is non-standard. Use builtin 'command -v' instead.
```

This doesn't hurt because it's non-voting. However, I'd prefer it to succeed.

It looks like shellcheck wants us to replace `which` with `command -v` so I'd like to give this a try. 