### PR TITLE
create_documentation_tasks: Don't backup / restore docs/docsite

### DIFF
--- a/tools/create_documentation_tasks.yml
+++ b/tools/create_documentation_tasks.yml
@@ -2,11 +2,5 @@
   ansible.builtin.pip:
     name: tox
 
-- name: Rescue docs/docsite
-  ansible.builtin.shell: 'mv ../docs/docsite /tmp'
-
 - name: Refresh the README.md
   ansible.builtin.shell: tox -e add_docs
-
-- name: Restore docs/docsite
-  ansible.builtin.shell: 'mv /tmp/docsite ../docs'


### PR DESCRIPTION
##### SUMMARY
Now that ansible-network/collection_prep#66 is merged, we don't need to backup and restore `docs/docsite` anymore.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
tools/create_documentation_tasks.yml