### PR TITLE
vmware_content_library_info/tests: does not need an ESXi

### DIFF
--- a/tests/integration/targets/vmware_content_library_info/aliases
+++ b/tests/integration/targets/vmware_content_library_info/aliases
@@ -1,3 +1,3 @@
 cloud/vcenter
 needs/target/prepare_vmware_tests
-zuul/vmware/vcenter_1esxi
+zuul/vmware/vcenter_only

--- a/tests/integration/targets/vmware_content_library_info/tasks/main.yml
+++ b/tests/integration/targets/vmware_content_library_info/tasks/main.yml
@@ -8,8 +8,6 @@
     - import_role:
         name: prepare_vmware_tests
       vars:
-        setup_attach_host: true
-        setup_datastore: true
         setup_content_library: true
 
     # Get List of Content Libraries


### PR DESCRIPTION
Use the lighter vcenter_only environment to run the test since the
tests don't require an ESXi host.
