### PR TITLE
vca_fw: Removed state set to absent from the example

### DIFF
--- a/docs/community.vmware.vca_fw_module.rst
+++ b/docs/community.vmware.vca_fw_module.rst
@@ -259,7 +259,6 @@ Examples
        - community.vmware.vca_fw:
            instance_id: 'b15ff1e5-1024-4f55-889f-ea0209726282'
            vdc_name: 'benz_ansible'
-           state: 'absent'
            fw_rules:
              - description: "ben testing"
                source_ip: "Any"

--- a/plugins/modules/vca_fw.py
+++ b/plugins/modules/vca_fw.py
@@ -40,7 +40,6 @@ EXAMPLES = r'''
    - community.vmware.vca_fw:
        instance_id: 'b15ff1e5-1024-4f55-889f-ea0209726282'
        vdc_name: 'benz_ansible'
-       state: 'absent'
        fw_rules:
          - description: "ben testing"
            source_ip: "Any"


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The example in the files vca_fw.py and vmware.vca_fw_module.rst is for adding firewall rules. However, the state is set to absent. So, removed the state variable.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vca_fw.py
vmware.vca_fw_module.rst

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
