### PR TITLE
[WIP] vmware_dvs_portgroup: Fix default for port_allocation

### DIFF
--- a/changelogs/fragments/1071_vmware_dvs_portgroup.yml
+++ b/changelogs/fragments/1071_vmware_dvs_portgroup.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_dvs_portgroup - fix the default for port_allocation when port_binding is set to static (https://github.com/ansible-collections/community.vmware/issues/1071)

--- a/plugins/modules/vmware_dvs_portgroup.py
+++ b/plugins/modules/vmware_dvs_portgroup.py
@@ -377,6 +377,9 @@ class VMwareDvsPortgroup(PyVmomi):
         self.dvs_portgroup = None
         self.dv_switch = None
 
+        if self.module.params['port_allocation'] is None and self.module.params['port_binding'] == 'static':
+            self.module.params['port_allocation'] = 'elastic'
+
         # Some sanity checks
         if self.module.params['port_allocation'] == 'elastic':
             if self.module.params['port_binding'] == 'ephemeral':

--- a/tests/integration/targets/prepare_vmware_tests/tasks/setup_dvs_portgroup.yml
+++ b/tests/integration/targets/prepare_vmware_tests/tasks/setup_dvs_portgroup.yml
@@ -5,7 +5,7 @@
     portgroup_name: '{{ dvpg1 }}'
     vlan_id: 0
     num_ports: 32
-    portgroup_type: earlyBinding
+    port_binding: static
     state: present
 
 - name: Create the DVS PG with slash in name
@@ -14,5 +14,5 @@
     switch_name: '{{ dvswitch1 }}'
     vlan_id: 0
     num_ports: 120
-    portgroup_type: earlyBinding
+    port_binding: static
     state: present

--- a/tests/integration/targets/prepare_vmware_tests/tasks/teardown_with_esxi.yml
+++ b/tests/integration/targets/prepare_vmware_tests/tasks/teardown_with_esxi.yml
@@ -37,8 +37,7 @@
     switch_name: "{{ dvswitch1 }}"
     portgroup_name: '{{ item }}'
     vlan_id: 0
-    num_ports: 32
-    portgroup_type: earlyBinding
+    port_binding: static
     state: absent
   loop:
   - DC0_DVPG0


### PR DESCRIPTION
##### SUMMARY
According to the documentation, `port_allocation` should default to `elastic` when `port_binding` is set to `static`. This isn't implemented correctly which leads to the module not being idempotent.

Fixes #1071 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
community.vmware.vmware_dvs_portgroup

##### ADDITIONAL INFORMATION
When unset, this leads to problems because `None != 'elastic'`:

https://github.com/ansible-collections/community.vmware/blob/47f2907b333cc9dc1c0564cdc91ec5cf38baae84/plugins/modules/vmware_dvs_portgroup.py#L604-L607