### PR TITLE
vmware_vm_host_drs_rule/tests: clean up resources

### DIFF
--- a/tests/integration/targets/vmware_vm_host_drs_rule/tasks/main.yml
+++ b/tests/integration/targets/vmware_vm_host_drs_rule/tasks/main.yml
@@ -79,3 +79,46 @@
     - assert:
         that:
             - "{{ drs_rule_host_0001_results.changed }}"
+
+    - name: Delete rules
+      vmware_vm_host_drs_rule:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        drs_rule_name: drs_rule_host_aff_0001
+        vm_group_name: DC0_C0_VM_GR1
+        host_group_name: DC0_C0_HOST_GR1
+        cluster_name: "{{ ccr1 }}"
+        state: absent
+      register: result
+    - debug: var=result
+    - assert:
+        that:
+            - result is changed
+
+    - name: Delete DRS VM group
+      vmware_drs_group:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        # Options
+        cluster_name: '{{ ccr1 }}'
+        datacenter_name: '{{ dc1 }}'
+        group_name: DC0_C0_VM_GR1
+        vms: "{{ virtual_machines_in_cluster | map(attribute='name') | list }}"
+        state: absent
+
+    - name: Delete DRS Host group
+      vmware_drs_group:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        # Options
+        cluster_name: '{{ ccr1 }}'
+        datacenter_name: '{{ dc1 }}'
+        group_name: DC0_C0_HOST_GR1
+        hosts: '{{ esxi_hosts }}'
+        state: absent


### PR DESCRIPTION
Remove the DRS rule and DRS groups at the end of the tests.
