### PR TITLE
Fix getting the next release

### DIFF
--- a/tools/prepare_release.yml
+++ b/tools/prepare_release.yml
@@ -3,7 +3,7 @@
     - name: Generate version
       block:
         - name: Get the next release version
-          ansible.builtin.shell: git tag --sort=-creatordate|head -n1|perl -pe 's/(\d+\.)(\d+)\.\d+/"$1" . ($2+1) . ".0"/e'
+          ansible.builtin.shell: git tag --sort=-creatordate --merged|head -n1|perl -pe 's/(\d+\.)(\d+)\.\d+/"$1" . ($2+1) . ".0"/e'
           register: result
 
         - name: Set the release version


### PR DESCRIPTION
##### SUMMARY
I think we have a bug creating the new version running `tools/prepare_release.yml`. At the moment, we use the _last_ tag as the basis for the new version:

https://github.com/ansible-collections/community.vmware/blob/89695ca1fff52435f385223e4fd024b0acb16e90/tools/prepare_release.yml#L3-L7

This means if we release 2.0.0 and then 1.18.0 (in the `stable-1.x` branch), the next generated version would be 1.19.0 instead of 2.1.0 (latest tag +1 in the minor version).

I think we can fix this by using the `--merged` parameter. As far as I understand, the `1.18.0` tag wouldn't turn up then because the tagged commit isn't part of the main branch.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tools/prepare_release.yml

##### ADDITIONAL INFORMATION
The bug should work the other way, too. If we release 2.0.0 and then want to release 1.18.0 in the `stable-1.x` branch, we would generate 2.1.0.