### PR TITLE
vmware_guest_powerstate - fix `shutdownguest` is not idempotent

### DIFF
--- a/changelogs/fragments/fix_shutdownguest_state_idempotency.yml
+++ b/changelogs/fragments/fix_shutdownguest_state_idempotency.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - vmware_guest_powerstate - `shutdownguest` power state is not idempotent
+  - vmware_guest_powerstate - `shutdownguest` power state is not idempotent (https://github.com/ansible-collections/community.vmware/pull/1227).

--- a/changelogs/fragments/fix_shutdownguest_state_idempotency.yml
+++ b/changelogs/fragments/fix_shutdownguest_state_idempotency.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_guest_powerstate - `shutdownguest` power state is not idempotent

--- a/plugins/module_utils/vmware.py
+++ b/plugins/module_utils/vmware.py
@@ -982,9 +982,11 @@ def set_vm_power_state(content, vm, state, force, timeout=0, answers=None):
                     else:
                         result['failed'] = True
                         result['msg'] = "VMware tools should be installed for guest shutdown/reboot"
+                elif current_state == 'poweredoff':
+                    result['changed'] = False
                 else:
                     result['failed'] = True
-                    result['msg'] = "Virtual machine %s must be in poweredon state for guest shutdown/reboot" % vm.name
+                    result['msg'] = "Virtual machine %s must be in poweredon state for guest reboot" % vm.name
 
             else:
                 result['failed'] = True


### PR DESCRIPTION
##### SUMMARY
The `shutdownguest` power state is not idempotent.\
Running a play twice results in `"Virtual machine XXX must be in poweredon state for guest shutdown/reboot"` error message while the second run shouldn't do anything as the VM is already powered  off.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_guest_powerstate

