### PR TITLE
vmware_cluster_drs/ha/vsan remove alias and change default for enable

### DIFF
--- a/changelogs/fragments/vmware_cluster_drs-ha-vsan-enable_default.yml
+++ b/changelogs/fragments/vmware_cluster_drs-ha-vsan-enable_default.yml
@@ -1,0 +1,7 @@
+breaking_changes:
+- vmware_cluster_drs - The parameter alias ``enable_drs`` has been removed, use ``enable`` instead.
+- vmware_cluster_ha - The parameter alias ``enable_ha`` has been removed, use ``enable`` instead.
+- vmware_cluster_vsan - The parameter alias ``enable_vsan`` has been removed, use ``enable`` instead.
+- vmware_cluster_drs - The default for ``enable`` has been changed from ``false`` to ``true``.
+- vmware_cluster_ha - The default for ``enable`` has been changed from ``false`` to ``true``.
+- vmware_cluster_vsan - The default for ``enable`` has been changed from ``false`` to ``true``.

--- a/plugins/modules/vmware_cluster_drs.py
+++ b/plugins/modules/vmware_cluster_drs.py
@@ -39,8 +39,7 @@ options:
       description:
       - Whether to enable DRS.
       type: bool
-      default: false
-      aliases: [ enable_drs ]
+      default: true
     drs_enable_vm_behavior_overrides:
       description:
       - Whether DRS Behavior overrides for individual virtual machines are enabled.
@@ -153,9 +152,6 @@ class VMwareCluster(PyVmomi):
         else:
             self.changed_advanced_settings = None
 
-        self.module.warn("The default for enable will change from false to true in a future version to make the behavior more consistent with other modules."
-                         "Please make sure your playbooks don't rely on the default being false so you don't run into problems.")
-
     def check_drs_config_diff(self):
         """
         Check DRS configuration diff
@@ -218,7 +214,7 @@ def main():
         cluster_name=dict(type='str', required=True),
         datacenter=dict(type='str', required=True, aliases=['datacenter_name']),
         # DRS
-        enable=dict(type='bool', default=False, aliases=['enable_drs']),
+        enable=dict(type='bool', default=True),
         drs_enable_vm_behavior_overrides=dict(type='bool', default=True),
         drs_default_vm_behavior=dict(type='str',
                                      choices=['fullyAutomated', 'manual', 'partiallyAutomated'],

--- a/plugins/modules/vmware_cluster_ha.py
+++ b/plugins/modules/vmware_cluster_ha.py
@@ -40,8 +40,7 @@ options:
       description:
       - Whether to enable HA.
       type: bool
-      default: false
-      aliases: [ enable_ha ]
+      default: true
     ha_host_monitoring:
       description:
       - Whether HA restarts virtual machines after a host fails.
@@ -284,9 +283,6 @@ class VMwareCluster(PyVmomi):
         else:
             self.changed_advanced_settings = None
 
-        self.module.warn("The default for enable will change from false to true in a future version to make the behavior more consistent with other modules."
-                         "Please make sure your playbooks don't rely on the default being false so you don't run into problems.")
-
     def get_failover_hosts(self):
         """
         Get failover hosts for failover_host_admission_control policy
@@ -459,7 +455,7 @@ def main():
         cluster_name=dict(type='str', required=True),
         datacenter=dict(type='str', required=True, aliases=['datacenter_name']),
         # HA
-        enable=dict(type='bool', default=False, aliases=['enable_ha']),
+        enable=dict(type='bool', default=True),
         ha_host_monitoring=dict(type='str',
                                 default='enabled',
                                 choices=['enabled', 'disabled']),

--- a/plugins/modules/vmware_cluster_vsan.py
+++ b/plugins/modules/vmware_cluster_vsan.py
@@ -41,8 +41,7 @@ options:
       description:
       - Whether to enable vSAN.
       type: bool
-      default: false
-      aliases: [ enable_vsan ]
+      default: true
     vsan_auto_claim_storage:
       description:
       - Whether the VSAN service is configured to automatically claim local storage
@@ -170,9 +169,6 @@ class VMwareCluster(PyVmomi):
         vcMos = vsanapiutils.GetVsanVcMos(client_stub, context=ssl_context, version=apiVersion)
         self.vsanClusterConfigSystem = vcMos['vsan-cluster-config-system']
 
-        self.module.warn("The default for enable will change from false to true in a future version to make the behavior more consistent with other modules."
-                         "Please make sure your playbooks don't rely on the default being false so you don't run into problems.")
-
     def check_vsan_config_diff(self):
         """
         Check VSAN configuration diff
@@ -261,7 +257,7 @@ def main():
         cluster_name=dict(type='str', required=True),
         datacenter=dict(type='str', required=True, aliases=['datacenter_name']),
         # VSAN
-        enable=dict(type='bool', default=False, aliases=['enable_vsan']),
+        enable=dict(type='bool', default=True),
         vsan_auto_claim_storage=dict(type='bool', default=False),
         advanced_options=dict(type='dict', options=dict(
             automatic_rebalance=dict(type='bool', required=False),

--- a/tests/integration/targets/vmware_cluster_drs/tasks/main.yml
+++ b/tests/integration/targets/vmware_cluster_drs/tasks/main.yml
@@ -42,7 +42,7 @@
     password: "{{ vcenter_password }}"
     datacenter_name: "{{ dc1 }}"
     cluster_name: test_cluster_drs
-    enable_drs: false
+    enable: false
   register: cluster_drs_result_0002
 
 - name: Ensure DRS is disabled

--- a/tests/integration/targets/vmware_cluster_ha/tasks/main.yml
+++ b/tests/integration/targets/vmware_cluster_ha/tasks/main.yml
@@ -40,7 +40,7 @@
     password: "{{ vcenter_password }}"
     datacenter_name: "{{ dc1 }}"
     cluster_name: test_cluster_ha
-    enable_ha: false
+    enable: false
   register: disable_ha_result
 
 - name: Ensure HA is disabled

--- a/tests/integration/targets/vmware_cluster_vsan/tasks/main.yml
+++ b/tests/integration/targets/vmware_cluster_vsan/tasks/main.yml
@@ -44,7 +44,7 @@
         password: "{{ vcenter_password }}"
         datacenter_name: "{{ dc1 }}"
         cluster_name: test_cluster_vsan
-        enable_vsan: true
+        enable: true
       register: cluster_vsan_result_0002
 
     - name: Ensure vSAN is not enabled again


### PR DESCRIPTION
##### SUMMARY
The default for `enable` in vmware_cluster_drs/ha/vsan should be `true` instead of `false`. This is more consistent with other modules and might avoid serious issues.

Fixes #739

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_cluster_drs
vmware_cluster_ha
vmware_cluster_vsan

##### ADDITIONAL INFORMATION
I've also removed the aliases for `enable`. `enable_drs` is a bit redundant in a module dealing with DRS, it should be obvious what `enable` is about.