### PR TITLE
vmware_vm_inventory/tests: only spawn 1 VM with 1GB of RAM

### DIFF
--- a/tests/integration/targets/vmware_vm_inventory/prepare_environment.yml
+++ b/tests/integration/targets/vmware_vm_inventory/prepare_environment.yml
@@ -13,14 +13,33 @@
       vars:
         setup_attach_host: true
         setup_datastore: true
-        setup_virtualmachines: true
 
-    - name: set state to poweron the first VM
-      vmware_guest_powerstate:
-        name: "{{ item.name }}"
-        folder: '{{ f0 }}'
+    - name: Create VM
+      vmware_guest:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        datacenter: "{{ dc1 }}"
+        validate_certs: false
+        name: test_vm1
+        folder: vm
+        esxi_hostname: "{{ esxi1 }}"
         state: powered-on
-      with_items: '{{ virtual_machines }}'
+        guest_id: debian8_64Guest
+        disk:
+        - size_gb: 1
+          type: thin
+          datastore: local
+        cdrom:
+          type: iso
+          iso_path: "[{{ ro_datastore }}] fedora.iso"
+        hardware:
+          # vmware_guest_disk need vmx-13 to reconfigure the disks
+          version: 13
+          memory_mb: 1024
+          num_cpus: 1
+          scsi: paravirtual
+      register: vm_create
 
     - copy:
         dest: vmware.yaml

--- a/tests/integration/targets/vmware_vm_inventory/test_inventory.yml
+++ b/tests/integration/targets/vmware_vm_inventory/test_inventory.yml
@@ -6,5 +6,5 @@
   tasks:
     - assert:
         that:
-            - "{{ groups['debian8_64Guest'] | length }} == 4"
-            - hostvars['DC0_H0_VM0'] is defined
+            - "{{ groups['debian8_64Guest'] | length }} == 1"
+            - hostvars['test_vm1'] is defined


### PR DESCRIPTION
Fedora cannot boot properly with just 128MB of memory. This was not a
problem with ESXi 6.7.0U3 but with 7.0.3, the ESXi can figure out that
the VM has crashed because it's run out of for memory.

So, now we start one single VM and we ensure it's got enough memory.
