### PR TITLE
Revert "tests: disable vmware_content_library_manager for now (#1172)"

### DIFF
--- a/tests/integration/targets/vmware_content_library_manager/aliases
+++ b/tests/integration/targets/vmware_content_library_manager/aliases
@@ -2,5 +2,3 @@ cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
 zuul/vmware/govcsim
-# we're hitting some SERVICE_UNAVAILABLE errors time to time with our current set-up
-disabled


### PR DESCRIPTION
We increased the memory of the VCSA instance to 32GB and the stability
is much better.

This reverts commit ec583c02f55ec25a131cc9c25461c4924eab9dbf.
