### PR TITLE
Remove pre-collection version_added documentation

### DIFF
--- a/changelogs/fragments/remove_pre-collection_version_added.yml
+++ b/changelogs/fragments/remove_pre-collection_version_added.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Remove `version_added` documentation that pre-dates the collection, that is refers to Ansible < 2.10 (https://github.com/ansible-collections/community.vmware/pull/1215).

--- a/plugins/doc_fragments/vmware.py
+++ b/plugins/doc_fragments/vmware.py
@@ -106,23 +106,17 @@ options:
       - Environment variable supported added in Ansible 2.6.
       type: int
       default: 443
-      version_added: '2.5'
-      version_added_collection: 'ansible.builtin'
     proxy_host:
       description:
       - Address of a proxy that will receive all HTTPS requests and relay them.
       - The format is a hostname or a IP.
       - If the value is not specified in the task, the value of environment variable C(VMWARE_PROXY_HOST) will be used instead.
       type: str
-      version_added: '2.9'
-      version_added_collection: 'ansible.builtin'
       required: False
     proxy_port:
       description:
       - Port of the HTTP proxy that will receive all HTTPS requests and relay them.
       - If the value is not specified in the task, the value of environment variable C(VMWARE_PROXY_PORT) will be used instead.
       type: int
-      version_added: '2.9'
-      version_added_collection: 'ansible.builtin'
       required: False
     '''

--- a/plugins/inventory/vmware_vm_inventory.py
+++ b/plugins/inventory/vmware_vm_inventory.py
@@ -124,7 +124,6 @@ DOCUMENTATION = r'''
             - Each resource item is represented by exactly one C('vim_type_snake_case):C(list of resource names) pair and optional nested I(resources)
             - Key name is based on snake case of a vim type name; e.g C(host_system) correspond to C(vim.HostSystem)
             - See  L(VIM Types,https://pubs.vmware.com/vi-sdk/visdk250/ReferenceGuide/index-mo_types.html)
-            version_added: "2.10"
             required: False
             type: list
             default: []


### PR DESCRIPTION
##### SUMMARY
`plugins/inventory/vmware_vm_inventory.py`and `plugins/doc_fragments/vmware.py` have a `version_added` of 2.something. This refers to the Ansible version. Now that the collection is version 2, I think this will create misunderstandings in the future. So I'd like to remove them.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
vmware_vm_inventory

##### ADDITIONAL INFORMATION
