### PR TITLE
add datastore_url to vm output from vm_info module

### DIFF
--- a/changelogs/fragements/datastore_url-added-to-vm_info.yaml
+++ b/changelogs/fragements/datastore_url-added-to-vm_info.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_vm_info - adding fact about ``datastore_url`` to output (https://github.com/ansible-collections/community.vmware/pull/1143).

--- a/plugins/modules/vmware_vm_info.py
+++ b/plugins/modules/vmware_vm_info.py
@@ -26,7 +26,7 @@ notes:
 - Tested on ESXi 6.7, vSphere 5.5 and vSphere 6.5
 - From 2.8 and onwards, information are returned as list of dict instead of dict.
 - Fact about C(moid) added in VMware collection 1.4.0.
-- datastore_url is added to output in version 1.18.0.
+- Fact about C(datastore_url) is added to output in version 1.18.0.
 requirements:
 - python >= 2.6
 - PyVmomi

--- a/plugins/modules/vmware_vm_info.py
+++ b/plugins/modules/vmware_vm_info.py
@@ -26,6 +26,7 @@ notes:
 - Tested on ESXi 6.7, vSphere 5.5 and vSphere 6.5
 - From 2.8 and onwards, information are returned as list of dict instead of dict.
 - Fact about C(moid) added in VMware collection 1.4.0.
+- datastore_url is added to output in version 1.18.0.
 requirements:
 - python >= 2.6
 - PyVmomi
@@ -148,6 +149,23 @@ EXAMPLES = r'''
     folder: "/Asia-Datacenter1/vm/prod"
   delegate_to: localhost
   register: vm_info
+
+- name: Get datastore_url from given VM name
+  block:
+    - name: Get virtual machine info
+      community.vmware.vmware_vm_info:
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+      delegate_to: localhost
+      register: vm_info
+
+    - debug:
+        msg: "{{ item.datastore_url }}"
+      with_items:
+        - "{{ vm_info.virtual_machines | json_query(query) }}"
+      vars:
+        query: "[?guest_name=='DC0_H0_VM0']"
 '''
 
 RETURN = r'''

--- a/plugins/modules/vmware_vm_info.py
+++ b/plugins/modules/vmware_vm_info.py
@@ -279,6 +279,11 @@ class VmwareVmInfo(PyVmomi):
 
             vm_folder = PyVmomi.get_vm_path(content=self.content, vm_name=vm)
             datacenter = get_parent_datacenter(vm)
+            datastore_url = list()
+            for entry in vm.config.datastoreUrl:
+                datastore_url.append({key: gettattr(entry, key)
+                    for key in dir(entry):
+                    if not key.startswith('_')})
             virtual_machine = {
                 "guest_name": summary.config.name,
                 "guest_fullname": summary.config.guestFullName,
@@ -294,6 +299,7 @@ class VmwareVmInfo(PyVmomi):
                 "tags": vm_tags,
                 "folder": vm_folder,
                 "moid": vm._moId,
+                "datastore_url": datastore_url,
             }
 
             vm_type = self.module.params.get('vm_type')

--- a/plugins/modules/vmware_vm_info.py
+++ b/plugins/modules/vmware_vm_info.py
@@ -304,8 +304,10 @@ class VmwareVmInfo(PyVmomi):
             vm_folder = PyVmomi.get_vm_path(content=self.content, vm_name=vm)
             datacenter = get_parent_datacenter(vm)
             datastore_url = list()
-            for entry in vm.config.datastoreUrl:
-                datastore_url.append({key: getattr(entry, key) for key in dir(entry) if not key.startswith('_')})
+            datastore_attributes = ('name', 'url')
+            if vm.config.datastoreUrl:
+                for entry in vm.config.datastoreUrl:
+                    datastore_url.append({key: getattr(entry, key) for key in dir(entry) if key in datastore_attributes})
             virtual_machine = {
                 "guest_name": summary.config.name,
                 "guest_fullname": summary.config.guestFullName,

--- a/plugins/modules/vmware_vm_info.py
+++ b/plugins/modules/vmware_vm_info.py
@@ -26,7 +26,7 @@ notes:
 - Tested on ESXi 6.7, vSphere 5.5 and vSphere 6.5
 - From 2.8 and onwards, information are returned as list of dict instead of dict.
 - Fact about C(moid) added in VMware collection 1.4.0.
-- Fact about C(datastore_url) is added to output in version 1.18.0.
+- Fact about C(datastore_url) is added in VMware collection 1.18.0.
 requirements:
 - python >= 2.6
 - PyVmomi
@@ -119,7 +119,7 @@ EXAMPLES = r'''
     - debug:
         msg: "{{ item.uuid }}"
       with_items:
-        - "{{ vm_info.virtual_machines | json_query(query) }}"
+        - "{{ vm_info.virtual_machines | community.general.json_query(query) }}"
       vars:
         query: "[?guest_name=='DC0_H0_VM0']"
 
@@ -137,7 +137,7 @@ EXAMPLES = r'''
     - debug:
         msg: "{{ item.tags }}"
       with_items:
-        - "{{ vm_info.virtual_machines | json_query(query) }}"
+        - "{{ vm_info.virtual_machines | community.general.json_query(query) }}"
       vars:
         query: "[?guest_name=='DC0_H0_VM0']"
 
@@ -163,7 +163,7 @@ EXAMPLES = r'''
     - debug:
         msg: "{{ item.datastore_url }}"
       with_items:
-        - "{{ vm_info.virtual_machines | json_query(query) }}"
+        - "{{ vm_info.virtual_machines | community.general.json_query(query) }}"
       vars:
         query: "[?guest_name=='DC0_H0_VM0']"
 '''
@@ -198,6 +198,12 @@ virtual_machines:
         "attributes": {
             "job": "backup-prepare"
         },
+        "datastore_url": [
+            {
+                "name": "t880-o2g",
+                "url": "/vmfs/volumes/e074264a-e5c82a58"
+            }
+        ],
         "tags": [
             {
                 "category_id": "urn:vmomi:InventoryServiceCategory:b316cc45-f1a9-4277-811d-56c7e7975203:GLOBAL",

--- a/plugins/modules/vmware_vm_info.py
+++ b/plugins/modules/vmware_vm_info.py
@@ -299,9 +299,7 @@ class VmwareVmInfo(PyVmomi):
             datacenter = get_parent_datacenter(vm)
             datastore_url = list()
             for entry in vm.config.datastoreUrl:
-                datastore_url.append({key: gettattr(entry, key)
-                    for key in dir(entry):
-                    if not key.startswith('_')})
+                datastore_url.append({key: getattr(entry, key) for key in dir(entry) if not key.startswith('_')})
             virtual_machine = {
                 "guest_name": summary.config.name,
                 "guest_fullname": summary.config.guestFullName,


### PR DESCRIPTION
##### SUMMARY
Build a list out of the datastore object inside of vm object and output with the other infos. This is useful for getting some data for building and managing drs groups for all vms inside one or multiple clusters.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
datastore_url support for vmware_vm_info

##### ADDITIONAL INFORMATION
The following example snippet will be inside of every vm output.
```paste below
 "datastore_url": [
                    {
                        "name": "t880-o2g",
                        "url": "/vmfs/volumes/e074264a-e5c82a58"
                    }
                ],
```
