### PR TITLE
vmware_guest_network: Fix uncaught exception

### DIFF
--- a/changelogs/fragments/25-vmware_guest_network-catch_taskerror.yml
+++ b/changelogs/fragments/25-vmware_guest_network-catch_taskerror.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_guest_network - fix a bug that can crash the module due to an uncaught exception (https://github.com/ansible-collections/community.vmware/issues/25).

--- a/plugins/modules/vmware_guest_network.py
+++ b/plugins/modules/vmware_guest_network.py
@@ -184,6 +184,7 @@ options:
         - Manual specified MAC address of the network adapter when creating, or reconfiguring.
         - If not specified when creating new network adapter, mac address will be generated automatically.
         - When reconfigure MAC address, VM should be in powered off state.
+        - There are restrictions on the MAC addresses you can set. Consult the documentation of your vSphere version as to allowed MAC addresses.
       connected:
         type: bool
         description:

--- a/plugins/modules/vmware_guest_network.py
+++ b/plugins/modules/vmware_guest_network.py
@@ -330,8 +330,9 @@ except ImportError:
     pass
 
 import copy
+from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, vmware_argument_spec, wait_for_task
+from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, TaskError, vmware_argument_spec, wait_for_task
 
 
 class PyVmomiHelper(PyVmomi):
@@ -792,6 +793,8 @@ class PyVmomiHelper(PyVmomi):
                 wait_for_task(task)
             except (vim.fault.InvalidDeviceSpec, vim.fault.RestrictedVersion) as e:
                 self.module.fail_json(msg='failed to reconfigure guest', detail=e.msg)
+            except TaskError as task_e:
+                self.module.fail_json(msg=to_native(task_e))
 
             if task.info.state == 'error':
                 self.module.fail_json(msg='failed to reconfigure guest', detail=task.info.error.msg)


### PR DESCRIPTION
##### SUMMARY

In rare cases, `wait_for_task` throws a `TaskError`. But since vmware_guest_network only catches `vim.fault.InvalidDeviceSpec` and `vim.fault.RestrictedVersion` the module will crash instead of just fail.

Fixes #25

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_guest_network

##### ADDITIONAL INFORMATION
This happens when people try to manually set a MAC address from the [reserved](https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.troubleshooting.doc/GUID-7F723748-E7B8-48B9-A773-3822C514684B.html) range `00:50:56:40:YY:ZZ` - `00:50:56:7F:YY:ZZ` but there might be other scenarios crashing the module because of the uncaught exception.