### PR TITLE
Getting the full path and using a different condition to fix issue.

### DIFF
--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -1055,6 +1055,7 @@ from ansible_collections.community.vmware.plugins.module_utils.vmware import (
     find_dvspg_by_name,
     wait_for_vm_ip,
     quote_obj_name,
+    get_folder_abs_path,
 )
 from ansible_collections.community.vmware.plugins.module_utils.vm_device_helper import PyVmomiDeviceHelper
 from ansible_collections.community.vmware.plugins.module_utils.vmware_spbm import SPBM
@@ -2797,21 +2798,7 @@ class PyVmomiHelper(PyVmomi):
 
         dcpath = compile_folder_path_for_object(datacenter)
 
-        # Nested folder does not have trailing /
-        if not dcpath.endswith('/'):
-            dcpath += '/'
-
-        # Check for full path first in case it was already supplied
-        if self.folder.startswith(
-            dcpath + self.params["datacenter"] + "/vm"
-        ) or self.folder.startswith(dcpath + "/" + self.params["datacenter"] + "/vm"):
-            fullpath = self.folder
-        elif self.folder.startswith("/vm/") or self.folder == "/vm":
-            fullpath = "%s%s%s" % (dcpath, self.params["datacenter"], self.folder)
-        elif self.folder.startswith("/"):
-            fullpath = "%s%s/vm%s" % (dcpath, self.params["datacenter"], self.folder)
-        else:
-            fullpath = "%s%s/vm/%s" % (dcpath, self.params["datacenter"], self.folder)
+        fullpath = get_folder_abs_path(dcpath, self.params['datacenter'], self.folder)
 
         f_obj = self.content.searchIndex.FindByInventoryPath(fullpath)
 


### PR DESCRIPTION
##### SUMMARY
Fixes #1090 when creating / deleting a VM with vmware_guest it could be created/deleted in an another folder. 
As mentioned in this issue, the fix was to compare VM paths correctly. 

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
vmware_guest causes an issue when creating / deleting a VM in folder with similar name, e.g. :

└───Project
    ├───aaa1
    ├───aaa111
    │               test1
    └───aaa1111
When I want to create a virtual machine with name test1 in the aaa1 folder, the virtual machine is created (customized) in the aaa111 folder, instead of the aaa1 folder. And, when I try to delete the test1 machine from the aaa1 folder, I will delete it from the aaa111 folder.
