### PR TITLE
[backport] vmware_guest: Fix version_added of advanced_settings

### DIFF
--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -478,7 +478,7 @@ options:
     - Incorrect key and values will be ignored.
     elements: dict
     type: list
-    version_added: '1.7.0'
+    version_added: '1.8.0'
   annotation:
     description:
     - A note or annotation to include in the virtual machine.


### PR DESCRIPTION
Backport of #1156:

##### SUMMARY
The docs for `vmware_guest`  incorrectly state that the [advanced_settings](https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_guest_module.html#parameter-advanced_settings) parameter was added in 1.7.0.

This PR sets the release date to the correct version 1.8.0.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
vmware_guest

##### ADDITIONAL INFORMATION
The feature was added in #179 as d5d00e3a2c9fcae82858c9d31d4cc7791560573b.
It did not make it into 1.7.0 but was released as part of 1.8.0, see the [release notes](https://github.com/ansible-collections/community.vmware/blob/main/CHANGELOG.rst#v1-8-0).