### PR TITLE
Prepare for distutils.version being removed in Python 3.12

### DIFF
--- a/changelogs/fragments/disutils.version.yml
+++ b/changelogs/fragments/disutils.version.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Various modules and plugins - use vendored version of ``distutils.version`` included in ansible-core 2.12 if available. This avoids breakage when ``distutils`` is removed from the standard library of Python 3.12. Note that ansible-core 2.11, ansible-base 2.10 and Ansible 2.9 are right now not compatible with Python 3.12, hence this fix does not target these ansible-core/-base/2.9 versions."

--- a/plugins/module_utils/version.py
+++ b/plugins/module_utils/version.py
@@ -3,7 +3,7 @@
 # Copyright: (c) 2021, Felix Fontein <felix@fontein.de>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-"""Provide Version object to compare version numbers."""
+"""Provide version object to compare version numbers."""
 
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type

--- a/plugins/module_utils/version.py
+++ b/plugins/module_utils/version.py
@@ -14,6 +14,6 @@ try:
     from ansible.module_utils.compat.version import LooseVersion  # noqa: F401
 except ImportError:
     try:
-        from distutils.version import LooseVersion
+        from distutils.version import LooseVersion  # noqa: F401
     except ImportError as exc:
         raise_from(ImportError('To use this plugin or module with ansible-core < 2.11, you need to use Python < 3.12 with distutils.version present'), exc)

--- a/plugins/module_utils/version.py
+++ b/plugins/module_utils/version.py
@@ -11,7 +11,7 @@ __metaclass__ = type
 from ansible.module_utils.six import raise_from
 
 try:
-    from ansible.module_utils.compat.version import LooseVersion
+    from ansible.module_utils.compat.version import LooseVersion  # noqa: F401
 except ImportError:
     try:
         from distutils.version import LooseVersion

--- a/plugins/module_utils/version.py
+++ b/plugins/module_utils/version.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2021, Felix Fontein <felix@fontein.de>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Provide Version object to compare version numbers."""
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from ansible.module_utils.six import raise_from
+
+try:
+    from ansible.module_utils.compat.version import LooseVersion
+except ImportError:
+    try:
+        from distutils.version import LooseVersion
+    except ImportError as exc:
+        raise_from(ImportError('To use this plugin or module with ansible-core < 2.11, you need to use Python < 3.12 with distutils.version present'), exc)

--- a/plugins/modules/vmware_category.py
+++ b/plugins/modules/vmware_category.py
@@ -151,10 +151,9 @@ category_results:
     }
 '''
 
-from distutils.version import LooseVersion
-
 from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.community.vmware.plugins.module_utils.version import LooseVersion
 from ansible_collections.community.vmware.plugins.module_utils.vmware import connect_to_api
 from ansible_collections.community.vmware.plugins.module_utils.vmware_rest_client import VmwareRestClient
 

--- a/plugins/modules/vmware_vc_infraprofile_info.py
+++ b/plugins/modules/vmware_vc_infraprofile_info.py
@@ -149,8 +149,8 @@ import_profile:
     }
 '''
 
-from distutils.version import LooseVersion
 from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.community.vmware.plugins.module_utils.version import LooseVersion
 from ansible_collections.community.vmware.plugins.module_utils.vmware_rest_client import VmwareRestClient
 from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi
 import json


### PR DESCRIPTION
##### SUMMARY

distutils has been deprecafed and will be removed from
Python's stdlib in Python 3.12 (see https://python.org/dev/peps/pep-0632).

This PR replaces the use of distutils.version.LooseVersion and distutils.version.StrictVersion
with LooseVersion from the vendored copy of distutils.version
included with ansible-core 2.12 (ansible/ansible#74644) if available,
and falls back to distutils.version for ansible-core 2.11 and before.

Since ansible-core 2.11 and earlier do not support Python 3.12 (since
they use LooseVersion itself in various places), this incomplete fix
should be OK for now. Also, the way this PR works (by adding a new
module_utils version that abstracts away where LooseVersion comes from),
it is easy to also fix this for ansible-core 2.11 and earlier later on.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/disutils.version.yml
plugins/module_utils/version.py
plugins/modules/vmware_category.py
plugins/modules/vmware_vc_infraprofile_info.py
