### PR TITLE
vmware_host_lockdown: Fix vim import

### DIFF
--- a/changelogs/fragments/1083_vmware_host_lockdown.yml
+++ b/changelogs/fragments/1083_vmware_host_lockdown.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_host_lockdown - Fix an issue when enabling or disabling lockdown mode failes (https://github.com/ansible-collections/community.vmware/issues/1083)

--- a/plugins/modules/vmware_host_lockdown.py
+++ b/plugins/modules/vmware_host_lockdown.py
@@ -121,7 +121,7 @@ results:
 '''
 
 try:
-    from pyvmomi import vim
+    from pyVmomi import vim
     HAS_PYVMOMI = True
 except ImportError:
     HAS_PYVMOMI = False


### PR DESCRIPTION
##### SUMMARY
There's a typo, the module includes `vim` from `pyvmomi` instead of `pyVmomi` (with a capital `V`) and doesn't check that this works:

https://github.com/ansible-collections/community.vmware/blob/f418bdaa6a678c09b6fb9115d927d8c44d50060f/plugins/modules/vmware_host_lockdown.py#L123-L126

Fixes #1083

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_host_lockdown

##### ADDITIONAL INFORMATION
I think nobody ran into this issue yet because enabling or disabling lockdown seldom fails (in my experience) and `vim` is only used in this case:

https://github.com/ansible-collections/community.vmware/blob/f418bdaa6a678c09b6fb9115d927d8c44d50060f/plugins/modules/vmware_host_lockdown.py#L176-L182