### PR TITLE
tests: disable vmware_content_library_manager for now

### DIFF
--- a/tests/integration/targets/vmware_content_library_manager/aliases
+++ b/tests/integration/targets/vmware_content_library_manager/aliases
@@ -2,3 +2,5 @@ cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
 zuul/vmware/govcsim
+# we're hitting some SERVICE_UNAVAILABLE errors time to time with our current set-up
+disabled


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1278
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1279

The test is not super stable and this impact the CI.
