### PR TITLE
[WIP] vmware_dvs_portgroup: Fix default for port_allocation

### DIFF
--- a/changelogs/fragments/1071_vmware_dvs_portgroup.yml
+++ b/changelogs/fragments/1071_vmware_dvs_portgroup.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_dvs_portgroup - fix the default for port_allocation when port_binding is set to static (https://github.com/ansible-collections/community.vmware/issues/1071)

--- a/plugins/modules/vmware_dvs_portgroup.py
+++ b/plugins/modules/vmware_dvs_portgroup.py
@@ -272,7 +272,7 @@ extends_documentation_fragment:
 '''
 
 EXAMPLES = r'''
-- name: Create vlan portgroup
+- name: Create vlan portgroup with 120 ports
   community.vmware.vmware_dvs_portgroup:
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
@@ -282,10 +282,11 @@ EXAMPLES = r'''
     vlan_id: 123
     num_ports: 120
     port_binding: static
+    port_allocation: fixed
     state: present
   delegate_to: localhost
 
-- name: Create vlan trunk portgroup
+- name: Create elastic vlan trunk portgroup
   community.vmware.vmware_dvs_portgroup:
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
@@ -294,12 +295,11 @@ EXAMPLES = r'''
     switch_name: dvSwitch
     vlan_id: 1-1000, 1005, 1100-1200
     vlan_trunk: True
-    num_ports: 120
     port_binding: static
     state: present
   delegate_to: localhost
 
-- name: Create private vlan portgroup
+- name: Create private vlan portgroup with 120 ports
   vmware_dvs_portgroup:
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
@@ -310,10 +310,11 @@ EXAMPLES = r'''
     vlan_private: True
     num_ports: 120
     port_binding: static
+    port_allocation: fixed
     state: present
   delegate_to: localhost
 
-- name: Create no-vlan portgroup
+- name: Create (explicitly) elastic no-vlan portgroup
   community.vmware.vmware_dvs_portgroup:
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
@@ -321,12 +322,12 @@ EXAMPLES = r'''
     portgroup_name: no-vlan-portrgoup
     switch_name: dvSwitch
     vlan_id: 0
-    num_ports: 120
     port_binding: static
+    port_allocation: elastic
     state: present
   delegate_to: localhost
 
-- name: Create vlan portgroup with all security and port policies
+- name: Create elastic vlan portgroup with all security and port policies
   community.vmware.vmware_dvs_portgroup:
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
@@ -334,7 +335,6 @@ EXAMPLES = r'''
     portgroup_name: vlan-123-portrgoup
     switch_name: dvSwitch
     vlan_id: 123
-    num_ports: 120
     port_binding: static
     state: present
     network_policy:

--- a/plugins/modules/vmware_dvs_portgroup.py
+++ b/plugins/modules/vmware_dvs_portgroup.py
@@ -599,10 +599,8 @@ class VMwareDvsPortgroup(PyVmomi):
         if self.dvs_portgroup is None:
             return 'absent'
 
-        # Check config
-        if self.module.params['port_allocation'] != 'elastic' and self.module.params['port_binding'] != 'ephemeral':
-            if self.dvs_portgroup.config.numPorts != self.module.params['num_ports']:
-                return 'update'
+        if self.dvs_portgroup.config.numPorts != self.module.params['num_ports']:
+            return 'update'
 
         # Default port config
         defaultPortConfig = self.dvs_portgroup.config.defaultPortConfig

--- a/plugins/modules/vmware_dvs_portgroup.py
+++ b/plugins/modules/vmware_dvs_portgroup.py
@@ -374,8 +374,12 @@ from ansible_collections.community.vmware.plugins.module_utils.vmware import (
 class VMwareDvsPortgroup(PyVmomi):
     def __init__(self, module):
         super(VMwareDvsPortgroup, self).__init__(module)
-        self.dvs_portgroup = None
-        self.dv_switch = None
+
+        self.dv_switch = find_dvs_by_name(self.content, self.module.params['switch_name'])
+
+        if self.dv_switch is None:
+            self.module.fail_json(msg="A distributed virtual switch with name %s does not exist" % self.module.params['switch_name'])
+        self.dvs_portgroup = find_dvspg_by_name(self.dv_switch, self.module.params['portgroup_name'])
 
         # Some sanity checks
         if self.module.params['port_allocation'] == 'elastic':
@@ -592,12 +596,6 @@ class VMwareDvsPortgroup(PyVmomi):
         return False
 
     def check_dvspg_state(self):
-        self.dv_switch = find_dvs_by_name(self.content, self.module.params['switch_name'])
-
-        if self.dv_switch is None:
-            self.module.fail_json(msg="A distributed virtual switch with name %s does not exist" % self.module.params['switch_name'])
-        self.dvs_portgroup = find_dvspg_by_name(self.dv_switch, self.module.params['portgroup_name'])
-
         if self.dvs_portgroup is None:
             return 'absent'
 

--- a/tests/integration/targets/prepare_vmware_tests/tasks/setup_dvs_portgroup.yml
+++ b/tests/integration/targets/prepare_vmware_tests/tasks/setup_dvs_portgroup.yml
@@ -5,7 +5,8 @@
     portgroup_name: '{{ dvpg1 }}'
     vlan_id: 0
     num_ports: 32
-    portgroup_type: earlyBinding
+    port_binding: static
+    port_allocation: fixed
     state: present
 
 - name: Create the DVS PG with slash in name
@@ -14,5 +15,6 @@
     switch_name: '{{ dvswitch1 }}'
     vlan_id: 0
     num_ports: 120
-    portgroup_type: earlyBinding
+    port_binding: static
+    port_allocation: fixed
     state: present

--- a/tests/integration/targets/prepare_vmware_tests/tasks/teardown_with_esxi.yml
+++ b/tests/integration/targets/prepare_vmware_tests/tasks/teardown_with_esxi.yml
@@ -38,7 +38,8 @@
     portgroup_name: '{{ item }}'
     vlan_id: 0
     num_ports: 32
-    portgroup_type: earlyBinding
+    port_binding: static
+    port_allocation: fixed
     state: absent
   loop:
   - DC0_DVPG0


### PR DESCRIPTION
##### SUMMARY
According to the documentation, `port_allocation` should default to `elastic` when `port_binding` is set to `static`. This isn't implemented correctly which leads to the module not being idempotent.

Fixes #1071 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
community.vmware.vmware_dvs_portgroup

##### ADDITIONAL INFORMATION
When unset, this leads to problems because `None != 'elastic'`:

https://github.com/ansible-collections/community.vmware/blob/47f2907b333cc9dc1c0564cdc91ec5cf38baae84/plugins/modules/vmware_dvs_portgroup.py#L604-L607