### PR TITLE
vmware_content_library_manager: reenable the tests

### DIFF
--- a/tests/integration/targets/vmware_content_library_manager/aliases
+++ b/tests/integration/targets/vmware_content_library_manager/aliases
@@ -2,4 +2,3 @@ cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
 zuul/vmware/govcsim
-disabled

--- a/tests/integration/targets/vmware_content_library_manager/tasks/main.yml
+++ b/tests/integration/targets/vmware_content_library_manager/tasks/main.yml
@@ -101,6 +101,11 @@
         library_type: subscribed
         state: absent
 
+    - name: get finger print
+      shell: echo | openssl s_client -connect wp-content.vmware.com:443 |& openssl x509 -fingerprint -noout
+      register: _finger_print
+    - debug: var=_finger_print
+
     - &subscribed_content_lib_create
       name: Create subscribed content library
       vmware_content_library_manager:
@@ -113,7 +118,7 @@
         subscription_url: "https://wp-content.vmware.com/v2/latest/lib.json"
         update_on_demand: true
         library_type: subscribed
-        ssl_thumbprint: ba:c6:4e:d9:ad:d4:53:b5:86:5a:5d:70:36:cf:89:93:d1:6c:f9:63
+        ssl_thumbprint: '{{ _finger_print.stdout.split("=")[1] }}'
         datastore_name: '{{ rw_datastore }}'
         state: present
       register: subscribed_content_lib_create_result
@@ -144,7 +149,7 @@
         subscription_url: https://download3.vmware.com/software/vmw-tools/lib.json
         update_on_demand: true
         library_type: subscribed
-        ssl_thumbprint: ba:c6:4e:d9:ad:d4:53:b5:86:5a:5d:70:36:cf:89:93:d1:6c:f9:63
+        ssl_thumbprint: '{{ _finger_print.stdout.split("=")[1] }}'
         state: present
       register: subscribed_content_lib_update_result
 


### PR DESCRIPTION
The test now dynamically retrieves the fingerprint of
wp-content.vmware.com. This way we don't need to hardcode the key.

Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1217