### PR TITLE
Specify mutual exclusion of parameters

### DIFF
--- a/docs/community.vmware.vmware_resource_pool_module.rst
+++ b/docs/community.vmware.vmware_resource_pool_module.rst
@@ -53,7 +53,6 @@ Parameters
                 <td>
                         <div>Name of the cluster to configure the resource pool.</div>
                         <div>This parameter is required if <code>esxi_hostname</code> or <code>parent_resource_pool</code> is not specified.</div>
-                        <div>The <code>cluster</code>, <code>esxi_hostname</code> and <code>parent_resource_pool</code> parameters are mutually exclusive.</div>
                 </td>
             </tr>
             <tr>
@@ -179,7 +178,6 @@ Parameters
                         <div>Name of the host to configure the resource pool.</div>
                         <div>The host must not be member of a cluster.</div>
                         <div>This parameter is required if <code>cluster</code> or <code>parent_resource_pool</code> is not specified.</div>
-                        <div>The <code>cluster</code>, <code>esxi_hostname</code> and <code>parent_resource_pool</code> parameters are mutually exclusive.</div>
                 </td>
             </tr>
             <tr>
@@ -305,7 +303,6 @@ Parameters
                 <td>
                         <div>Name of the parent resource pool.</div>
                         <div>This parameter is required if <code>cluster</code> or <code>esxi_hostname</code> is not specified.</div>
-                        <div>The <code>cluster</code>, <code>esxi_hostname</code> and <code>parent_resource_pool</code> parameters are mutually exclusive.</div>
                 </td>
             </tr>
             <tr>

--- a/docs/community.vmware.vmware_resource_pool_module.rst
+++ b/docs/community.vmware.vmware_resource_pool_module.rst
@@ -154,7 +154,7 @@ Parameters
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
-                         / <span style="color: red">required</span>esxi
+                         / <span style="color: red">required</span>
                     </div>
                 </td>
                 <td>

--- a/docs/community.vmware.vmware_resource_pool_module.rst
+++ b/docs/community.vmware.vmware_resource_pool_module.rst
@@ -53,6 +53,7 @@ Parameters
                 <td>
                         <div>Name of the cluster to configure the resource pool.</div>
                         <div>This parameter is required if <code>esxi_hostname</code> or <code>parent_resource_pool</code> is not specified.</div>
+                        <div>The <code>cluster</code>, <code>esxi_hostname</code> and <code>parent_resource_pool</code> parameters are mutually exclusive.</div>
                 </td>
             </tr>
             <tr>
@@ -153,7 +154,7 @@ Parameters
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
-                         / <span style="color: red">required</span>
+                         / <span style="color: red">required</span>esxi
                     </div>
                 </td>
                 <td>
@@ -178,6 +179,7 @@ Parameters
                         <div>Name of the host to configure the resource pool.</div>
                         <div>The host must not be member of a cluster.</div>
                         <div>This parameter is required if <code>cluster</code> or <code>parent_resource_pool</code> is not specified.</div>
+                        <div>The <code>cluster</code>, <code>esxi_hostname</code> and <code>parent_resource_pool</code> parameters are mutually exclusive.</div>
                 </td>
             </tr>
             <tr>
@@ -303,6 +305,7 @@ Parameters
                 <td>
                         <div>Name of the parent resource pool.</div>
                         <div>This parameter is required if <code>cluster</code> or <code>esxi_hostname</code> is not specified.</div>
+                        <div>The <code>cluster</code>, <code>esxi_hostname</code> and <code>parent_resource_pool</code> parameters are mutually exclusive.</div>
                 </td>
             </tr>
             <tr>

--- a/plugins/modules/vmware_resource_pool.py
+++ b/plugins/modules/vmware_resource_pool.py
@@ -31,18 +31,21 @@ options:
         description:
             - Name of the cluster to configure the resource pool.
             - This parameter is required if C(esxi_hostname) or C(parent_resource_pool) is not specified.
+            - The C(cluster), C(esxi_hostname) and C(parent_resource_pool) parameters are mutually exclusive.
         type: str
     esxi_hostname:
         description:
             - Name of the host to configure the resource pool.
             - The host must not be member of a cluster.
             - This parameter is required if C(cluster) or C(parent_resource_pool) is not specified.
+            - The C(cluster), C(esxi_hostname) and C(parent_resource_pool) parameters are mutually exclusive.
         type: str
         version_added: '1.5.0'
     parent_resource_pool:
         description:
             - Name of the parent resource pool.
             - This parameter is required if C(cluster) or C(esxi_hostname) is not specified.
+            - The C(cluster), C(esxi_hostname) and C(parent_resource_pool) parameters are mutually exclusive.
         type: str
         version_added: '1.9.0'
     resource_pool:


### PR DESCRIPTION
Make it clear that "cluster", "esxi_hostname" and "parent_resource_pool" are mutually exclusive parameters.

##### SUMMARY
Given the current documentation it's not clear that one cannot use more than one of these parameters at a time.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
community.vmware.vmware_resource_pool
