### PR TITLE
vmware_host_snmp: Add code to support SNMP values

### DIFF
--- a/changelogs/fragments/1044_add_syscontact_syslocation_vmware_host_snmp.yml
+++ b/changelogs/fragments/1044_add_syscontact_syslocation_vmware_host_snmp.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_host_snmp - implement setting syscontact and syslocation (https://github.com/ansible-collections/community.vmware/issues/1044).

--- a/docs/community.vmware.vmware_host_snmp_module.rst
+++ b/docs/community.vmware.vmware_host_snmp_module.rst
@@ -241,6 +241,36 @@ Parameters
             <tr>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>sys_contact</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>System contact who manages the system.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>sys_location</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>System location.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>trap_filter</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
@@ -358,6 +388,16 @@ Examples
         trap_filter:
           - 1.3.6.1.4.1.6876.4.1.1.0
           - 1.3.6.1.4.1.6876.4.1.1.1
+        state: enabled
+      delegate_to: localhost
+
+    - name: Enable and configure SNMP system contact and location
+      community.vmware.vmware_host_snmp:
+        hostname: '{{ esxi_hostname }}'
+        username: '{{ esxi_username }}'
+        password: '{{ esxi_password }}'
+        sys_contact: "admin@testemail.com"
+        sys_location: "Austin, USA"
         state: enabled
       delegate_to: localhost
 

--- a/docs/community.vmware.vmware_host_snmp_module.rst
+++ b/docs/community.vmware.vmware_host_snmp_module.rst
@@ -241,36 +241,6 @@ Parameters
             <tr>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
-                    <b>sys_contact</b>
-                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
-                    <div style="font-size: small">
-                        <span style="color: purple">string</span>
-                    </div>
-                </td>
-                <td>
-                </td>
-                <td>
-                        <div>System contact who manages the system.</div>
-                </td>
-            </tr>
-            <tr>
-                <td colspan="1">
-                    <div class="ansibleOptionAnchor" id="parameter-"></div>
-                    <b>sys_location</b>
-                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
-                    <div style="font-size: small">
-                        <span style="color: purple">string</span>
-                    </div>
-                </td>
-                <td>
-                </td>
-                <td>
-                        <div>System location.</div>
-                </td>
-            </tr>
-            <tr>
-                <td colspan="1">
-                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>trap_filter</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
@@ -388,16 +358,6 @@ Examples
         trap_filter:
           - 1.3.6.1.4.1.6876.4.1.1.0
           - 1.3.6.1.4.1.6876.4.1.1.1
-        state: enabled
-      delegate_to: localhost
-
-    - name: Enable and configure SNMP system contact and location
-      community.vmware.vmware_host_snmp:
-        hostname: '{{ esxi_hostname }}'
-        username: '{{ esxi_username }}'
-        password: '{{ esxi_password }}'
-        sys_contact: "admin@testemail.com"
-        sys_location: "Austin, USA"
         state: enabled
       delegate_to: localhost
 

--- a/plugins/modules/vmware_host_snmp.py
+++ b/plugins/modules/vmware_host_snmp.py
@@ -78,12 +78,10 @@ options:
         - System contact who manages the system.
     type: str
     version_added: '1.17.0'
-    version_added: '1.17.0'
   sys_location:
     description:
         - System location.
     type: str
-    version_added: '1.17.0'
     version_added: '1.17.0'
 extends_documentation_fragment:
 - community.vmware.vmware.documentation

--- a/plugins/modules/vmware_host_snmp.py
+++ b/plugins/modules/vmware_host_snmp.py
@@ -78,6 +78,7 @@ options:
         - System contact who manages the system.
     type: str
     version_added: '1.17.0'
+    version_added: '1.17.0'
   sys_location:
     description:
         - System location.

--- a/plugins/modules/vmware_host_snmp.py
+++ b/plugins/modules/vmware_host_snmp.py
@@ -84,6 +84,7 @@ options:
         - System location.
     type: str
     version_added: '1.17.0'
+    version_added: '1.17.0'
 extends_documentation_fragment:
 - community.vmware.vmware.documentation
 

--- a/plugins/modules/vmware_host_snmp.py
+++ b/plugins/modules/vmware_host_snmp.py
@@ -73,6 +73,14 @@ options:
     type: str
     choices: [ debug, info, warning, error ]
     default: info
+  sys_contact:
+    description:
+        - System contact who manages the system.
+    type: str
+  sys_location:
+    description:
+        - System location.
+    type: str
 extends_documentation_fragment:
 - community.vmware.vmware.documentation
 
@@ -104,6 +112,16 @@ EXAMPLES = r'''
     trap_filter:
       - 1.3.6.1.4.1.6876.4.1.1.0
       - 1.3.6.1.4.1.6876.4.1.1.1
+    state: enabled
+  delegate_to: localhost
+
+- name: Enable and configure SNMP system contact and location
+  community.vmware.vmware_host_snmp:
+    hostname: '{{ esxi_hostname }}'
+    username: '{{ esxi_username }}'
+    password: '{{ esxi_password }}'
+    sys_contact: "admin@testemail.com"
+    sys_location: "Austin, USA"
     state: enabled
   delegate_to: localhost
 
@@ -171,6 +189,8 @@ class VmwareHostSnmp(PyVmomi):
         log_level = self.params.get("log_level")
         send_trap = self.params.get("send_trap")
         trap_filter = self.params.get("trap_filter")
+        sys_contact = self.params.get("sys_contact")
+        sys_location = self.params.get("sys_location")
         event_filter = None
         if trap_filter:
             event_filter = ';'.join(trap_filter)
@@ -207,6 +227,10 @@ class VmwareHostSnmp(PyVmomi):
                     results['log_level_previous'] = option.value
                 if option.key == 'EventFilter' and option.value != hw_source:
                     results['trap_filter_previous'] = option.value.split(';')
+                if option.key == 'syscontact' and option.value != hw_source:
+                    results['syscontact_previous'] = option.value
+                if option.key == 'syslocation' and option.value != hw_source:
+                    results['syslocation_previous'] = option.value
             # Build factory default config
             destination = vim.host.SnmpSystem.SnmpConfigSpec.Destination()
             destination.hostName = ""
@@ -315,6 +339,8 @@ class VmwareHostSnmp(PyVmomi):
             results['log_level'] = log_level
             results['trap_filter'] = trap_filter
             event_filter_found = False
+            sys_contact_found = False
+            sys_location_found = False
             if snmp_config_spec.option:
                 for option in snmp_config_spec.option:
                     if option.key == 'EnvEventSource' and option.value != hw_source:
@@ -334,6 +360,20 @@ class VmwareHostSnmp(PyVmomi):
                             changed_list.append("trap filter")
                             results['trap_filter_previous'] = option.value.split(';')
                             option.value = event_filter
+                    if option.key == 'syscontact':
+                        sys_contact_found = True
+                        if sys_contact is not None and option.value != sys_contact:
+                            changed = True
+                            changed_list.append("sys contact")
+                            results['sys_contact_previous'] = option.value
+                            option.value = sys_contact
+                    if option.key == 'syslocation':
+                        sys_location_found = True
+                        if sys_location is not None and option.value != sys_location:
+                            changed = True
+                            changed_list.append("sys location")
+                            results['sys_location_previous'] = option.value
+                            option.value = sys_location
             if trap_filter and not event_filter_found:
                 changed = True
                 changed_list.append("trap filter")
@@ -351,7 +391,16 @@ class VmwareHostSnmp(PyVmomi):
                 # Doesn't work. Need to reset config instead
                 # snmp_config_spec.option = options
                 reset_hint = True
-
+            if sys_contact and not sys_contact_found:
+                changed = True
+                changed_list.append("sys contact")
+                results['sys_contact_previous'] = ''
+                snmp_config_spec.option.append(self.create_option('syscontact', sys_contact))
+            if sys_location and not sys_location_found:
+                changed = True
+                changed_list.append("sys location")
+                results['sys_location_previous'] = ''
+                snmp_config_spec.option.append(self.create_option('syslocation', sys_location))
         if changed:
             if snmp_state == 'reset':
                 if self.module.check_mode:
@@ -472,6 +521,8 @@ def main():
         hw_source=dict(type='str', default='indications', choices=['indications', 'sensors']),
         log_level=dict(type='str', default='info', choices=['debug', 'info', 'warning', 'error']),
         send_trap=dict(type='bool', default=False),
+        sys_contact=dict(type='str', required=False),
+        sys_location=dict(type='str', required=False),
     )
 
     module = AnsibleModule(

--- a/plugins/modules/vmware_host_snmp.py
+++ b/plugins/modules/vmware_host_snmp.py
@@ -77,10 +77,12 @@ options:
     description:
         - System contact who manages the system.
     type: str
+    version_added: '1.17.0'
   sys_location:
     description:
         - System location.
     type: str
+    version_added: '1.17.0'
 extends_documentation_fragment:
 - community.vmware.vmware.documentation
 
@@ -521,8 +523,8 @@ def main():
         hw_source=dict(type='str', default='indications', choices=['indications', 'sensors']),
         log_level=dict(type='str', default='info', choices=['debug', 'info', 'warning', 'error']),
         send_trap=dict(type='bool', default=False),
-        sys_contact=dict(type='str', required=False),
-        sys_location=dict(type='str', required=False),
+        sys_contact=dict(type='str'),
+        sys_location=dict(type='str')
     )
 
     module = AnsibleModule(

--- a/tests/integration/targets/vmware_host_snmp/tasks/main.yml
+++ b/tests/integration/targets/vmware_host_snmp/tasks/main.yml
@@ -41,6 +41,22 @@
           - snmp_enabled is defined
           - snmp_enabled.changed
 
+    - name: Enable and configure SNMP system contact and location
+      vmware_host_snmp:
+        hostname: '{{ esxi1 }}'
+        username: '{{ esxi_user }}'
+        password: '{{ esxi_password }}'
+        sys_contact: "admin@testemail.com"
+        sys_location: "Austin, USA"
+        state: enabled
+        validate_certs: false
+      register: snmp_enabled_sys_options
+    - debug: var=snmp_enabled_sys_options
+    - assert:
+        that:
+          - snmp_enabled_sys_options is defined
+          - snmp_enabled_sys_options.changed
+
     - name: Disable SNMP
       vmware_host_snmp:
         hostname: '{{ esxi1 }}'
@@ -49,8 +65,8 @@
         state: disabled
         validate_certs: false
       register: snmp_disabled
-    - debug: var=snmp_enabled
+    - debug: var=snmp_disabled
     - assert:
         that:
-          - snmp_enabled is defined
-          - snmp_enabled.changed
+          - snmp_disabled is defined
+          - snmp_disabled.changed


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/community.vmware/pull/1102

##### SUMMARY
Added code to support setting SNMP syscontact and syslocation.

Fixes #1044

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_host_snmp.py
community.vmware.vmware_host_snmp_module.rst

##### ADDITIONAL INFORMATION
```paste below

```
