### PR TITLE
vmware_guest_sendkey: add additional USB scan codes for `HOME` and `END`

### DIFF
--- a/changelogs/fragments/1117_add_additional_usb_scan_codes.yml
+++ b/changelogs/fragments/1117_add_additional_usb_scan_codes.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_guest_sendkey - added additional USB scan codes for HOME and END.

--- a/docs/community.vmware.vmware_guest_sendkey_module.rst
+++ b/docs/community.vmware.vmware_guest_sendkey_module.rst
@@ -147,7 +147,7 @@ Parameters
                 </td>
                 <td>
                         <div>The list of the keys will be sent to the virtual machine.</div>
-                        <div>Valid values are <code>ENTER</code>, <code>ESC</code>, <code>BACKSPACE</code>, <code>TAB</code>, <code>SPACE</code>, <code>CAPSLOCK</code>, <code>HOME</code>, <code>DELETE</code>, <code>END</code>, <code>CTRL_ALT_DEL</code>, <code>CTRL_C</code> and <code>F1</code> to <code>F12</code>, <code>RIGHTARROW</code>, <code>LEFTARROW</code>, <code>DOWNARROW</code>, <code>UPARROW</code>.</div>
+                        <div>Valid values are <code>ENTER</code>, <code>ESC</code>, <code>BACKSPACE</code>, <code>TAB</code>, <code>SPACE</code>, <code>CAPSLOCK</code>, <code>DELETE</code>, <code>CTRL_ALT_DEL</code>, <code>CTRL_C</code> and <code>F1</code> to <code>F12</code>, <code>RIGHTARROW</code>, <code>LEFTARROW</code>, <code>DOWNARROW</code>, <code>UPARROW</code>.</div>
                         <div>If both <code>keys_send</code> and <code>string_send</code> are specified, keys in <code>keys_send</code> list will be sent in front of the <code>string_send</code>.</div>
                 </td>
             </tr>

--- a/docs/community.vmware.vmware_guest_sendkey_module.rst
+++ b/docs/community.vmware.vmware_guest_sendkey_module.rst
@@ -147,7 +147,7 @@ Parameters
                 </td>
                 <td>
                         <div>The list of the keys will be sent to the virtual machine.</div>
-                        <div>Valid values are <code>ENTER</code>, <code>ESC</code>, <code>BACKSPACE</code>, <code>TAB</code>, <code>SPACE</code>, <code>CAPSLOCK</code>, <code>DELETE</code>, <code>CTRL_ALT_DEL</code>, <code>CTRL_C</code> and <code>F1</code> to <code>F12</code>, <code>RIGHTARROW</code>, <code>LEFTARROW</code>, <code>DOWNARROW</code>, <code>UPARROW</code>.</div>
+                        <div>Valid values are <code>ENTER</code>, <code>ESC</code>, <code>BACKSPACE</code>, <code>TAB</code>, <code>SPACE</code>, <code>CAPSLOCK</code>, <code>HOME</code>, <code>DELETE</code>, <code>END</code>, <code>CTRL_ALT_DEL</code>, <code>CTRL_C</code> and <code>F1</code> to <code>F12</code>, <code>RIGHTARROW</code>, <code>LEFTARROW</code>, <code>DOWNARROW</code>, <code>UPARROW</code>.</div>
                         <div>If both <code>keys_send</code> and <code>string_send</code> are specified, keys in <code>keys_send</code> list will be sent in front of the <code>string_send</code>.</div>
                 </td>
             </tr>

--- a/plugins/modules/vmware_guest_sendkey.py
+++ b/plugins/modules/vmware_guest_sendkey.py
@@ -81,6 +81,7 @@ options:
      - 'Valid values are C(ENTER), C(ESC), C(BACKSPACE), C(TAB), C(SPACE), C(CAPSLOCK), C(HOME), C(DELETE), C(END), C(CTRL_ALT_DEL),
         C(CTRL_C) and C(F1) to C(F12), C(RIGHTARROW), C(LEFTARROW), C(DOWNARROW), C(UPARROW).'
      - If both C(keys_send) and C(string_send) are specified, keys in C(keys_send) list will be sent in front of the C(string_send).
+     - C(HOME) and C(END) are added in version 1.17.0.
      type: list
      elements: str
    sleep_time:

--- a/plugins/modules/vmware_guest_sendkey.py
+++ b/plugins/modules/vmware_guest_sendkey.py
@@ -81,7 +81,7 @@ options:
      - 'Valid values are C(ENTER), C(ESC), C(BACKSPACE), C(TAB), C(SPACE), C(CAPSLOCK), C(HOME), C(DELETE), C(END), C(CTRL_ALT_DEL),
         C(CTRL_C) and C(F1) to C(F12), C(RIGHTARROW), C(LEFTARROW), C(DOWNARROW), C(UPARROW).'
      - If both C(keys_send) and C(string_send) are specified, keys in C(keys_send) list will be sent in front of the C(string_send).
-     - C(HOME) and C(END) are added in version 1.17.0.
+     - Values C(HOME) and C(END) are added in version 1.17.0.
      type: list
      elements: str
    sleep_time:

--- a/plugins/modules/vmware_guest_sendkey.py
+++ b/plugins/modules/vmware_guest_sendkey.py
@@ -78,7 +78,7 @@ options:
    keys_send:
      description:
      - The list of the keys will be sent to the virtual machine.
-     - 'Valid values are C(ENTER), C(ESC), C(BACKSPACE), C(TAB), C(SPACE), C(CAPSLOCK), C(DELETE), C(CTRL_ALT_DEL),
+     - 'Valid values are C(ENTER), C(ESC), C(BACKSPACE), C(TAB), C(SPACE), C(CAPSLOCK), C(HOME), C(DELETE), C(END), C(CTRL_ALT_DEL),
         C(CTRL_C) and C(F1) to C(F12), C(RIGHTARROW), C(LEFTARROW), C(DOWNARROW), C(UPARROW).'
      - If both C(keys_send) and C(string_send) are specified, keys in C(keys_send) list will be sent in front of the C(string_send).
      type: list
@@ -241,7 +241,9 @@ class PyVmomiHelper(PyVmomi):
             ('F10', '0x43', [('', [])]),
             ('F11', '0x44', [('', [])]),
             ('F12', '0x45', [('', [])]),
+            ('HOME', '0x4a', [('', [])]),
             ('DELETE', '0x4c', [('', [])]),
+            ('END', '0x4d', [('', [])]),
             ('CTRL_ALT_DEL', '0x4c', [('', ['CTRL', 'ALT'])]),
             ('CTRL_C', '0x06', [('', ['CTRL'])]),
             ('RIGHTARROW', '0x4f', [('', [])]),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Add additional USB scan codes for HOME and END.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- vmware_guest_sendkey

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

See the following document for HID usage tables: https://www.usb.org/sites/default/files/documents/hut1_12v2.pdf. The codes for `HOME` and `END` can be found on page 55.

