### PR TITLE
vmware_vm_inventory/tests: power on only one VM

### DIFF
--- a/tests/integration/targets/vmware_vm_inventory/prepare_environment.yml
+++ b/tests/integration/targets/vmware_vm_inventory/prepare_environment.yml
@@ -17,10 +17,9 @@
 
     - name: set state to poweron the first VM
       vmware_guest_powerstate:
-        name: "{{ item.name }}"
+        name: "{{ virtual_machines[0].name }}"
         folder: '{{ f0 }}'
         state: powered-on
-      with_items: '{{ virtual_machines }}'
 
     - copy:
         dest: vmware.yaml


### PR DESCRIPTION
Only use one VM to preserve the resources.
