### PR TITLE
Add vmware_host_user_manager to manage the local user in ESXi

### DIFF
--- a/docs/community.vmware.vmware_host_user_manager_module.rst
+++ b/docs/community.vmware.vmware_host_user_manager_module.rst
@@ -1,0 +1,365 @@
+.. _community.vmware.vmware_host_user_manager_module:
+
+
+*****************************************
+community.vmware.vmware_host_user_manager
+*****************************************
+
+**Manage users of ESXi**
+
+
+Version added: 1.18.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- This module can be added or updated or deleted the local user of ESXi host.
+
+
+
+Requirements
+------------
+The below requirements are needed on the host that executes this module.
+
+- python >= 3.6
+- PyVmomi
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+            <th width="100%">Comments</th>
+        </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>esxi_hostname</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Name of the ESXi host that is managing the local user.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>hostname</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The hostname or IP address of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_HOST</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>override_user_password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                    <li>yes</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>If the local user exists and updates the password, change this parameter value is true.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The password of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PASSWORD</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: pass, pwd</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">443</div>
+                </td>
+                <td>
+                        <div>The port number of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PORT</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>proxy_host</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Address of a proxy that will receive all HTTPS requests and relay them.</div>
+                        <div>The format is a hostname or a IP.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PROXY_HOST</code> will be used instead.</div>
+                        <div>This feature depends on a version of pyvmomi greater than v6.7.1.2018.12</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>proxy_port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Port of the HTTP proxy that will receive all HTTPS requests and relay them.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PROXY_PORT</code> will be used instead.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                    <li>absent</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>If set to <code>present</code>, add a new local user or update information.</div>
+                        <div>If set to <code>absent</code>, delete the local user.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>user_description</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The local user description.</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: local_user_description</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>user_name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Name of the local user.</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: local_user_name</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>user_password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The local user password.</div>
+                        <div>If you&#x27;d like to update the password, require the <em>override_user_password</em> is true.</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: local_user_password</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>username</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The username of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_USER</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: admin, user</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>validate_certs</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>no</li>
+                                    <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Allows connection when SSL certificates are not valid. Set to <code>false</code> when certificates are not trusted.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_VALIDATE_CERTS</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                        <div>If set to <code>true</code>, please make sure Python &gt;= 2.7.9 is installed on the given machine.</div>
+                </td>
+            </tr>
+    </table>
+    <br/>
+
+
+
+
+Examples
+--------
+
+.. code-block:: yaml
+
+    - name: Add new local user to ESXi host
+      community.vmware.vmware_host_user_manager:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        esxi_hostname: "{{ esxi1 }}"
+        user_name: example
+        user_description: "example user"
+        user_password: "{{ local_user_password }}"
+        state: present
+
+    - name: Update the local user password in ESXi host
+      community.vmware.vmware_host_user_manager:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        esxi_hostname: "{{ esxi1 }}"
+        user_name: example
+        user_description: "example user"
+        user_password: "{{ local_user_password }}"
+        override_user_password: true
+        state: present
+
+    - name: Delete the local user in ESXi host
+      community.vmware.vmware_host_user_manager:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        esxi_hostname: "{{ esxi1 }}"
+        user_name: example
+        state: absent
+
+
+
+Return Values
+-------------
+Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>msg</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>always</td>
+                <td>
+                            <div>The executed result for the module.</div>
+                    <br/>
+                        <div style="font-size: smaller"><b>Sample:</b></div>
+                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{
+        &quot;msg&quot;: &quot;Added the new user.
+    }</div>
+                </td>
+            </tr>
+    </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- sky-joker (@sky-joker)

--- a/plugins/modules/vmware_host_user_manager.py
+++ b/plugins/modules/vmware_host_user_manager.py
@@ -17,7 +17,7 @@ description:
 requirements:
   - python >= 3.6
   - PyVmomi
-version_added: '1.18.0'
+version_added: '2.1.0'
 options:
   esxi_hostname:
     description:

--- a/plugins/modules/vmware_host_user_manager.py
+++ b/plugins/modules/vmware_host_user_manager.py
@@ -13,7 +13,7 @@ short_description: Manage users of ESXi
 author:
   - sky-joker (@sky-joker)
 description:
-  - This module can be added or updated or deleted the local user of ESXi host.
+  - This module can add, update or delete local users on ESXi host.
 requirements:
   - python >= 3.6
   - PyVmomi

--- a/plugins/modules/vmware_host_user_manager.py
+++ b/plugins/modules/vmware_host_user_manager.py
@@ -245,7 +245,7 @@ def main():
         user_name=dict(type="str", required=True, aliases=["local_user_name"]),
         user_password=dict(type="str", aliases=["local_user_password"], no_log=True),
         user_description=dict(type="str", aliases=["local_user_description"]),
-        override_user_password=dict(type="bool", default=False),
+        override_user_password=dict(type="bool", default=False, no_log=False),
         state=dict(type="str", default="present", choices=["present", "absent"])
     )
 

--- a/plugins/modules/vmware_host_user_manager.py
+++ b/plugins/modules/vmware_host_user_manager.py
@@ -1,0 +1,264 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2022, sky-joker
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+module: vmware_host_user_manager
+short_description: Manage users of ESXi
+author:
+  - sky-joker (@sky-joker)
+description:
+  - This module can be added or updated or deleted the local user of ESXi host.
+requirements:
+  - python >= 3.6
+  - PyVmomi
+version_added: '1.18.0'
+options:
+  esxi_hostname:
+    description:
+      - Name of the ESXi host that is managing the local user.
+    type: str
+    required: true
+  user_name:
+    description:
+      - Name of the local user.
+    aliases:
+      - local_user_name
+    type: str
+    required: true
+  user_password:
+    description:
+      - The local user password.
+      - If you'd like to update the password, require the I(override_user_password) is true.
+    aliases:
+      - local_user_password
+    type: str
+  user_description:
+    description:
+      - The local user description.
+    aliases:
+      - local_user_description
+    type: str
+  override_user_password:
+    description:
+      - If the local user exists and updates the password, change this parameter value is true.
+    default: false
+    type: bool
+  state:
+    description:
+      - If set to C(present), add a new local user or update information.
+      - If set to C(absent), delete the local user.
+    default: present
+    type: str
+    choices:
+      - present
+      - absent
+extends_documentation_fragment:
+  - community.vmware.vmware.documentation
+'''
+
+EXAMPLES = r'''
+- name: Add new local user to ESXi host
+  community.vmware.vmware_host_user_manager:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    user_name: example
+    user_description: "example user"
+    user_password: "{{ local_user_password }}"
+    state: present
+
+- name: Update the local user password in ESXi host
+  community.vmware.vmware_host_user_manager:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    user_name: example
+    user_description: "example user"
+    user_password: "{{ local_user_password }}"
+    override_user_password: true
+    state: present
+
+- name: Delete the local user in ESXi host
+  community.vmware.vmware_host_user_manager:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    user_name: example
+    state: absent
+'''
+
+RETURN = r'''
+msg:
+  description: The executed result for the module.
+  returned: always
+  type: str
+  sample: >-
+    {
+        "msg": "Added the new user.
+    }
+'''
+
+try:
+    from pyVmomi import vim
+except ImportError:
+    pass
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_text
+from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, vmware_argument_spec
+
+
+class VmwareHostUserManager(PyVmomi):
+    def __init__(self, module):
+        super(VmwareHostUserManager, self).__init__(module)
+        self.esxi_hostname = module.params["esxi_hostname"]
+        self.user_name = module.params["user_name"]
+        self.user_password = module.params["user_password"]
+        self.user_description = module.params["user_description"]
+        self.override_user_password = module.params["override_user_password"]
+        self.state = module.params["state"]
+
+    def search_user(self):
+        """
+        Search the specified user from ESXi
+
+        Returns: searched user
+        """
+        searchStr = self.user_name
+        exactMatch = True
+        findUsers = True
+        findGroups = False
+        user_account = self.host_obj.configManager.userDirectory.RetrieveUserGroups(None, searchStr, None, None, exactMatch, findUsers, findGroups)
+        return user_account
+
+    def ensure_user_info_diff(self, user_account):
+        """
+        Ensure a user information difference.
+        The method can check a user description difference only.
+        Also, it can't get the set password via vSphere API.
+
+        Returns: bool
+        """
+        if user_account.fullName != self.user_description and self.user_description is not None:
+            return True
+
+        return False
+
+    def add_user(self):
+        """
+        Add a new user
+        """
+        user_spec = vim.host.LocalAccountManager.AccountSpecification(
+            id=self.user_name,
+            description=self.user_description,
+            password=self.user_password
+        )
+        try:
+            self.host_obj.configManager.accountManager.CreateUser(user_spec)
+        except Exception as e:
+            self.module.fail_json(msg="Failed to add a new user: %s" % to_text(e.msg))
+
+    def update_user(self):
+        """
+        Update a user information
+        """
+        user_spec = vim.host.LocalAccountManager.AccountSpecification(
+            id=self.user_name,
+            description=self.user_description
+        )
+
+        if self.user_password and self.override_user_password:
+            user_spec.password = self.user_password
+
+        try:
+            self.host_obj.configManager.accountManager.UpdateUser(user_spec)
+        except Exception as e:
+            self.module.fail_json(msg="Failed to update a new password: %s" % to_text(e))
+
+    def remove_user(self):
+        """
+        Remove a user
+        """
+        try:
+            self.host_obj.configManager.accountManager.RemoveUser(self.user_name)
+        except Exception as e:
+            self.module.fail_json(msg="Failed to remove a user: %s" % to_text(e.msg))
+
+    def execute(self):
+        # The host name is unique in vCenter, so find the host from the whole.
+        self.host_obj = self.find_hostsystem_by_name(self.esxi_hostname)
+        if self.host_obj is None:
+            self.module.fail_json(msg="Cannot find the specified ESXi host: %s" % self.params['esxi_hostname'])
+
+        # Search the specified user
+        user_account = self.search_user()
+
+        changed = False
+        msg = "The change will not occur for the user information."
+        if self.state == "present":
+            if user_account:
+                user_diff = self.ensure_user_info_diff(user_account[0])
+                # If you want to update a user password, require the override_user_passwd is true.
+                if user_diff or self.override_user_password:
+                    changed = True
+                    if self.module.check_mode:
+                        msg = "The user information will be updated."
+                    else:
+                        msg = "Updated the user information."
+                        self.update_user()
+            else:
+                changed = True
+                if self.module.check_mode:
+                    msg = "The new user will be added."
+                else:
+                    msg = "Added the new user."
+                    self.add_user()
+
+        if self.state == "absent":
+            if user_account:
+                changed = True
+                if self.module.check_mode:
+                    msg = "The user will be removed."
+                else:
+                    msg = "Removed the user."
+                    self.remove_user()
+
+        self.module.exit_json(changed=changed, msg=msg)
+
+
+def main():
+    argument_spec = vmware_argument_spec()
+    argument_spec.update(
+        esxi_hostname=dict(type="str", required=True),
+        user_name=dict(type="str", required=True, aliases=["local_user_name"]),
+        user_password=dict(type="str", aliases=["local_user_password"], no_log=True),
+        user_description=dict(type="str", aliases=["local_user_description"]),
+        override_user_password=dict(type="bool", default=False),
+        state=dict(type="str", default="present", choices=["present", "absent"])
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        required_if=[
+            ('override_user_password', True, ['user_password']),
+        ]
+    )
+    vmware_host_user_manager = VmwareHostUserManager(module)
+    vmware_host_user_manager.execute()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/vmware_host_user_manager/aliases
+++ b/tests/integration/targets/vmware_host_user_manager/aliases
@@ -1,0 +1,3 @@
+cloud/vcenter
+needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_host_user_manager/tasks/main.yml
+++ b/tests/integration/targets/vmware_host_user_manager/tasks/main.yml
@@ -1,0 +1,14 @@
+# Test code for the vmware_host_user_manager module.
+# Copyright: (c) 2022, sky-joker <sky.jokerxx@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_attach_host: true
+
+- name: Import operate_user_via_vcenter tasks
+  import_tasks: operate_user_via_vcenter.yml
+
+- name: Import operate_user_via_ESXi tasks
+  import_tasks: operate_user_via_ESXi.yml

--- a/tests/integration/targets/vmware_host_user_manager/tasks/operate_user_via_ESXi.yml
+++ b/tests/integration/targets/vmware_host_user_manager/tasks/operate_user_via_ESXi.yml
@@ -1,0 +1,196 @@
+# Test code for the vmware_host_user_manager module.
+# Copyright: (c) 2022, sky-joker <sky.jokerxx@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Add new local user with check_mode
+  community.vmware.vmware_host_user_manager:
+    hostname: "{{ esxi1 }}"
+    username: "{{ esxi_user }}"
+    password: "{{ esxi_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    user_name: example
+    user_password: Vmware!1@pass
+    user_description: example user
+    state: present
+  check_mode: true
+  register: add_new_user_result_check_mode
+
+- name: Guaranteed new local user additional
+  assert:
+    that:
+      - add_new_user_result_check_mode.changed is sameas true
+
+- name: Add new local user
+  community.vmware.vmware_host_user_manager:
+    hostname: "{{ esxi1 }}"
+    username: "{{ esxi_user }}"
+    password: "{{ esxi_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    user_name: example
+    user_password: Vmware!1@pass
+    user_description: example user
+    state: present
+  register: add_new_user_result
+
+- name: Guaranteed that added the new local user
+  assert:
+    that:
+      - add_new_user_result.changed is sameas true
+
+- name: Add new local user for idempotency test
+  community.vmware.vmware_host_user_manager:
+    hostname: "{{ esxi1 }}"
+    username: "{{ esxi_user }}"
+    password: "{{ esxi_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    user_name: example
+    user_password: Vmware!1@pass
+    user_description: example user
+    state: present
+  register: add_new_user_result_idempotency
+
+- name: Guaranteed that doesn't occur the changed
+  assert:
+    that:
+      - add_new_user_result_idempotency.changed is sameas false
+
+- name: Update the local user description with check_mode
+  community.vmware.vmware_host_user_manager:
+    hostname: "{{ esxi1 }}"
+    username: "{{ esxi_user }}"
+    password: "{{ esxi_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    user_name: example
+    user_description: example user111
+    state: present
+  check_mode: true
+  register: update_user_description_result_check_mode
+
+- name: Guaranteed the local user description updation
+  assert:
+    that:
+      - update_user_description_result_check_mode.changed is sameas true
+
+- name: Update the local user description
+  community.vmware.vmware_host_user_manager:
+    hostname: "{{ esxi1 }}"
+    username: "{{ esxi_user }}"
+    password: "{{ esxi_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    user_name: example
+    user_description: example user111
+    state: present
+  register: update_user_description_result
+
+- name: Guaranteed that updated the local user description
+  assert:
+    that:
+      - update_user_description_result.changed is sameas true
+
+- name: Update the local user description for idempotency test
+  community.vmware.vmware_host_user_manager:
+    hostname: "{{ esxi1 }}"
+    username: "{{ esxi_user }}"
+    password: "{{ esxi_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    user_name: example
+    user_description: example user111
+    state: present
+  register: update_user_description_result_idempotency
+
+- name: Guaranteed that doesn't occur the changed
+  assert:
+    that:
+      - update_user_description_result_idempotency.changed is sameas false
+
+- name: Update the local user password with check_mode
+  community.vmware.vmware_host_user_manager:
+    hostname: "{{ esxi1 }}"
+    username: "{{ esxi_user }}"
+    password: "{{ esxi_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    user_name: example
+    user_password: Vmware!1@pass222
+    override_user_password: true
+    state: present
+  check_mode: true
+  register: update_user_password_result_check_mode
+
+- name: Guaranteed the local user password updation
+  assert:
+    that:
+      - update_user_password_result_check_mode.changed is sameas true
+
+- name: Update the local user password
+  community.vmware.vmware_host_user_manager:
+    hostname: "{{ esxi1 }}"
+    username: "{{ esxi_user }}"
+    password: "{{ esxi_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    user_name: example
+    user_password: Vmware!1@pass222
+    override_user_password: true
+    state: present
+  register: update_user_password_result
+
+- name: Guaranteed that updated the local user password
+  assert:
+    that:
+      - update_user_password_result.changed is sameas true
+
+- name: Delete the local user with check_mode
+  community.vmware.vmware_host_user_manager:
+    hostname: "{{ esxi1 }}"
+    username: "{{ esxi_user }}"
+    password: "{{ esxi_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    user_name: example
+    state: absent
+  check_mode: true
+  register: delete_user_result_check_mode
+
+- name: Guaranteed new local user deletion
+  assert:
+    that:
+      - delete_user_result_check_mode.changed is sameas true
+
+- name: Delete new local user
+  community.vmware.vmware_host_user_manager:
+    hostname: "{{ esxi1 }}"
+    username: "{{ esxi_user }}"
+    password: "{{ esxi_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    user_name: example
+    state: absent
+  register: delete_new_user_result
+
+- name: Guaranteed that deleted the local user
+  assert:
+    that:
+      - delete_new_user_result.changed is sameas true
+
+- name: Delete the local user for idempotency test
+  community.vmware.vmware_host_user_manager:
+    hostname: "{{ esxi1 }}"
+    username: "{{ esxi_user }}"
+    password: "{{ esxi_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    user_name: example
+    state: absent
+  register: delete_user_result_idempotency
+
+- name: Guaranteed that doesn't occur the changed
+  assert:
+    that:
+      - delete_user_result_idempotency.changed is sameas false

--- a/tests/integration/targets/vmware_host_user_manager/tasks/operate_user_via_vcenter.yml
+++ b/tests/integration/targets/vmware_host_user_manager/tasks/operate_user_via_vcenter.yml
@@ -1,0 +1,196 @@
+# Test code for the vmware_host_user_manager module.
+# Copyright: (c) 2022, sky-joker <sky.jokerxx@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Add new local user with check_mode
+  community.vmware.vmware_host_user_manager:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    user_name: example
+    user_password: Vmware!1@pass
+    user_description: example user
+    state: present
+  check_mode: true
+  register: add_new_user_result_check_mode
+
+- name: Guaranteed new local user additional
+  assert:
+    that:
+      - add_new_user_result_check_mode.changed is sameas true
+
+- name: Add new local user
+  community.vmware.vmware_host_user_manager:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    user_name: example
+    user_password: Vmware!1@pass
+    user_description: example user
+    state: present
+  register: add_new_user_result
+
+- name: Guaranteed that added the new local user
+  assert:
+    that:
+      - add_new_user_result.changed is sameas true
+
+- name: Add new local user for idempotency test
+  community.vmware.vmware_host_user_manager:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    user_name: example
+    user_password: Vmware!1@pass
+    user_description: example user
+    state: present
+  register: add_new_user_result_idempotency
+
+- name: Guaranteed that doesn't occur the changed
+  assert:
+    that:
+      - add_new_user_result_idempotency.changed is sameas false
+
+- name: Update the local user description with check_mode
+  community.vmware.vmware_host_user_manager:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    user_name: example
+    user_description: example user111
+    state: present
+  check_mode: true
+  register: update_user_description_result_check_mode
+
+- name: Guaranteed the local user description updation
+  assert:
+    that:
+      - update_user_description_result_check_mode.changed is sameas true
+
+- name: Update the local user description
+  community.vmware.vmware_host_user_manager:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    user_name: example
+    user_description: example user111
+    state: present
+  register: update_user_description_result
+
+- name: Guaranteed that updated the local user description
+  assert:
+    that:
+      - update_user_description_result.changed is sameas true
+
+- name: Update the local user description for idempotency test
+  community.vmware.vmware_host_user_manager:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    user_name: example
+    user_description: example user111
+    state: present
+  register: update_user_description_result_idempotency
+
+- name: Guaranteed that doesn't occur the changed
+  assert:
+    that:
+      - update_user_description_result_idempotency.changed is sameas false
+
+- name: Update the local user password with check_mode
+  community.vmware.vmware_host_user_manager:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    user_name: example
+    user_password: Vmware!1@pass222
+    override_user_password: true
+    state: present
+  check_mode: true
+  register: update_user_password_result_check_mode
+
+- name: Guaranteed the local user password updation
+  assert:
+    that:
+      - update_user_password_result_check_mode.changed is sameas true
+
+- name: Update the local user password
+  community.vmware.vmware_host_user_manager:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    user_name: example
+    user_password: Vmware!1@pass222
+    override_user_password: true
+    state: present
+  register: update_user_password_result
+
+- name: Guaranteed that updated the local user password
+  assert:
+    that:
+      - update_user_password_result.changed is sameas true
+
+- name: Delete the local user with check_mode
+  community.vmware.vmware_host_user_manager:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    user_name: example
+    state: absent
+  check_mode: true
+  register: delete_user_result_check_mode
+
+- name: Guaranteed new local user deletion
+  assert:
+    that:
+      - delete_user_result_check_mode.changed is sameas true
+
+- name: Delete new local user
+  community.vmware.vmware_host_user_manager:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    user_name: example
+    state: absent
+  register: delete_new_user_result
+
+- name: Guaranteed that deleted the local user
+  assert:
+    that:
+      - delete_new_user_result.changed is sameas true
+
+- name: Delete the local user for idempotency test
+  community.vmware.vmware_host_user_manager:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    user_name: example
+    state: absent
+  register: delete_user_result_idempotency
+
+- name: Guaranteed that doesn't occur the changed
+  assert:
+    that:
+      - delete_user_result_idempotency.changed is sameas false


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1282

##### SUMMARY

This module can be added or updated or deleted the local user of ESXi via vCenter.

issues: https://github.com/ansible-collections/community.vmware/issues/1066

##### ISSUE TYPE

- New Module Pull Request

##### COMPONENT NAME

docs/community.vmware.vmware_host_user_manager_module.rst
plugins/modules/vmware_host_user_manager.py
tests/integration/targets/vmware_host_user_manager/aliases
tests/integration/targets/vmware_host_user_manager/tasks/main.yml
tests/integration/targets/vmware_host_user_manager/tasks/operate_user_via_ESXi.yml
tests/integration/targets/vmware_host_user_manager/tasks/operate_user_via_vcenter.yml

##### ADDITIONAL INFORMATION

tested on vCenter/ESXi 7.0.1