### PR TITLE
Change required ansible version to 2.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The collection includes the VMware modules and plugins supported by Ansible VMwa
 <!--start requires_ansible-->
 ## Ansible version compatibility
 
-This collection has been tested against following Ansible versions: **>=2.9.10**.
+This collection has been tested against following Ansible versions: **>=2.10.8**.
 
 Plugins and modules within a collection may be tested with only specific Ansible versions.
 A collection may contain metadata that identifies these versions.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The collection includes the VMware modules and plugins supported by Ansible VMwa
 <!--start requires_ansible-->
 ## Ansible version compatibility
 
-This collection has been tested against following Ansible versions: **>=2.10.8**.
+This collection has been tested against following Ansible versions: **>=2.11.0**.
 
 Plugins and modules within a collection may be tested with only specific Ansible versions.
 A collection may contain metadata that identifies these versions.

--- a/changelogs/fragments/1182_ansible_version.yml
+++ b/changelogs/fragments/1182_ansible_version.yml
@@ -1,2 +1,2 @@
 breaking_changes:
-- The collections now requires at least ansible-base 2.10.8, or ansible-core 2.11.0. Ansible 2.9 and before, and ansible-base versions before 2.10.8, are no longer supported.
+- The collection now requires at least ansible-core 2.11.0. Ansible 2.9 and before, and ansible-base versions are no longer supported.

--- a/changelogs/fragments/1182_ansible_version.yml
+++ b/changelogs/fragments/1182_ansible_version.yml
@@ -1,2 +1,2 @@
 breaking_changes:
-- The collections now requires at least ansible 2.10.8.
+- The collections now requires at least ansible-base 2.10.8, or ansible-core 2.11.0. Ansible 2.9 and before, and ansible-base versions before 2.10.8, are no longer supported.

--- a/changelogs/fragments/1182_ansible_version.yml
+++ b/changelogs/fragments/1182_ansible_version.yml
@@ -1,2 +1,2 @@
 breaking_changes:
-- The collection now requires at least ansible-core 2.11.0. Ansible 2.9 and before, and ansible-base versions are no longer supported.
+- The collection now requires at least ansible-core 2.11.0. Ansible 3 and before, and ansible-base versions are no longer supported.

--- a/changelogs/fragments/1182_ansible_version.yml
+++ b/changelogs/fragments/1182_ansible_version.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+- The collections now requires at least ansible 2.10.8.

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,5 +1,5 @@
 ---
-requires_ansible: '>=2.10.8'
+requires_ansible: '>=2.11.0'
 
 action_groups:
   vmware:

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,5 +1,5 @@
 ---
-requires_ansible: '>=2.9.10'
+requires_ansible: '>=2.10.8'
 
 action_groups:
   vmware:


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1284

I'd like to change the supported ansible version in order to avoid #1177. Anyway, I think it's time to get rid of ansible 2.9.

cc @felixfontein 