### PR TITLE
Prune references to old facts from new info modules

### DIFF
--- a/plugins/modules/vmware_cluster_info.py
+++ b/plugins/modules/vmware_cluster_info.py
@@ -15,7 +15,6 @@ short_description: Gather info about clusters available in given vCenter
 description:
     - This module can be used to gather information about clusters in VMWare infrastructure.
     - All values and VMware object names are case sensitive.
-    - This module was called C(vmware_cluster_facts) before Ansible 2.9. The usage did not change.
 author:
     - Abhijeet Kasurde (@Akasurde)
     - Christian Neugum (@digifuchsi)
@@ -341,11 +340,6 @@ def main():
         ],
         supports_check_mode=True,
     )
-    if module._name == 'vmware_cluster_facts':
-        module.deprecate(
-            msg="The 'vmware_cluster_facts' module has been renamed to 'vmware_cluster_info'",
-            version='3.0.0',  # was Ansible 2.13
-            collection_name='community.vmware')
 
     pyv = VmwreClusterInfoManager(module)
     pyv.gather_cluster_info()

--- a/plugins/modules/vmware_datastore_info.py
+++ b/plugins/modules/vmware_datastore_info.py
@@ -16,7 +16,6 @@ short_description: Gather info about datastores available in given vCenter
 description:
     - This module can be used to gather information about datastores in VMWare infrastructure.
     - All values and VMware object names are case sensitive.
-    - This module was called C(vmware_datastore_facts) before Ansible 2.9. The usage did not change.
 author:
     - Tim Rightnour (@garbled1)
 notes:
@@ -331,12 +330,6 @@ def main():
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True
                            )
-    if module._name == 'vmware_datastore_facts':
-        module.deprecate(
-            msg="The 'vmware_datastore_facts' module has been renamed to 'vmware_datastore_info'",
-            version='3.0.0',  # was Ansible 2.13
-            collection_name='community.vmware'
-        )
 
     result = dict(changed=False)
 

--- a/plugins/modules/vmware_guest_info.py
+++ b/plugins/modules/vmware_guest_info.py
@@ -15,7 +15,6 @@ module: vmware_guest_info
 short_description: Gather info about a single VM
 description:
     - Gather information about a single VM on a VMware ESX cluster.
-    - This module was called C(vmware_guest_facts) before Ansible 2.9. The usage did not change.
 author:
     - Loic Blot (@nerzhul) <loic.blot@unix-experience.fr>
 notes:
@@ -278,12 +277,6 @@ def main():
     module = AnsibleModule(argument_spec=argument_spec,
                            required_one_of=[['name', 'uuid', 'moid']],
                            supports_check_mode=True)
-    if module._name in ('vmware_guest_facts', 'community.vmware.vmware_guest_facts'):
-        module.deprecate(
-            msg="The 'vmware_guest_facts' module has been renamed to 'vmware_guest_info'",
-            version='3.0.0',
-            collection_name='community.vmware'
-        )
 
     if module.params.get('folder'):
         # FindByInventoryPath() does not require an absolute path

--- a/plugins/modules/vmware_guest_snapshot_info.py
+++ b/plugins/modules/vmware_guest_snapshot_info.py
@@ -15,7 +15,6 @@ module: vmware_guest_snapshot_info
 short_description: Gather info about virtual machine's snapshots in vCenter
 description:
     - This module can be used to gather information about virtual machine's snapshots.
-    - This module was called C(vmware_guest_snapshot_facts) before Ansible 2.9. The usage did not change.
 author:
     - Abhijeet Kasurde (@Akasurde)
 notes:
@@ -164,10 +163,6 @@ def main():
         ],
         supports_check_mode=True,
     )
-
-    if module._name in ('vmware_guest_snapshot_facts', 'community.vmware.vmware_guest_snapshot_facts'):
-        module.deprecate(msg="The 'vmware_guest_snapshot_facts' module has been renamed to 'vmware_guest_snapshot_info'",
-                         version='3.0.0', collection_name='community.vmware')  # was Ansible 2.13
 
     if module.params['folder']:
         # FindByInventoryPath() does not require an absolute path

--- a/plugins/modules/vmware_tag_info.py
+++ b/plugins/modules/vmware_tag_info.py
@@ -18,9 +18,6 @@ description:
 - This module can be used to collect information about VMware tags.
 - Tag feature is introduced in vSphere 6 version, so this module is not supported in the earlier versions of vSphere.
 - All variables and VMware object names are case sensitive.
-- This module was called C(vmware_tag_facts) before Ansible 2.9. The usage did not change.
-- C(tag_facts) will be deprecated in Ansible 2.14, since it does not return multiple tags with same name and different category id.
-- Please use C(tag_info) instead of C(tag_facts).
 author:
 - Abhijeet Kasurde (@Akasurde)
 notes:
@@ -163,9 +160,6 @@ def main():
     argument_spec = VmwareRestClient.vmware_client_argument_spec()
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True)
-    if module._name in ('vmware_tag_facts', 'community.vmware.vmware_tag_facts'):
-        module.deprecate("The 'vmware_tag_facts' module has been renamed to 'vmware_tag_info'",
-                         version='3.0.0', collection_name='community.vmware')  # was Ansible 2.13
 
     vmware_tag_info = VmTagInfoManager(module)
     vmware_tag_info.get_all_tags()

--- a/plugins/modules/vmware_vm_info.py
+++ b/plugins/modules/vmware_vm_info.py
@@ -17,7 +17,6 @@ short_description: Return basic info pertaining to a VMware machine guest
 description:
 - Return basic information pertaining to a vSphere or ESXi virtual machine guest.
 - Cluster name as fact is added in version 2.7.
-- This module was called C(vmware_vm_facts) before Ansible 2.9. The usage did not change.
 author:
 - Joseph Callen (@jcpowermac)
 - Abhijeet Kasurde (@Akasurde)
@@ -320,9 +319,6 @@ def main():
         argument_spec=argument_spec,
         supports_check_mode=True
     )
-    if module._name in ('vmware_vm_facts', 'community.vmware.vmware_vm_facts'):
-        module.deprecate("The 'vmware_vm_facts' module has been renamed to 'vmware_vm_info'",
-                         version='3.0.0', collection_name='community.vmware')  # was Ansible 2.13
 
     vmware_vm_info = VmwareVmInfo(module)
     _virtual_machines = vmware_vm_info.get_all_virtual_machines()


### PR DESCRIPTION
##### SUMMARY
Remove the references to the old `_facts` from the `_info` modules.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
vmware_cluster_info
vmware_datastore_info
vmware_guest_info
vmware_guest_snapshot_info
vmware_tag_info
vmware_vm_info

##### ADDITIONAL INFORMATION
Follow-up to #1141