### PR TITLE
tests: use hw version 11

### DIFF
--- a/tests/integration/targets/prepare_vmware_tests/tasks/setup_virtualmachines.yml
+++ b/tests/integration/targets/prepare_vmware_tests/tasks/setup_virtualmachines.yml
@@ -14,6 +14,7 @@
       memory_mb: 128
       num_cpus: 1
       scsi: paravirtual
+      version: 11
     cdrom:
       type: iso
       iso_path: "[{{ ro_datastore }}] fedora.iso"

--- a/tests/integration/targets/vmware_guest/tasks/create_rp_d1_c1_f0.yml
+++ b/tests/integration/targets/vmware_guest/tasks/create_rp_d1_c1_f0.yml
@@ -10,6 +10,7 @@
     guest_id: centos64Guest
     datacenter: "{{ dc1 }}"
     hardware:
+        version: 11
         num_cpus: 1
         memory_mb: 128
     disk:
@@ -61,6 +62,7 @@
     datacenter: "{{ dc1 }}"
     cluster: "{{ ccr1 }}"
     hardware:
+        version: 11
         num_cpus: 1
         memory_mb: 128
     disk:
@@ -114,6 +116,7 @@
     cluster: "{{ ccr1 }}"
     resource_pool: DC0_C0_RP1
     hardware:
+        version: 11
         num_cpus: 1
         memory_mb: 128
     disk:

--- a/tests/integration/targets/vmware_guest/tasks/network_with_device.yml
+++ b/tests/integration/targets/vmware_guest/tasks/network_with_device.yml
@@ -18,6 +18,7 @@
         datastore: "{{ rw_datastore }}"
     guest_id: rhel7_64guest
     hardware:
+      version: 11
       memory_mb: 128
       num_cpus: 1
     networks:
@@ -46,6 +47,7 @@
         datastore: "{{ rw_datastore }}"
     guest_id: rhel7_64guest
     hardware:
+      version: 11
       memory_mb: 128
       num_cpus: 1
     networks:

--- a/tests/integration/targets/vmware_guest_instant_clone/tasks/main.yml
+++ b/tests/integration/targets/vmware_guest_instant_clone/tasks/main.yml
@@ -25,6 +25,7 @@
     hardware:
       num_cpus: 1
       memory_mb: 512
+      version: 11
     disk:
       - size: 1gb
         type: thin

--- a/tests/integration/targets/vmware_guest_network/tasks/main.yml
+++ b/tests/integration/targets/vmware_guest_network/tasks/main.yml
@@ -28,7 +28,7 @@
         type: thin
         datastore: '{{ rw_datastore }}'
       hardware:
-        version: latest
+        version: 11
         memory_mb: 1024
         num_cpus: 1
         scsi: paravirtual

--- a/tests/integration/targets/vmware_guest_tools_wait/tasks/main.yml
+++ b/tests/integration/targets/vmware_guest_tools_wait/tasks/main.yml
@@ -28,7 +28,7 @@
         type: thin
         datastore: '{{ rw_datastore }}'
       hardware:
-        version: latest
+        version: 11
         memory_mb: 1024
         num_cpus: 1
         scsi: paravirtual

--- a/tests/integration/targets/vmware_host_auto_start/tasks/main.yml
+++ b/tests/integration/targets/vmware_host_auto_start/tasks/main.yml
@@ -43,7 +43,7 @@
           type: thin
           datastore: '{{ rw_datastore }}'
         hardware:
-          version: latest
+          version: 11
           memory_mb: 1024
           num_cpus: 1
           scsi: paravirtual

--- a/tests/integration/targets/vmware_vmotion/tasks/main.yml
+++ b/tests/integration/targets/vmware_vmotion/tasks/main.yml
@@ -44,7 +44,7 @@
       type: thin
       datastore: '{{ rw_datastore }}'
     hardware:
-      version: latest
+      version: 11
       memory_mb: 1024
       num_cpus: 1
       scsi: paravirtual


### PR DESCRIPTION
The ESXis of our CI come with an heterogeneous collection of CPU. The
goal is to avoid any dependency with recent CPU features.