### PR TITLE
always use debian8_64Guest in our functinal tests

### DIFF
--- a/tests/integration/targets/vmware_guest/tasks/clone_resize_disks.yml
+++ b/tests/integration/targets/vmware_guest/tasks/clone_resize_disks.yml
@@ -17,7 +17,7 @@
         hardware:
           num_cpus: 1
           memory_mb: 128
-        guest_id: centos7_64Guest
+        guest_id: debian8_64Guest
         disk:
           - size_gb: 1
             type: thin

--- a/tests/integration/targets/vmware_guest/tasks/create_vm_using_special_characters.yml
+++ b/tests/integration/targets/vmware_guest/tasks/create_vm_using_special_characters.yml
@@ -10,7 +10,7 @@
         datacenter: "{{ dc1 }}"
         folder: "{{ f0 }}"
         name: 'test_vm\/%'
-        guest_id: rhel7_64Guest
+        guest_id: debian8_64Guest
         hardware:
           memory_mb: 512
           num_cpus: 1
@@ -35,7 +35,7 @@
         datacenter: "{{ dc1 }}"
         folder: "{{ f0 }}"
         name: 'test_vm\/%'
-        guest_id: rhel7_64Guest
+        guest_id: debian8_64Guest
         hardware:
           memory_mb: 512
           num_cpus: 1

--- a/tests/integration/targets/vmware_guest/tasks/network_with_device.yml
+++ b/tests/integration/targets/vmware_guest/tasks/network_with_device.yml
@@ -16,7 +16,7 @@
     disk:
       - size: 10mb
         datastore: "{{ rw_datastore }}"
-    guest_id: rhel7_64guest
+    guest_id: debian8_64Guest
     hardware:
       memory_mb: 128
       num_cpus: 1
@@ -44,7 +44,7 @@
     disk:
       - size: 10mb
         datastore: "{{ rw_datastore }}"
-    guest_id: rhel7_64guest
+    guest_id: debian8_64Guest
     hardware:
       memory_mb: 128
       num_cpus: 1

--- a/tests/integration/targets/vmware_guest/tasks/network_with_dvpg.yml
+++ b/tests/integration/targets/vmware_guest/tasks/network_with_dvpg.yml
@@ -19,7 +19,7 @@
         disk:
           - size: 1gb
             datastore: "{{ rw_datastore }}"
-        guest_id: rhel7_64guest
+        guest_id: debian8_64Guest
         hardware:
           memory_mb: 128
           num_cpus: 1
@@ -46,7 +46,7 @@
         disk:
           - size: 1gb
             datastore: "{{ rw_datastore }}"
-        guest_id: rhel7_64guest
+        guest_id: debian8_64Guest
         hardware:
           memory_mb: 128
           num_cpus: 1
@@ -72,7 +72,7 @@
         disk:
           - size: 1gb
             datastore: "{{ rw_datastore }}"
-        guest_id: rhel7_64guest
+        guest_id: debian8_64Guest
         hardware:
           memory_mb: 128
           num_cpus: 1
@@ -98,7 +98,7 @@
         disk:
           - size: 1gb
             datastore: "{{ rw_datastore }}"
-        guest_id: rhel7_64guest
+        guest_id: debian8_64Guest
         hardware:
           memory_mb: 128
           num_cpus: 1
@@ -124,7 +124,7 @@
         disk:
           - size: 1gb
             datastore: "{{ rw_datastore }}"
-        guest_id: rhel7_64guest
+        guest_id: debian8_64Guest
         hardware:
           memory_mb: 128
           num_cpus: 1
@@ -170,7 +170,7 @@
             disk:
               - size: 10mb
                 datastore: "{{ rw_datastore }}"
-            guest_id: rhel7_64guest
+            guest_id: debian8_64Guest
             hardware:
               memory_mb: 128
               num_cpus: 1

--- a/tests/integration/targets/vmware_guest/tasks/network_with_portgroup.yml
+++ b/tests/integration/targets/vmware_guest/tasks/network_with_portgroup.yml
@@ -79,7 +79,7 @@
         disk:
           - size: 10mb
             datastore: "{{ rw_datastore }}"
-        guest_id: rhel7_64guest
+        guest_id: debian8_64Guest
         hardware:
           memory_mb: 128
           num_cpus: 1

--- a/tests/integration/targets/vmware_guest/tasks/reconfig_vm_to_latest_version.yml
+++ b/tests/integration/targets/vmware_guest/tasks/reconfig_vm_to_latest_version.yml
@@ -10,7 +10,7 @@
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     name: test_vm1
-    guest_id: centos7_64Guest
+    guest_id: debian8_64Guest
     datacenter: "{{ dc1 }}"
     folder: "{{ f0 }}"
     datastore: '{{ rw_datastore }}'
@@ -33,7 +33,7 @@
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     name: test_vm2
-    guest_id: centos7_64Guest
+    guest_id: debian8_64Guest
     datacenter: "{{ dc1 }}"
     folder: "{{ f0 }}"
     datastore: '{{ rw_datastore }}'
@@ -56,7 +56,7 @@
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     name: test_vm1
-    guest_id: centos7_64Guest
+    guest_id: debian8_64Guest
     datacenter: "{{ dc1 }}"
     folder: "{{ f0 }}"
     datastore: '{{ rw_datastore }}'

--- a/tests/integration/targets/vmware_guest_network/tasks/main.yml
+++ b/tests/integration/targets/vmware_guest_network/tasks/main.yml
@@ -22,7 +22,7 @@
       folder: '/DC0/vm/F0'
       name: test_vm1
       state: poweredon
-      guest_id: centos7_64Guest
+      guest_id: debian8_64Guest
       disk:
       - size_gb: 1
         type: thin

--- a/tests/integration/targets/vmware_guest_tools_wait/tasks/main.yml
+++ b/tests/integration/targets/vmware_guest_tools_wait/tasks/main.yml
@@ -22,7 +22,7 @@
       folder: '/DC0/vm/F0'
       name: test_vm1
       state: poweredon
-      guest_id: centos7_64Guest
+      guest_id: debian8_64Guest
       disk:
       - size_gb: 1
         type: thin

--- a/tests/integration/targets/vmware_host_auto_start/tasks/main.yml
+++ b/tests/integration/targets/vmware_host_auto_start/tasks/main.yml
@@ -37,7 +37,7 @@
         folder: vm
         esxi_hostname: "{{ esxi1 }}"
         state: present
-        guest_id: centos7_64Guest
+        guest_id: debian8_64Guest
         disk:
         - size_gb: 1
           type: thin

--- a/tests/integration/targets/vmware_vmotion/tasks/main.yml
+++ b/tests/integration/targets/vmware_vmotion/tasks/main.yml
@@ -38,7 +38,7 @@
     folder: vm
     esxi_hostname: "{{ esxi1 }}"
     state: present
-    guest_id: centos7_64Guest
+    guest_id: debian8_64Guest
     disk:
     - size_gb: 1
       type: thin


### PR DESCRIPTION
The use of the rhel7_64Guest guest_id unlocks some CPU features that we
cannot use yet with our CI envionment. The virtualized ESXi won't be able
to spawn the nested VM properly.
A consequence is the `Disconnected from virtual machine.` error message.
