### PR TITLE
added DistributedVirtualPortgroup object_type

### DIFF
--- a/changelogs/fragments/1176-vmware_dv_portgroup.yml
+++ b/changelogs/fragments/1176-vmware_dv_portgroup.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_object_role_permission - added VMware DV portgroup object_type for setting permissions (https://github.com/ansible-collections/community.vmware/pull/1176)

--- a/plugins/modules/vmware_object_role_permission.py
+++ b/plugins/modules/vmware_object_role_permission.py
@@ -55,7 +55,8 @@ options:
     default: 'Folder'
     choices: ['Folder', 'VirtualMachine', 'Datacenter', 'ResourcePool',
               'Datastore', 'Network', 'HostSystem', 'ComputeResource',
-              'ClusterComputeResource', 'DistributedVirtualSwitch']
+              'ClusterComputeResource', 'DistributedVirtualSwitch',
+              'DistributedVirtualPortgroup']
     type: str
   recursive:
     description:
@@ -322,6 +323,7 @@ def main():
                     'ComputeResource',
                     'ClusterComputeResource',
                     'DistributedVirtualSwitch',
+                    'DistributedVirtualPortgroup',
                 ],
             ),
             principal=dict(type='str'),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fixes https://github.com/ansible-collections/community.vmware/issues/1175 - Include DistributedVirtualPortgroup to community.vmware.vmware_object_role_permission object_type

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
community.vmware.vmware_object_role_permission

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
