### PR TITLE
tests: delete dvswitch during teardown

### DIFF
--- a/tests/integration/targets/prepare_vmware_tests/tasks/setup_dvswitch.yml
+++ b/tests/integration/targets/prepare_vmware_tests/tasks/setup_dvswitch.yml
@@ -17,4 +17,8 @@
       - vmnic1
     state: present
   with_items: "{{ esxi_hosts }}"
+  register: _result
+  until: _result is succeeded
+  retries: 10
+  delay: 1
   when: setup_attach_host is defined

--- a/tests/integration/targets/prepare_vmware_tests/tasks/teardown_with_esxi.yml
+++ b/tests/integration/targets/prepare_vmware_tests/tasks/teardown_with_esxi.yml
@@ -71,6 +71,13 @@
     state: absent
   with_items: "{{ result.value }}"
 
+- name: Delete the dvswitch
+  vmware_dvswitch:
+    datacenter_name: '{{ dc1 }}'
+    switch_name: '{{ dvswitch1 }}'
+    state: absent
+  ignore_errors: true
+
 - name: Get a list of all the datacenters
   vmware.vmware_rest.vcenter_datacenter_info:
     vcenter_hostname: '{{ vcenter_hostname }}'


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1300
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1301

Sounds like we get an error if a host was already attached to deleted
dvswitch.
