### PR TITLE
Added support for multiple SCSI controllers

### DIFF
--- a/changelogs/fragments/1203-vmware_guest_storage_policy-controller_number-param.yml
+++ b/changelogs/fragments/1203-vmware_guest_storage_policy-controller_number-param.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - vmware_guest_storage_policy - New parameter `controller_number` to support multiple SCSI controllers (https://github.com/ansible-collections/community.vmware/issues/1203).
+

--- a/changelogs/fragments/1203-vmware_guest_storage_policy-controller_number-param.yml
+++ b/changelogs/fragments/1203-vmware_guest_storage_policy-controller_number-param.yml
@@ -1,3 +1,2 @@
 minor_changes:
   - vmware_guest_storage_policy - New parameter `controller_number` to support multiple SCSI controllers (https://github.com/ansible-collections/community.vmware/issues/1203).
-

--- a/docs/community.vmware.vmware_guest_storage_policy_module.rst
+++ b/docs/community.vmware.vmware_guest_storage_policy_module.rst
@@ -94,6 +94,25 @@ Parameters
             </tr>
 
             <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>controller_number</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>SCSI Controller Number.</div>
+                        <div>Valid values range from 0 to 3.</div>
+                </td>
+            </tr>
+
+            <tr>
                 <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>folder</b>
@@ -330,7 +349,7 @@ Examples
 
 .. code-block:: yaml
 
-    - name: Enforce storepol1 policy for disk 0 and 1 using UUID
+    - name: Enforce storepol1 policy for disk 0 and 1 on controller 0 using UUID
       community.vmware.vmware_guest_storage_policy:
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
@@ -339,8 +358,10 @@ Examples
         uuid: cefd316c-fc19-45f3-a539-2cd03427a78d
         disk:
           - unit_number: 0
+            controller_number: 0
             policy: storepol1
           - unit_number: 1
+            controller_number: 0
             policy: storepol1
       delegate_to: localhost
       register: policy_status
@@ -383,7 +404,7 @@ Common return values are documented `here <https://docs.ansible.com/ansible/late
                             <div>Dictionary containing the changed policies of disk (list of dictionaries) and vm_home.</div>
                     <br/>
                         <div style="font-size: smaller"><b>Sample:</b></div>
-                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{&#x27;disk&#x27;: [{&#x27;policy&#x27;: &#x27;storepol1&#x27;, &#x27;unit_number&#x27;: 0}], &#x27;vm_home&#x27;: &#x27;storepol1&#x27;}</div>
+                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{&#x27;disk&#x27;: [{&#x27;controller_number&#x27;: &#x27;0&#x27;,&#x27;policy&#x27;: &#x27;storepol1&#x27;, &#x27;unit_number&#x27;: 0}], &#x27;vm_home&#x27;: &#x27;storepol1&#x27;}</div>
                 </td>
             </tr>
             <tr>

--- a/plugins/modules/vmware_guest_storage_policy.py
+++ b/plugins/modules/vmware_guest_storage_policy.py
@@ -414,7 +414,7 @@ def run_module():
                   elements='dict',
                   options=dict(
                        unit_number=dict(type='int', required=True),
-                       controller_number=dict(type='int', required=True),
+                       controller_number=dict(type='int', default=0),
                        policy=dict(type='str', required=True)
                   )),
         vm_home=dict(type='str'),

--- a/plugins/modules/vmware_guest_storage_policy.py
+++ b/plugins/modules/vmware_guest_storage_policy.py
@@ -97,7 +97,7 @@ options:
          - SCSI controller number.
          - Valid values range from 0 to 3.
          type: int
-         required: true
+         default: 0
        policy:
          description:
          - Name of the storage profile policy to enforce for the disk.

--- a/plugins/modules/vmware_guest_storage_policy.py
+++ b/plugins/modules/vmware_guest_storage_policy.py
@@ -364,7 +364,7 @@ class SPBM_helper(SPBM):
                 result['msg'] = "Unable to find storage policy `%s' for disk %s." % (policy, disk)
                 self.module.fail_json(**result)
             if not disk_obj:
-                errmsg = "Unable to find disk for controller_number '%s' unit_number '%s'. 7 is reserved for SCSI adapters." 
+                errmsg = "Unable to find disk for controller_number '%s' unit_number '%s'. 7 is reserved for SCSI adapters."
                 result['msg'] = errmsg % (controller_number, unit_number)
                 self.module.fail_json(**result)
             disks_objs[unit_number] = dict(disk=disk_obj, policy=pol_obj)

--- a/plugins/modules/vmware_guest_storage_policy.py
+++ b/plugins/modules/vmware_guest_storage_policy.py
@@ -259,14 +259,14 @@ class SPBM_helper(SPBM):
             if isinstance(device, vim.vm.device.VirtualSCSIController):
                 if device.busNumber == controller_number:
                    controllerKey = device.key
-                   break;
+                   break
 
-        if controllerKey is not None: ## if controller was found check disk
+        if controllerKey is not None:  ## if controller was found check disk
             for device in vm.config.hardware.device:
                 if not isinstance(device, vim.vm.device.VirtualDisk):
                     continue
                 if int(device.unitNumber) == int(unit_number) and \
-                           int(device.controllerKey) == controllerKey:
+                   int(device.controllerKey) == controllerKey:
                     return device
 
         return None

--- a/plugins/modules/vmware_guest_storage_policy.py
+++ b/plugins/modules/vmware_guest_storage_policy.py
@@ -364,7 +364,8 @@ class SPBM_helper(SPBM):
                 result['msg'] = "Unable to find storage policy `%s' for disk %s." % (policy, disk)
                 self.module.fail_json(**result)
             if not disk_obj:
-                result['msg'] = "Unable to find disk for controller %s  unit_number `%s'. 7 will be reserved for SCSI adapters." % (controller_number, unit_number)
+                errmsg = "Unable to find disk for controller_number '%s' unit_number '%s'. 7 is reserved for SCSI adapters." 
+                result['msg'] = errmsg % (controller_number, unit_number)
                 self.module.fail_json(**result)
             disks_objs[unit_number] = dict(disk=disk_obj, policy=pol_obj)
 

--- a/plugins/modules/vmware_guest_storage_policy.py
+++ b/plugins/modules/vmware_guest_storage_policy.py
@@ -258,10 +258,10 @@ class SPBM_helper(SPBM):
         for device in vm.config.hardware.device:
             if isinstance(device, vim.vm.device.VirtualSCSIController):
                 if device.busNumber == controller_number:
-                   controllerKey = device.key
-                   break
+                    controllerKey = device.key
+                    break
 
-        if controllerKey is not None:  ## if controller was found check disk
+        if controllerKey is not None:  # if controller was found check disk
             for device in vm.config.hardware.device:
                 if not isinstance(device, vim.vm.device.VirtualDisk):
                     continue

--- a/plugins/modules/vmware_guest_storage_policy.py
+++ b/plugins/modules/vmware_guest_storage_policy.py
@@ -92,6 +92,12 @@ options:
          - Valid values range from 0 to 15.
          type: int
          required: true
+       controller_number:
+         description:
+         - SCSI controller number.
+         - Valid values range from 0 to 3.
+         type: int
+         required: true
        policy:
          description:
          - Name of the storage profile policy to enforce for the disk.
@@ -102,7 +108,7 @@ extends_documentation_fragment:
 '''
 
 EXAMPLES = r'''
-- name: Enforce storepol1 policy for disk 0 and 1 using UUID
+- name: Enforce storepol1 policy for disk 0 and 1 on SCSI controller 0 using UUID
   community.vmware.vmware_guest_storage_policy:
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
@@ -111,8 +117,10 @@ EXAMPLES = r'''
     uuid: cefd316c-fc19-45f3-a539-2cd03427a78d
     disk:
       - unit_number: 0
+        controller_number: 0
         policy: storepol1
       - unit_number: 1
+        controller_number: 0
         policy: storepol1
   delegate_to: localhost
   register: policy_status
@@ -233,7 +241,7 @@ class SPBM_helper(SPBM):
         spec.vmProfile = [profileSpec]
         return vm.ReconfigVM_Task(spec)
 
-    def GetVirtualDiskObj(self, vm, unit_number):
+    def GetVirtualDiskObj(self, vm, unit_number, controller_number):
         """
         Get a virtual disk object.
 
@@ -241,18 +249,29 @@ class SPBM_helper(SPBM):
         :type vm: VirtualMachine
         :param unit_number: virtual machine's disk unit number.
         :type unit_number: int
+        :param controller_number: virtual machine's controller number.
+        :type controller_number: int
         :returns: VirtualDisk object if exists, else None.
         :rtype: VirtualDisk, None
         """
+        controllerKey = None
         for device in vm.config.hardware.device:
-            if not isinstance(device, vim.vm.device.VirtualDisk):
-                continue
-            if int(device.unitNumber) == int(unit_number):
-                return device
+            if isinstance(device, vim.vm.device.VirtualSCSIController):
+                if device.busNumber == controller_number:
+                   controllerKey = device.key
+                   break;
+
+        if controllerKey is not None: ## if controller was found check disk
+            for device in vm.config.hardware.device:
+                if not isinstance(device, vim.vm.device.VirtualDisk):
+                    continue
+                if int(device.unitNumber) == int(unit_number) and \
+                           int(device.controllerKey) == controllerKey:
+                    return device
 
         return None
 
-    def SetVMDiskStorageProfile(self, vm, unit_number, profile):
+    def SetVMDiskStorageProfile(self, vm, unit_number, controller_number, profile):
         """
         Set VM's disk storage policy profile.
 
@@ -260,6 +279,8 @@ class SPBM_helper(SPBM):
         :type vm: VirtualMachine
         :param unit_number: virtual machine's disk unit number.
         :type unit_number: int
+        :param controller_number: virtual machine's controller number.
+        :type controller_number: int
         :param profile: A VMware Storage Policy profile
         :type profile: pbm.profile.Profile
         :returns: VMware task object.
@@ -272,7 +293,7 @@ class SPBM_helper(SPBM):
 
         deviceSpec = vim.vm.device.VirtualDeviceSpec()
         deviceSpec.operation = vim.vm.device.VirtualDeviceSpec.Operation.edit
-        disk_obj = self.GetVirtualDiskObj(vm, unit_number)
+        disk_obj = self.GetVirtualDiskObj(vm, unit_number, controller_number)
         deviceSpec.device = disk_obj
         deviceSpec.profile = [profileSpec]
         spec.deviceChange = [deviceSpec]
@@ -336,13 +357,14 @@ class SPBM_helper(SPBM):
         for disk in disks:
             policy = str(disk['policy'])
             unit_number = int(disk['unit_number'])
-            disk_obj = self.GetVirtualDiskObj(vm_obj, unit_number)
+            controller_number = int(disk['controller_number'])
+            disk_obj = self.GetVirtualDiskObj(vm_obj, unit_number, controller_number)
             pol_obj = self.SearchStorageProfileByName(pm, policy)
             if not pol_obj:
                 result['msg'] = "Unable to find storage policy `%s' for disk %s." % (policy, disk)
                 self.module.fail_json(**result)
             if not disk_obj:
-                result['msg'] = "Unable to find disk for unit_number `%s'. 7 will be reserved for SCSI adapters." % unit_number
+                result['msg'] = "Unable to find disk for controller %s  unit_number `%s'. 7 will be reserved for SCSI adapters." % (controller_number, unit_number)
                 self.module.fail_json(**result)
             disks_objs[unit_number] = dict(disk=disk_obj, policy=pol_obj)
 
@@ -351,6 +373,7 @@ class SPBM_helper(SPBM):
         for disk in disks:
             policy = str(disk['policy'])
             unit_number = int(disk['unit_number'])
+            controller_number = int(disk['controller_number'])
             disk_obj = disks_objs[unit_number]['disk']
             pol_obj = disks_objs[unit_number]['policy']
             pmObjectType = pbm.ServerObjectRef.ObjectType("virtualDiskId")
@@ -363,6 +386,7 @@ class SPBM_helper(SPBM):
                 # task success, and exit.
                 if not self.module.check_mode:
                     task = self.SetVMDiskStorageProfile(vm_obj, unit_number,
+                                                        controller_number,
                                                         pol_obj)
                     wait_for_task(task)
                 result['changed'] = True
@@ -389,6 +413,7 @@ def run_module():
                   elements='dict',
                   options=dict(
                        unit_number=dict(type='int', required=True),
+                       controller_number=dict(type='int', required=True),
                        policy=dict(type='str', required=True)
                   )),
         vm_home=dict(type='str'),

--- a/tests/integration/targets/vmware_guest_storage_policy/tasks/main.yml
+++ b/tests/integration/targets/vmware_guest_storage_policy/tasks/main.yml
@@ -111,7 +111,7 @@
         that:
           - vm_home_sp_idp.changed_policies.vm_home == ""
 
-    - name: "004: Assign storage policy to disk unit {{ unit_number }} check_mode test"
+    - name: "004: Assign storage policy to controller number {{ controller_number}} disk unit {{ unit_number }} check_mode test"
       vmware_guest_storage_policy: &disk_args
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
@@ -120,6 +120,7 @@
         name: "{{ virtual_machines[0].name }}"
         disk:
           - unit_number: "{{ unit_number }}"
+            controller_number: "{{ controller_number }}"
             policy: "{{ storage_policy }}"
       register: disk_sp_cm
       check_mode: true
@@ -133,6 +134,7 @@
       assert:
         that:
           - disk_sp_cm.changed_policies.disk[0].unit_number == unit_number
+          - disk_sp_cm.changed_policies.disk[0].controller_number == controller_number
           - disk_sp_cm.changed_policies.disk[0].policy == storage_policy
 
     - name: "005: Assign storage policy to disk unit {{ unit_number }}"
@@ -149,6 +151,7 @@
       assert:
         that:
           - disk_sp.changed_policies.disk[0].unit_number == unit_number
+          - disk_sp.changed_policies.disk[0].controller_number == controller_number
           - disk_sp.changed_policies.disk[0].policy == storage_policy
 
     - name: "006: Assign storage policy to disk unit {{ unit_number }} idempotence test"
@@ -203,3 +206,4 @@
     category: "vm_guest_storage_profile_cat001"
     tag: "vm_guest_storage_profile_tag001"
     unit_number: 0
+    controller_number: 0


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Fixes [#1203](https://github.com/ansible-collections/community.vmware/issues/1203) - vmware_guest_storage_policy missing SCSI controller parameter
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
community.vmware.vmware_guest_storage_policy
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
