### PR TITLE
disable vmware_host_tcpip_stacks/tests for now

### DIFF
--- a/tests/integration/targets/vmware_host_tcpip_stacks/aliases
+++ b/tests/integration/targets/vmware_host_tcpip_stacks/aliases
@@ -1,3 +1,4 @@
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
+disabled


### PR DESCRIPTION
With vcenter 7.0.3, the vmware_host_tcpip_stacks tests break the
IPv4 configuration of the node. We must preserve the original
gateway or the node become unreachable.

See: https://github.com/ansible-collections/community.vmware/issues/1120
See: https://9f6249684dbca3f269bd-b5dfc8e1a8b1871b232cb0142d3e37c5.ssl.cf5.rackcdn.com/1101/a22fda4f98f6cc0277579dddcfd2f6bf4338e6ca/check/ansible-test-cloud-integration-vcenter7_1esxi-python36-stable211_2_of_2/b220e11/job-output.txt
