### PR TITLE
vmware_vcenter_settings/tests: restore advanced_settings config

### DIFF
--- a/tests/integration/targets/vmware_vcenter_settings/tasks/main.yml
+++ b/tests/integration/targets/vmware_vcenter_settings/tasks/main.yml
@@ -213,3 +213,12 @@
     assert:
       that:
         - not configure_advanced_settings_again.changed
+
+  - name: Restore the original advanced_settings configuration
+    community.vmware.vmware_vcenter_settings:
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      validate_certs: false
+      advanced_settings:
+        'config.vcls.clusters.domain-c8.enabled': 'true'


### PR DESCRIPTION
Restore the original advanced_settings configuration to be able to run
the test two times in a row.
