### PR TITLE
Add support for configuring SR-IOV advanced options on a network interface in a VM

### DIFF
--- a/changelogs/fragments/1080-add-sr-iov-advanced-options.yml
+++ b/changelogs/fragments/1080-add-sr-iov-advanced-options.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - create_nic - support advanced SR-IOV options from the VMware API (PCI device physical/virtual backing and guest OS MTU change)

--- a/changelogs/fragments/1080-add-sr-iov-advanced-options.yml
+++ b/changelogs/fragments/1080-add-sr-iov-advanced-options.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - create_nic - support advanced SR-IOV options from the VMware API (PCI device physical/virtual backing and guest OS MTU change)
+  - create_nic - add advanced SR-IOV options from the VMware API (PCI dev PF/VF backing and guest OS MTU change)

--- a/plugins/module_utils/vm_device_helper.py
+++ b/plugins/module_utils/vm_device_helper.py
@@ -292,6 +292,18 @@ class PyVmomiDeviceHelper(object):
         nic.device.connectable.startConnected = bool(device_infos.get('start_connected', True))
         nic.device.connectable.allowGuestControl = bool(device_infos.get('allow_guest_control', True))
         nic.device.connectable.connected = bool(device_infos.get('connected', True))
+        if device_type == 'sriov':
+            pf_backing = device_infos.get('physical_function_backing', None)
+            vf_backing = device_infos.get('virtual_function_backing', None)
+
+            nic.device.allowGuestOSMtuChange = bool(device_infos.get('allow_gest_os_mtu_change', True))
+            nic.device.sriovBacking = vim.vm.device.VirtualSriovEthernetCard.SriovBackingInfo()
+            if pf_backing is not None:
+                nic.device.sriovBacking.physicalFunctionBacking = vim.vm.device.VirtualPCIPassthrough.DeviceBackingInfo()
+                nic.device.sriovBacking.physicalFunctionBacking.id = pf_backing
+            if vf_backing is not None:
+                nic.device.sriovBacking.virtualFunctionBacking = vim.vm.device.VirtualPCIPassthrough.DeviceBackingInfo()
+                nic.device.sriovBacking.virtualFunctionBacking.id = vf_backing
         if 'mac' in device_infos and is_mac(device_infos['mac']):
             nic.device.addressType = 'manual'
             nic.device.macAddress = device_infos['mac']


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
A very basic patch to add support for configuring the device backing of a SR-IOV device.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_guest: Add the following options to a network interface definition, which are to be used for a sriov device : 
- allow_gest_os_mtu_change
- physical_function_backing
- virtual_function_backing

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Initial module behavior would be to assign the first physical hardware available from the network port group. However, I have a scenario where I need to connect one VM to two different physical network interfaces for redundancy purposes, as they are connected to different network equipments.

Therefore, I want to be able to request that SR-IOV NIC 1 is connected to 0000:5d:00.0 and NIC 2 is connected to 0000:5d:00.1, for instance.

I eventually plan on implementing a lookup feature to figure the PCI ID directly from the "vmnicX" name, but this could also be done in real time by matching against curated information acquired via another Ansible task such as vmware_host_vmnic_info.

<!--- Paste verbatim command output below, e.g. before and after your change -->
The following code then makes it possible to get the results I want :
```paste below
- vmware_guest:
  <<: *vmware_common_parameters
  networks:
    - { 'name': PortGroup, 'device_type': 'sriov', 'physical_function_backing': '0000:5d:00.0' }
    - { 'name': PortGroup, 'device_type': 'sriov', 'physical_function_backing': '0000:5d:00.1' }
```

This allows to pin the physical function backing to a specific device, while keeping the virtual function selection automatic.

My implementation is based on the details for sriov devices in the API documentation from VMware:
https://vdc-download.vmware.com/vmwb-repository/dcr-public/98d63b35-d822-47fe-a87a-ddefd469df06/2e3c7b58-f2bd-486e-8bb1-a75eb0640bee/doc/vim.vm.device.VirtualSriovEthernetCard.html