### PR TITLE
vmware_vm_storage_policy tag_names type changed from str to list

### DIFF
--- a/plugins/modules/vmware_vm_storage_policy.py
+++ b/plugins/modules/vmware_vm_storage_policy.py
@@ -49,7 +49,7 @@ options:
     - This parameter is ignored when C(state=absent).
     - This parameter is required when C(state=present).
     required: False
-    type: str
+    type: list
   tag_affinity:
     description:
     - If set to C(true), the storage policy enforces that virtual machines require the existence of a tag for datastore placement.


### PR DESCRIPTION
##### SUMMARY
This is to allow the module to have multiple tag_names that can be added to a new storage profile

Fixes #1134
Fixes #1142

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_vm_storage_policy 
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
