### PR TITLE
vmware_dvs_portgroup: Remove portgroup_type

### DIFF
--- a/changelogs/fragments/vmware_dvs_portgroup-portgroup_type.yml
+++ b/changelogs/fragments/vmware_dvs_portgroup-portgroup_type.yml
@@ -1,0 +1,2 @@
+removed_features:
+- vmware_dvs_portgroup - The deprecated parameter ``portgroup_type`` has been removed, use ``port_binding`` instead.

--- a/tests/integration/targets/prepare_vmware_tests/tasks/setup_dvs_portgroup.yml
+++ b/tests/integration/targets/prepare_vmware_tests/tasks/setup_dvs_portgroup.yml
@@ -5,7 +5,8 @@
     portgroup_name: '{{ dvpg1 }}'
     vlan_id: 0
     num_ports: 32
-    portgroup_type: earlyBinding
+    port_binding: 'static'
+    port_allocation: 'fixed'
     state: present
 
 - name: Create the DVS PG with slash in name
@@ -14,5 +15,6 @@
     switch_name: '{{ dvswitch1 }}'
     vlan_id: 0
     num_ports: 120
-    portgroup_type: earlyBinding
+    port_binding: 'static'
+    port_allocation: 'fixed'
     state: present

--- a/tests/integration/targets/vmware_dvs_portgroup/tasks/main.yml
+++ b/tests/integration/targets/vmware_dvs_portgroup/tasks/main.yml
@@ -320,7 +320,7 @@
     that:
         - dvs_pg_result_0009.changed
 
-- name: Change portgroup_type to ephemeral
+- name: Change portgroup to ephemeral
   vmware_dvs_portgroup:
     validate_certs: false
     hostname: "{{ vcenter_hostname }}"

--- a/tests/integration/targets/vmware_dvs_portgroup_find/tasks/main.yml
+++ b/tests/integration/targets/vmware_dvs_portgroup_find/tasks/main.yml
@@ -55,7 +55,8 @@
         portgroup_name: 'dvportgroup\/%'
         vlan_id: 1
         num_ports: 8
-        portgroup_type: earlyBinding
+        port_binding: 'static'
+        port_allocation: 'fixed'
         state: present
       register: create_dvportgroup_with_special_characters_result
 
@@ -92,7 +93,8 @@
         portgroup_name: 'dvportgroup\/%'
         vlan_id: 1
         num_ports: 8
-        portgroup_type: earlyBinding
+        port_binding: 'static'
+        port_allocation: 'fixed'
         state: absent
       register: delete_dvportgroup_with_special_characters_result
 

--- a/tests/integration/targets/vmware_dvs_portgroup_info/tasks/main.yml
+++ b/tests/integration/targets/vmware_dvs_portgroup_info/tasks/main.yml
@@ -50,7 +50,8 @@
             portgroup_name: 'dvportgroup\/%'
             vlan_id: 1
             num_ports: 8
-            portgroup_type: earlyBinding
+            port_binding: 'static'
+            port_allocation: 'fixed'
             state: present
           register: create_dvportgroup_with_special_characters_result
 
@@ -81,7 +82,8 @@
             portgroup_name: 'dvportgroup\/%'
             vlan_id: 1
             num_ports: 8
-            portgroup_type: earlyBinding
+            port_binding: 'static'
+            port_allocation: 'fixed'
             state: absent
           register: delete_dvportgroup_with_special_characters_result
 

--- a/tests/integration/targets/vmware_guest/tasks/network_with_dvpg.yml
+++ b/tests/integration/targets/vmware_guest/tasks/network_with_dvpg.yml
@@ -147,7 +147,8 @@
             switch_name: "{{ dvswitch1 }}"
             portgroup_name: "192.168.0.0/24"
             vlan_id: 0
-            portgroup_type: earlyBinding
+            port_binding: 'static'
+            port_allocation: 'fixed'
             num_ports: 8
             state: present
           register: create_dvportgroup_result
@@ -192,7 +193,8 @@
             switch_name: "{{ dvswitch1 }}"
             portgroup_name: "192.168.0.0/24"
             vlan_id: 0
-            portgroup_type: earlyBinding
+            port_binding: 'static'
+            port_allocation: 'fixed'
             num_ports: 8
             state: absent
           register: delete_dvportgroup_result

--- a/tests/integration/targets/vmware_guest/tasks/network_with_portgroup.yml
+++ b/tests/integration/targets/vmware_guest/tasks/network_with_portgroup.yml
@@ -12,7 +12,8 @@
     switch_name: "{{ dvswitch1 }}"
     vlan_id: "1"
     num_ports: 2
-    portgroup_type: earlyBinding
+    port_binding: 'static'
+    port_allocation: 'fixed'
     state: present
   register: dvsportgroup
 - debug: var=dvsportgroup

--- a/tests/integration/targets/vmware_guest_network/tasks/main.yml
+++ b/tests/integration/targets/vmware_guest_network/tasks/main.yml
@@ -439,7 +439,8 @@
           switch_name: "{{ dvswitch1 }}"
           portgroup_name: 204dvpg
           num_ports: 8
-          portgroup_type: earlyBinding
+          port_binding: 'static'
+          port_allocation: 'fixed'
           vlan_id: 1
           state: present
         register: prepare_integration_test_204_result
@@ -508,7 +509,8 @@
           switch_name: "{{ dvswitch1 }}"
           portgroup_name: 204dvpg
           num_ports: 8
-          portgroup_type: earlyBinding
+          port_binding: 'static'
+          port_allocation: 'fixed'
           vlan_id: 1
           state: absent
         register: delete_integration_test_204_result

--- a/tests/integration/targets/vmware_migrate_vmk/tasks/main.yml
+++ b/tests/integration/targets/vmware_migrate_vmk/tasks/main.yml
@@ -129,7 +129,8 @@
         validate_certs: false
         switch_name: "{{ dvswitch1 }}"
         portgroup_name: "{{ dvswitch_pg_name_for_test }}"
-        portgroup_type: earlyBinding
+        port_binding: 'static'
+        port_allocation: 'fixed'
         num_ports: 8
         vlan_id: 0
         state: present

--- a/tests/integration/targets/vmware_vspan_session/tasks/main.yml
+++ b/tests/integration/targets/vmware_vspan_session/tasks/main.yml
@@ -38,7 +38,8 @@
     switch_name: dvswitch_0001
     vlan_id: 123
     num_ports: 120
-    portgroup_type: earlyBinding
+    port_binding: 'static'
+    port_allocation: 'fixed'
     state: present
     network_policy:
       promiscuous: true


### PR DESCRIPTION
##### SUMMARY
Remove the deprecated parameter ``portgroup_type``.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_dvs_portgroup

##### ADDITIONAL INFORMATION
#743
#1071
#1136