### PR TITLE
vmware_vm_config_option: add more properties in output when getting VM configurations

### DIFF
--- a/changelogs/fragments/vmware_vm_config_option.yml
+++ b/changelogs/fragments/vmware_vm_config_option.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_vm_config_option - Add support_usb_controller, support_ethernet_card, support_disk_controller properties in output of getting VM default configs (https://github.com/ansible-collections/community.vmware/pull/1202).

--- a/changelogs/fragments/vmware_vm_config_option.yml
+++ b/changelogs/fragments/vmware_vm_config_option.yml
@@ -1,2 +1,4 @@
 minor_changes:
   - vmware_vm_config_option - Add support_usb_controller, support_ethernet_card, support_disk_controller properties in output of getting VM default configs (https://github.com/ansible-collections/community.vmware/pull/1202).
+deprecated_features:
+  - vmware_vm_config_option - Dict item names in result will be changed from strings joined with spaces to strings joined with underlines, e.g. `Guest fullname` will be changed to `guest_fullname` in version 3.

--- a/plugins/modules/vmware_vm_config_option.py
+++ b/plugins/modules/vmware_vm_config_option.py
@@ -276,7 +276,6 @@ class VmConfigOption(PyVmomi):
             vm_config_option_all = self.get_config_option_by_spec(env_browser=env_browser, key=hardware_version)
             supported_gos_list = self.get_guest_id_list(guest_os_desc=vm_config_option_all)
             if self.params.get('get_guest_os_ids'):
-                # info_key = 'Supported guest IDs for %s' % vm_config_option_all.version
                 results.update({vm_config_option_all.version: supported_gos_list})
 
             if self.params.get('get_config_options') and len(guest_id) != 0:

--- a/plugins/modules/vmware_vm_config_option.py
+++ b/plugins/modules/vmware_vm_config_option.py
@@ -165,7 +165,7 @@ class VmConfigOption(PyVmomi):
 
         return vm_config_option
 
-    def get_config_option_recommended(self, guest_os_desc):
+    def get_config_option_recommended(self, guest_os_desc, hwv_version=''):
         guest_os_option_dict = {}
         support_usb_controller = []
         support_disk_controller = []
@@ -191,6 +191,8 @@ class VmConfigOption(PyVmomi):
                     if dev_type == guest_os_desc[0].recommendedCdromController:
                         default_cdrom_ctl = name
             guest_os_option_dict = {
+                'Hardware version': hwv_version,
+                'Guest ID': guest_os_desc[0].id,
                 'Guest fullname': guest_os_desc[0].fullName,
                 'Default CPU cores per socket': guest_os_desc[0].numRecommendedCoresPerSocket,
                 'Default CPU socket': guest_os_desc[0].numRecommendedPhysicalSockets,
@@ -285,9 +287,8 @@ class VmConfigOption(PyVmomi):
                 vm_config_option_guest = self.get_config_option_by_spec(env_browser=env_browser, guest_id=guest_id,
                                                                         key=hardware_version)
                 guest_os_options = vm_config_option_guest.guestOSDescriptor
-                guest_os_option_dict = self.get_config_option_recommended(guest_os_desc=guest_os_options)
-                results.update({'Guest ID': guest_id[0]})
-                results.update({'Hardware version': vm_config_option_guest.version})
+                guest_os_option_dict = self.get_config_option_recommended(guest_os_desc=guest_os_options,
+                                                                          hwv_version=vm_config_option_guest.version)
                 results.update({'Recommended config options': guest_os_option_dict})
 
         self.module.exit_json(changed=False, failed=False, instance=results)
@@ -312,8 +313,8 @@ def main():
             ['cluster_name', 'esxi_hostname'],
         ]
     )
-    module.deprecate(msg="Names of items in results dict will be changed from strings with spaces to strings"
-                         " joined with underlines, e.g., 'Guest fullname' will be changed to 'guest_fullname'.",
+    module.deprecate(msg="Dict item names in 'instance' result will be changed from strings joined with spaces to"
+                         " strings joined with underlines, e.g., 'Guest fullname' will be changed to 'guest_fullname'.",
                      version='3.0.0', collection_name="community.vmware")
     vm_config_option_guest = VmConfigOption(module)
     vm_config_option_guest.get_config_option_for_guest()

--- a/plugins/modules/vmware_vm_config_option.py
+++ b/plugins/modules/vmware_vm_config_option.py
@@ -191,18 +191,18 @@ class VmConfigOption(PyVmomi):
                     if dev_type == guest_os_desc[0].recommendedCdromController:
                         default_cdrom_ctl = name
             guest_os_option_dict = {
-                'guest_fullname': guest_os_desc[0].fullName,
-                'rec_cpu_cores_per_socket': guest_os_desc[0].numRecommendedCoresPerSocket,
-                'rec_cpu_socket': guest_os_desc[0].numRecommendedPhysicalSockets,
-                'rec_memory_mb': guest_os_desc[0].recommendedMemMB,
-                'default_firmware': guest_os_desc[0].recommendedFirmware,
-                'default_secure_boot': guest_os_desc[0].defaultSecureBoot,
-                'support_secure_boot': guest_os_desc[0].supportsSecureBoot,
-                'default_disk_controller': default_disk_ctl,
-                'rec_disk_mb': guest_os_desc[0].recommendedDiskSizeMB,
-                'default_ethernet': default_ethernet,
-                'default_cdrom_controller': default_cdrom_ctl,
-                'default_usb_controller': default_usb_ctl,
+                'Guest fullname': guest_os_desc[0].fullName,
+                'Default CPU cores per socket': guest_os_desc[0].numRecommendedCoresPerSocket,
+                'Default CPU socket': guest_os_desc[0].numRecommendedPhysicalSockets,
+                'Default memory in MB': guest_os_desc[0].recommendedMemMB,
+                'Default firmware': guest_os_desc[0].recommendedFirmware,
+                'Default secure boot': guest_os_desc[0].defaultSecureBoot,
+                'Support secure boot': guest_os_desc[0].supportsSecureBoot,
+                'Default disk controller': default_disk_ctl,
+                'Default disk size in MB': guest_os_desc[0].recommendedDiskSizeMB,
+                'Default network adapter': default_ethernet,
+                'Default CDROM controller': default_cdrom_ctl,
+                'Default USB controller': default_usb_ctl,
                 'support_tpm_20': guest_os_desc[0].supportsTPM20,
                 'support_persistent_memory': guest_os_desc[0].persistentMemorySupported,
                 'rec_persistent_memory': guest_os_desc[0].recommendedPersistentMemoryMB,
@@ -264,8 +264,8 @@ class VmConfigOption(PyVmomi):
         # Get supported hardware versions list
         support_create_list, default_config = self.get_hardware_versions(env_browser=env_browser)
         if self.params.get('get_hardware_versions'):
-            results.update({'supported_hardware_versions': support_create_list,
-                            'default_hardware_version': default_config})
+            results.update({'Supported hardware versions': support_create_list,
+                            'Default hardware version': default_config})
 
         if self.params.get('get_guest_os_ids') or self.params.get('get_config_options'):
             # Get supported guest ID list
@@ -286,9 +286,9 @@ class VmConfigOption(PyVmomi):
                                                                         key=hardware_version)
                 guest_os_options = vm_config_option_guest.guestOSDescriptor
                 guest_os_option_dict = self.get_config_option_recommended(guest_os_desc=guest_os_options)
-                results.update({'guest_id': guest_id[0]})
-                results.update({'hardware_version': vm_config_option_guest.version})
-                results.update({'recommended_config_options': guest_os_option_dict})
+                results.update({'Guest ID': guest_id[0]})
+                results.update({'Hardware version': vm_config_option_guest.version})
+                results.update({'Recommended config options': guest_os_option_dict})
 
         self.module.exit_json(changed=False, failed=False, instance=results)
 
@@ -312,6 +312,9 @@ def main():
             ['cluster_name', 'esxi_hostname'],
         ]
     )
+    module.deprecate(msg="Names of items in results dict will be changed from strings with spaces to strings"
+                         " joined with underlines, e.g., 'Guest fullname' will be changed to 'guest_fullname'.",
+                     version='3.0.0', collection_name="community.vmware")
     vm_config_option_guest = VmConfigOption(module)
     vm_config_option_guest.get_config_option_for_guest()
 

--- a/tests/integration/targets/vmware_vm_config_option/tasks/main.yml
+++ b/tests/integration/targets/vmware_vm_config_option/tasks/main.yml
@@ -75,7 +75,7 @@
             datacenter: "{{ dc1 }}"
             esxi_hostname: "{{ esxi_hosts[0] }}"
             get_guest_os_ids: true
-            hardware_version: "{{ config_option_keys_1.instance.supported_hardware_versions[0] }}"
+            hardware_version: "{{ config_option_keys_1['instance']['Supported hardware versions'][0] }}"
           register: guest_ids_2
           ignore_errors: true
 
@@ -91,8 +91,7 @@
             - not guest_ids_2.failed
       when:
         - "'instance' in config_option_keys_1"
-        - "'supported_hardware_versions' in config_option_keys_1.instance"
-        - config_option_keys_1.instance.supported_hardware_versions | length != 0
+        - "'Supported hardware versions' in config_option_keys_1['instance']"
 
     # Ignore errors due to there is known issue on vSphere 7.0.x
     # https://github.com/vmware/pyvmomi/issues/915
@@ -141,7 +140,7 @@
         password: "{{ esxi_password }}"
         esxi_hostname: "{{ esxi_hosts[0] }}"
         get_guest_os_ids: true
-        hardware_version: "{{ config_option_keys_3.instance.supported_hardware_versions[2] }}"
+        hardware_version: "{{ config_option_keys_3['instance']['Supported hardware versions'][2] }}"
       register: guest_ids_3
       ignore_errors: true
 

--- a/tests/integration/targets/vmware_vm_config_option/tasks/main.yml
+++ b/tests/integration/targets/vmware_vm_config_option/tasks/main.yml
@@ -58,6 +58,7 @@
       assert:
         that:
           - "'instance' in guest_ids_1"
+          - guest_ids_1.instance | length != 0
       when:
         - "'failed' in guest_ids_1"
         - not guest_ids_1.failed
@@ -74,7 +75,7 @@
             datacenter: "{{ dc1 }}"
             esxi_hostname: "{{ esxi_hosts[0] }}"
             get_guest_os_ids: true
-            hardware_version: "{{ config_option_keys_1['instance']['Supported hardware versions'][0] }}"
+            hardware_version: "{{ config_option_keys_1.instance.supported_hardware_versions[0] }}"
           register: guest_ids_2
           ignore_errors: true
 
@@ -84,12 +85,14 @@
           assert:
             that:
               - "'instance' in guest_ids_2"
+              - guest_ids_2.instance | length != 0
           when:
             - "'failed' in guest_ids_2"
             - not guest_ids_2.failed
       when:
         - "'instance' in config_option_keys_1"
-        - "'Supported hardware versions' in config_option_keys_1['instance']"
+        - "'supported_hardware_versions' in config_option_keys_1.instance"
+        - config_option_keys_1.instance.supported_hardware_versions | length != 0
 
     # Ignore errors due to there is known issue on vSphere 7.0.x
     # https://github.com/vmware/pyvmomi/issues/915
@@ -112,6 +115,43 @@
       assert:
         that:
           - "'instance' in recommended_configs"
+          - recommended_configs.instance | length != 0
       when:
         - "'failed' in recommended_configs"
         - not recommended_configs.failed
+
+    - name: get list of config option keys by connecting to ESXi host
+      community.vmware.vmware_vm_config_option:
+        validate_certs: false
+        hostname: "{{ esxi_hosts[0] }}"
+        username: "{{ esxi_user }}"
+        password: "{{ esxi_password }}"
+        esxi_hostname: "{{ esxi_hosts[0] }}"
+        get_hardware_versions: true
+      register: config_option_keys_3
+
+    - debug:
+        var: config_option_keys_3
+
+    - name: get list of supported guest IDs by connecting to ESXi host with config option key
+      community.vmware.vmware_vm_config_option:
+        validate_certs: false
+        hostname: "{{ esxi_hosts[0] }}"
+        username: "{{ esxi_user }}"
+        password: "{{ esxi_password }}"
+        esxi_hostname: "{{ esxi_hosts[0] }}"
+        get_guest_os_ids: true
+        hardware_version: "{{ config_option_keys_3.instance.supported_hardware_versions[2] }}"
+      register: guest_ids_3
+      ignore_errors: true
+
+    - debug:
+        var: guest_ids_3
+    - name: check guest ID list returned when task not failed
+      assert:
+        that:
+          - "'instance' in guest_ids_3"
+          - guest_ids_3.instance | length != 0
+      when:
+        - "'failed' in guest_ids_3"
+        - not guest_ids_3.failed


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1420

Signed-off-by: dianew <dianew@vmware.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add supported disk controller types, supported network adapter types, supported USB controller types in the recommended_config_options output.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_vm_config_option

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
ok: [localhost] => {
    "vm_default_config": {
        "changed": false,
        "failed": false,
        "instance": {
            "guest_id": "amazonlinux2_64Guest",
            "hardware_version": "vmx-15",
            "recommended_config_options": {
                "default_cdrom_controller": "sata",
                "default_disk_controller": "paravirtual",
                "default_ethernet": "vmxnet3",
                "default_firmware": "efi",
                "default_secure_boot": false,
                "default_usb_controller": "",
                "guest_fullname": "Amazon Linux 2 (64-bit)",
                "rec_cpu_cores_per_socket": 2,
                "rec_cpu_socket": 1,
                "rec_disk_mb": 16384,
                "rec_memory_mb": 2048,
                "rec_persistent_memory": 8192,
                "rec_vram_kb": 8192,
                "support_disk_controller": [
                    "lsilogic",
                    "paravirtual",
                    "lsilogicsas",
                    "sata",
                    "nvme"
                ],
                "support_ethernet_card": [
                    "vmxnet3",
                    "e1000e",
                    "sriov"
                ],
                "support_min_persistent_mem_mb": 4,
                "support_persistent_memory": true,
                "support_secure_boot": true,
                "support_tpm_20": false,
                "support_usb_controller": [
                    "usb2",
                    "usb3"
                ]
            }
        }
    }
}
```
