### PR TITLE
vmware_export_ovf: add export with extra config support

### DIFF
--- a/changelogs/fragments/vmware_export_ovf.yml
+++ b/changelogs/fragments/vmware_export_ovf.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_export_ovf - Add a new parameter 'export_with_extraconfig' to support export extra config options in ovf (https://github.com/ansible-collections/community.vmware/pull/1161).

--- a/plugins/modules/vmware_export_ovf.py
+++ b/plugins/modules/vmware_export_ovf.py
@@ -70,6 +70,10 @@ options:
     description:
     - Export an ISO image of the media mounted on the CD/DVD Drive within the virtual machine.
     type: bool
+  export_with_extraconfig
+    default: false
+    description:
+    - All extra configuration options are exported for a virtual machine.
   download_timeout:
     description:
     - The user defined timeout in second of exporting file.
@@ -209,7 +213,7 @@ class VMwareExportVmOvf(PyVmomi):
     def export_to_ovf_files(self, vm_obj):
         self.create_export_dir(vm_obj=vm_obj)
         export_with_iso = False
-        if 'export_with_images' in self.params and self.params['export_with_images']:
+        if self.params['export_with_images']:
             export_with_iso = True
         self.download_timeout = self.params['download_timeout']
 
@@ -284,6 +288,10 @@ class VMwareExportVmOvf(PyVmomi):
             ovf_parameters = vim.OvfManager.CreateDescriptorParams()
             ovf_parameters.name = ovf_descriptor_name
             ovf_parameters.ovfFiles = ovf_files
+            if self.params['export_with_extraconfig']:
+                ovf_parameters.exportOption = ['extraconfig']
+            if self.params['export_with_images']:
+                ovf_parameters.includeImageFiles = True
             vm_descriptor_result = ovf_manager.CreateDescriptor(obj=vm_obj, cdp=ovf_parameters)
             if vm_descriptor_result.error:
                 http_nfc_lease.HttpNfcLeaseAbort()
@@ -325,6 +333,7 @@ def main():
         datacenter=dict(type='str', default='ha-datacenter'),
         export_dir=dict(type='path', required=True),
         export_with_images=dict(type='bool', default=False),
+        export_with_extraconfig=dict(type='bool', default=False),
         download_timeout=dict(type='int', default=30),
     )
 

--- a/plugins/modules/vmware_export_ovf.py
+++ b/plugins/modules/vmware_export_ovf.py
@@ -70,7 +70,8 @@ options:
     description:
     - Export an ISO image of the media mounted on the CD/DVD Drive within the virtual machine.
     type: bool
-  export_with_extraconfig
+  export_with_extraconfig:
+    type: bool
     default: false
     description:
     - All extra configuration options are exported for a virtual machine.

--- a/plugins/modules/vmware_export_ovf.py
+++ b/plugins/modules/vmware_export_ovf.py
@@ -75,7 +75,7 @@ options:
     default: false
     description:
     - All extra configuration options are exported for a virtual machine.
-    version_added: '1.18.0'
+    version_added: '2.0.0'
   download_timeout:
     description:
     - The user defined timeout in second of exporting file.

--- a/plugins/modules/vmware_export_ovf.py
+++ b/plugins/modules/vmware_export_ovf.py
@@ -74,6 +74,7 @@ options:
     default: false
     description:
     - All extra configuration options are exported for a virtual machine.
+    version_added: '1.18.0'
   download_timeout:
     description:
     - The user defined timeout in second of exporting file.


### PR DESCRIPTION
Signed-off-by: dianew <dianew@vmware.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
There is known issue of if there is no extra config in ovf, then when template imported to Fusion, it may encounter GOS can not boot up issue.
So add a new parameter `export_with_extraconfig` in this module to contain VM extra config options in ovf file when exporting to template.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_export_ovf

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
