### PR TITLE
tests: use vmware.vmware_rest to clean up the resources

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,3 +6,4 @@ pytest-xdist
 # We should avoid these two modules with py3
 pytest-mock
 mock
+aiohttp ; python_version >= '3.6'

--- a/tests/integration/targets/prepare_vmware_tests/tasks/setup_virtualmachines.yml
+++ b/tests/integration/targets/prepare_vmware_tests/tasks/setup_virtualmachines.yml
@@ -7,7 +7,7 @@
     state: poweredoff
     guest_id: debian8_64Guest
     disk:
-    - size_gb: 1
+    - size_mb: 10
       type: thin
       datastore: '{{ rw_datastore }}'
     hardware:

--- a/tests/integration/targets/prepare_vmware_tests/tasks/teardown.yml
+++ b/tests/integration/targets/prepare_vmware_tests/tasks/teardown.yml
@@ -1,23 +1,27 @@
 ---
-- name: Delete a datastore cluster to datacenter
-  vmware_datastore_cluster:
-    datacenter_name: "{{ dc1 }}"
-    datastore_cluster_name: '{{ item }}'
-    state: absent
-  with_items:
-    - DSC1
-    - DSC2
-  ignore_errors: true
-
-- name: Remove the datacenter
-  vmware_datacenter:
-    datacenter_name: '{{ item }}'
-    state: absent
-  when: vcsim is not defined
-  with_items:
-    - '{{ dc1 }}'
-    - datacenter_0001
-
+- when: not (vcsim is defined)
+  block:
+    - name: Get a list of all the datacenters
+      vmware.vmware_rest.vcenter_datacenter_info:
+        vcenter_hostname: '{{ vcenter_hostname }}'
+        vcenter_username: '{{ vcenter_username }}'
+        vcenter_password: '{{ vcenter_password }}'
+        vcenter_validate_certs: false
+      register: existing_datacenters
+    - name: Force delete the existing DC
+      vmware.vmware_rest.vcenter_datacenter:
+        vcenter_hostname: '{{ vcenter_hostname }}'
+        vcenter_username: '{{ vcenter_username }}'
+        vcenter_password: '{{ vcenter_password }}'
+        vcenter_validate_certs: false
+        state: absent
+        datacenter: '{{ item.datacenter }}'
+        force: true
+      with_items: "{{ existing_datacenters.value }}"
+      until: _result is succeeded
+      retries: 10
+      delay: 1
+      register: _result
 - name: kill vcsim
   uri:
     url: "http://{{ vcsim }}:5000/killall"

--- a/tests/integration/targets/prepare_vmware_tests/tasks/teardown_with_esxi.yml
+++ b/tests/integration/targets/prepare_vmware_tests/tasks/teardown_with_esxi.yml
@@ -1,111 +1,94 @@
 ---
-- name: Clean up the firewall rules
-  vmware_host_firewall_manager:
-    cluster_name: '{{ ccr1 }}'
-    rules:
-        - name: vvold
-          enabled: false
-        - name: CIMHttpServer
-          enabled: true
-          allowed_hosts:
-            all_ip: true
-        - name: NFC
-          enabled: true
-          allowed_hosts:
-            all_ip: true
+- name: Collect the list of the existing VM
+  vmware.vmware_rest.vcenter_vm_info:
+    vcenter_hostname: '{{ vcenter_hostname }}'
+    vcenter_username: '{{ vcenter_username }}'
+    vcenter_password: '{{ vcenter_password }}'
+    vcenter_validate_certs: false
+  register: existing_vms
+  until: existing_vms is not failed
+
+- name: Turn off the VM
+  vmware.vmware_rest.vcenter_vm_power:
+    vcenter_hostname: '{{ vcenter_hostname }}'
+    vcenter_username: '{{ vcenter_username }}'
+    vcenter_password: '{{ vcenter_password }}'
+    vcenter_validate_certs: false
+    state: stop
+    vm: '{{ item.vm }}'
+  with_items: "{{ existing_vms.value }}"
   ignore_errors: true
 
-- name: Remove the VM prepared by prepare_vmware_tests
-  vmware_guest:
-    name: "{{ item.name }}"
+- name: Delete the VMs
+  vmware.vmware_rest.vcenter_vm:
+    vcenter_hostname: '{{ vcenter_hostname }}'
+    vcenter_username: '{{ vcenter_username }}'
+    vcenter_password: '{{ vcenter_password }}'
+    vcenter_validate_certs: false
+    state: absent
+    vm: '{{ item.vm }}'
+  with_items: "{{ existing_vms.value }}"
+  when:
+    - not item.name.startswith("vCLS")
+
+
+- name: Build a list of local libraries
+  vmware.vmware_rest.content_locallibrary_info:
+    vcenter_hostname: '{{ vcenter_hostname }}'
+    vcenter_username: '{{ vcenter_username }}'
+    vcenter_password: '{{ vcenter_password }}'
+    vcenter_validate_certs: false
+  register: result
+  retries: 100
+  delay: 3
+  until: result is not failed
+
+- name: Delete all the local libraries
+  vmware.vmware_rest.content_locallibrary:
+    vcenter_hostname: '{{ vcenter_hostname }}'
+    vcenter_username: '{{ vcenter_username }}'
+    vcenter_password: '{{ vcenter_password }}'
+    vcenter_validate_certs: false
+    library_id: "{{ item.id }}"
+    state: absent
+  with_items: "{{ result.value }}"
+
+- name: Build a list of subscribed libraries
+  vmware.vmware_rest.content_subscribedlibrary_info:
+    vcenter_hostname: '{{ vcenter_hostname }}'
+    vcenter_username: '{{ vcenter_username }}'
+    vcenter_password: '{{ vcenter_password }}'
+    vcenter_validate_certs: false
+  register: result
+
+- name: Delete all the subscribed libraries
+  vmware.vmware_rest.content_subscribedlibrary:
+    vcenter_hostname: '{{ vcenter_hostname }}'
+    vcenter_username: '{{ vcenter_username }}'
+    vcenter_password: '{{ vcenter_password }}'
+    vcenter_validate_certs: false
+    library_id: "{{ item.id }}"
+    state: absent
+  with_items: "{{ result.value }}"
+
+- name: Get a list of all the datacenters
+  vmware.vmware_rest.vcenter_datacenter_info:
+    vcenter_hostname: '{{ vcenter_hostname }}'
+    vcenter_username: '{{ vcenter_username }}'
+    vcenter_password: '{{ vcenter_password }}'
+    vcenter_validate_certs: false
+  register: existing_datacenters
+- name: Force delete the existing DC
+  vmware.vmware_rest.vcenter_datacenter:
+    vcenter_hostname: '{{ vcenter_hostname }}'
+    vcenter_username: '{{ vcenter_username }}'
+    vcenter_password: '{{ vcenter_password }}'
+    vcenter_validate_certs: false
+    state: absent
+    datacenter: '{{ item.datacenter }}'
     force: true
-    state: absent
-  with_items: '{{ virtual_machines + virtual_machines_in_cluster }}'
-
-- name: Remove the test_vm* VMs
-  vmware_guest:
-    name: "{{ item }}"
-    force: true
-    state: absent
-  with_items:
-    - test_vm1
-    - test_vm2
-    - test_vm3
-
-- name: Remove the DVS portgroups
-  vmware_dvs_portgroup:
-    switch_name: "{{ dvswitch1 }}"
-    portgroup_name: '{{ item }}'
-    vlan_id: 0
-    num_ports: 32
-    portgroup_type: earlyBinding
-    state: absent
-  loop:
-  - DC0_DVPG0
-  - DVPG/1
-  ignore_errors: true
-
-- name: Remove the DVSwitch
-  vmware_dvswitch:
-    datacenter_name: '{{ dc1 }}'
-    state: absent
-    switch_name: '{{ item }}'
-  loop:
-    - '{{ dvswitch1 }}'
-    - dvswitch_0001
-    - dvswitch_0002
-  ignore_errors: true
-
-- name: Clean up the VM Network portgroup
-  vmware_portgroup:
-    esxi_hostname: '{{ esxi_hosts }}'
-    switch: isolated_vSwitch
-    portgroup: VM Network
-    state: absent
-  ignore_errors: true
-  with_items:
-  - isolated_vSwitch
-  - vSwitch0
-
-- name: Remove the vSwitches
-  vmware_vswitch:
-    hostname: '{{ item }}'
-    username: '{{ esxi_user }}'
-    password: '{{ esxi_password }}'
-    switch_name: "{{ switch1 }}"
-    state: absent
-  with_items: "{{ esxi_hosts }}"
-  ignore_errors: true
-
-- include_tasks: move_host_out_of_cluster.yml
-
-- name: Umount NFS datastores from ESXi (1/2)
-  vmware_host_datastore:
-      hostname: '{{ item }}'
-      username: '{{ esxi_user }}'
-      password: '{{ esxi_password }}'
-      datastore_name: '{{ ro_datastore }}'
-      state: absent
-  with_items: "{{ esxi_hosts }}"
-  ignore_errors: true
-
-- name: Umount NFS datastores from ESXi (2/2)
-  vmware_host_datastore:
-      hostname: '{{ item }}'
-      username: '{{ esxi_user }}'
-      password: '{{ esxi_password }}'
-      datastore_name: '{{ rw_datastore }}'
-      state: absent
-  with_items: "{{ esxi_hosts }}"
-  ignore_errors: true
-
-- name: Remove ESXi Hosts from vCenter
-  vmware_host:
-    datacenter_name: '{{ dc1 }}'
-    cluster_name: '{{ ccr1 }}'
-    esxi_hostname: '{{ item }}'
-    esxi_username: '{{ esxi_user }}'
-    esxi_password: '{{ esxi_password }}'
-    state: absent
-  with_items: "{{ esxi_hosts }}"
-  ignore_errors: true
+  with_items: "{{ existing_datacenters.value }}"
+  until: _result is succeeded
+  retries: 10
+  delay: 1
+  register: _result

--- a/tests/integration/targets/vmware_guest/tasks/check_mode.yml
+++ b/tests/integration/targets/vmware_guest/tasks/check_mode.yml
@@ -2,6 +2,28 @@
 # Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+- name: Create VMs
+  vmware_guest:
+    datacenter: "{{ dc1 }}"
+    folder: '{{ f0 }}'
+    name: DC0_H0_VM0
+    state: poweredoff
+    guest_id: debian8_64Guest
+    disk:
+    - size_mb: 10
+      type: thin
+      datastore: '{{ rw_datastore }}'
+    hardware:
+      memory_mb: 128
+      num_cpus: 1
+      scsi: paravirtual
+      version: 11
+    cdrom:
+      type: iso
+      iso_path: "[{{ ro_datastore }}] fedora.iso"
+    networks:
+    - name: VM Network
+
 - name: Perform all operation in check mode
   vmware_guest:
     validate_certs: false
@@ -26,9 +48,6 @@
     - reboot-guest
   register: check_mode_state
   check_mode: true
-
-- debug:
-    var: check_mode_state
 
 - name: assert that changes were made
   assert:

--- a/tests/integration/targets/vmware_guest/tasks/clone_customize_guest_test.yml
+++ b/tests/integration/targets/vmware_guest/tasks/clone_customize_guest_test.yml
@@ -2,6 +2,28 @@
 # Copyright: (c) 2019, Pavan Bidkar <pbidkar@vmware.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+- name: Create VMs
+  vmware_guest:
+    datacenter: "{{ dc1 }}"
+    folder: '{{ f0 }}'
+    name: DC0_H0_VM0
+    state: poweredoff
+    guest_id: debian8_64Guest
+    disk:
+    - size_mb: 10
+      type: thin
+      datastore: '{{ rw_datastore }}'
+    hardware:
+      memory_mb: 128
+      num_cpus: 1
+      scsi: paravirtual
+      version: 11
+    cdrom:
+      type: iso
+      iso_path: "[{{ ro_datastore }}] fedora.iso"
+    networks:
+    - name: VM Network
+
 - name: clone vm from template and customize GOS
   vmware_guest:
     validate_certs: false
@@ -9,10 +31,10 @@
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     name: test_vm1
-    template: "{{ virtual_machines[0].name }}"
+    template: DC0_H0_VM0
     datacenter: "{{ dc1 }}"
     state: poweredoff
-    folder: "{{ virtual_machines[0].folder }}"
+    folder: "{{ f0 }}"
     convert: thin
   register: clone_customize
 

--- a/tests/integration/targets/vmware_guest/tasks/clone_with_convert.yml
+++ b/tests/integration/targets/vmware_guest/tasks/clone_with_convert.yml
@@ -2,6 +2,28 @@
 # Copyright: (c) 2018, Christophe FERREIRA <christophe.ferreira@cnaf.fr>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+- name: Create VMs
+  vmware_guest:
+    datacenter: "{{ dc1 }}"
+    folder: '{{ f0 }}'
+    name: DC0_H0_VM0
+    state: poweredoff
+    guest_id: debian8_64Guest
+    disk:
+    - size_mb: 10
+      type: thin
+      datastore: '{{ rw_datastore }}'
+    hardware:
+      memory_mb: 128
+      num_cpus: 1
+      scsi: paravirtual
+      version: 11
+    cdrom:
+      type: iso
+      iso_path: "[{{ ro_datastore }}] fedora.iso"
+    networks:
+    - name: VM Network
+
 - name: clone vm from template and convert to thin
   vmware_guest:
     validate_certs: false
@@ -9,10 +31,10 @@
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     name: test_vm1
-    template: "{{ virtual_machines[0].name }}"
+    template: DC0_H0_VM0
     datacenter: "{{ dc1 }}"
     state: poweredoff
-    folder: "{{ virtual_machines[0].folder }}"
+    folder: "{{ f0 }}"
     convert: thin
   register: clone_thin
 

--- a/tests/integration/targets/vmware_guest/tasks/main.yml
+++ b/tests/integration/targets/vmware_guest/tasks/main.yml
@@ -10,7 +10,6 @@
     setup_datastore: true
     setup_dvswitch: true
     setup_resource_pool: true
-    setup_virtualmachines: true
     setup_dvs_portgroup: true
 
 - include_tasks: run_test_playbook.yml

--- a/tests/integration/targets/vmware_guest/tasks/run_test_playbook.yml
+++ b/tests/integration/targets/vmware_guest/tasks/run_test_playbook.yml
@@ -1,17 +1,32 @@
 - block:
   - include_tasks: '{{ test_playbook }}'
   always:
-    - name: Remove VM
-      vmware_guest:
-        hostname: "{{ vcenter_hostname }}"
-        username: "{{ vcenter_username }}"
-        password: "{{ vcenter_password }}"
-        validate_certs: false
-#        cluster: "{{ ccr1 }}"
-        name: '{{ item }}'
-        force: true
+    - name: Collect the list of the existing VM
+      vmware.vmware_rest.vcenter_vm_info:
+        vcenter_hostname: '{{ vcenter_hostname }}'
+        vcenter_username: '{{ vcenter_username }}'
+        vcenter_password: '{{ vcenter_password }}'
+        vcenter_validate_certs: false
+      register: existing_vms
+      until: existing_vms is not failed
+    - name: Turn off the VM
+      vmware.vmware_rest.vcenter_vm_power:
+        vcenter_hostname: '{{ vcenter_hostname }}'
+        vcenter_username: '{{ vcenter_username }}'
+        vcenter_password: '{{ vcenter_password }}'
+        vcenter_validate_certs: false
+        state: stop
+        vm: '{{ item.vm }}'
+      with_items: "{{ existing_vms.value }}"
+      ignore_errors: true
+    - name: Clean up VM
+      vmware.vmware_rest.vcenter_vm:
+        vcenter_hostname: '{{ vcenter_hostname }}'
+        vcenter_username: '{{ vcenter_username }}'
+        vcenter_password: '{{ vcenter_password }}'
+        vcenter_validate_certs: false
         state: absent
-      with_items:
-        - test_vm1
-        - test_vm2
-        - test_vm3
+        vm: '{{ item.vm }}'
+      with_items: "{{ existing_vms.value }}"
+      when:
+        - not item.name.startswith("vCLS")

--- a/tests/integration/targets/vmware_guest_disk_info/tasks/main.yml
+++ b/tests/integration/targets/vmware_guest_disk_info/tasks/main.yml
@@ -7,7 +7,28 @@
   vars:
     setup_attach_host: true
     setup_datastore: true
-    setup_virtualmachines: true
+
+- name: Create VMs
+  vmware_guest:
+    datacenter: "{{ dc1 }}"
+    folder: '{{ f0 }}'
+    name: DC0_H0_VM0
+    state: poweredoff
+    guest_id: debian8_64Guest
+    disk:
+    - size_mb: 10
+      type: thin
+      datastore: '{{ rw_datastore }}'
+    hardware:
+      memory_mb: 128
+      num_cpus: 1
+      scsi: paravirtual
+      version: 11
+    cdrom:
+      type: iso
+      iso_path: "[{{ ro_datastore }}] fedora.iso"
+    networks:
+    - name: VM Network
 
 - name: set state to poweron the first VM
   vmware_guest_powerstate:
@@ -15,7 +36,7 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    name: "{{ virtual_machines[0].name }}"
+    name: DC0_H0_VM0
     folder: '{{ f0 }}'
     state: powered-on
 
@@ -25,7 +46,7 @@
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
-    name: "{{ virtual_machines[0].name }}"
+    name: DC0_H0_VM0
     datacenter: '{{ dc1 }}'
   register: disk_info
 

--- a/tests/integration/targets/vmware_host_datastore/tasks/main.yml
+++ b/tests/integration/targets/vmware_host_datastore/tasks/main.yml
@@ -46,6 +46,7 @@
           - mount_vmware_host_datastore is failed
           - mount_vmware_host_datastore.msg == "Failed to find ESXi hostname nohost"
 
+    # note: datastore is already mounted
     - name: Mount NFS (ro_datastore) datastores on esxi1 using esxi_hostname
       vmware_host_datastore:
         hostname: "{{ vcenter_hostname }}"
@@ -61,9 +62,6 @@
         validate_certs: false
       register: mount_vmware_host_datastore
     - debug: var=mount_vmware_host_datastore
-    - assert:
-        that:
-          - mount_vmware_host_datastore is changed
 
     - name: Mount NFS (ro_datastore) datastores to ESXi directly
       vmware_host_datastore:

--- a/tests/integration/targets/vmware_host_firewall_manager/tasks/main.yml
+++ b/tests/integration/targets/vmware_host_firewall_manager/tasks/main.yml
@@ -220,3 +220,18 @@
       assert:
         that:
           - nfc_state.allowed_hosts.current_allowed_ip == ["1.2.3.4"]
+    - name: Clean up the firewall rules
+      vmware_host_firewall_manager:
+        cluster_name: '{{ ccr1 }}'
+        rules:
+            - name: vvold
+              enabled: false
+            - name: CIMHttpServer
+              enabled: true
+              allowed_hosts:
+                all_ip: true
+            - name: NFC
+              enabled: true
+              allowed_hosts:
+                all_ip: true
+      ignore_errors: true


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1215

vmware.vmware_rest allow uses to simplify the clean up of the resources
and avoid any leaked VM.
Also:

- test VMs use lighter disk size.
- do not umount the datastore during the teardown.
