### PR TITLE
Remove FQCN from jsonfile plugin in tests

### DIFF
--- a/tests/integration/targets/inventory_vmware_host_inventory/runme.sh
+++ b/tests/integration/targets/inventory_vmware_host_inventory/runme.sh
@@ -5,7 +5,7 @@ set -eux
 export ANSIBLE_PYTHON_INTERPRETER=${ANSIBLE_TEST_PYTHON_INTERPRETER:-$(command -v python)}
 export ANSIBLE_INVENTORY_ENABLED="community.vmware.vmware_host_inventory,host_list,ini"
 export ANSIBLE_CACHE_PLUGIN_CONNECTION="${PWD}/inventory_cache"
-export ANSIBLE_CACHE_PLUGIN="community.general.jsonfile"
+export ANSIBLE_CACHE_PLUGIN="jsonfile"
 
 export INVENTORY_DIR="${PWD}/_test/hosts"
 mkdir -p "${INVENTORY_DIR}" 2>/dev/null
@@ -36,7 +36,7 @@ trap cleanup INT TERM EXIT
 ansible-playbook playbook/prepare_vmware.yml "$@"
 
 # Test Cache
-# Cache requires community.general.jsonfile
+# Cache requires jsonfile
 # ansible-playbook playbook/build_inventory_with_cache.yml "$@"
 # ansible-inventory -i "${INVENTORY_DIR}" --list
 # ansible-playbook -i "${INVENTORY_DIR}" playbook/test_inventory_cache.yml "$@"

--- a/tests/integration/targets/inventory_vmware_host_inventory/runme.sh
+++ b/tests/integration/targets/inventory_vmware_host_inventory/runme.sh
@@ -42,6 +42,7 @@ ansible-playbook playbook/prepare_vmware.yml "$@"
 # ansible-playbook -i "${INVENTORY_DIR}" playbook/test_inventory_cache.yml "$@"
 
 # Test YAML and TOML
+ansible-playbook playbook/install_dependencies.yml "$@"
 ansible-playbook playbook/build_inventory_without_cache.yml "$@"
 ansible-inventory -i "${INVENTORY_DIR}" --list --yaml 1>/dev/null
 if ${ANSIBLE_PYTHON_INTERPRETER} -m pip list 2>/dev/null | grep toml >/dev/null 2>&1; then

--- a/tests/integration/targets/inventory_vmware_vm_inventory/aliases
+++ b/tests/integration/targets/inventory_vmware_vm_inventory/aliases
@@ -1,2 +1,3 @@
 cloud/vcenter
 needs/target/prepare_vmware_tests
+zuul/vmware/govcsim

--- a/tests/integration/targets/inventory_vmware_vm_inventory/runme.sh
+++ b/tests/integration/targets/inventory_vmware_vm_inventory/runme.sh
@@ -42,6 +42,7 @@ ansible-inventory -i "${INVENTORY_DIR}" --list 1>/dev/null
 ansible-playbook -i "${INVENTORY_DIR}" playbook/test_inventory_cache.yml "$@"
 
 # Test YAML and TOML
+ansible-playbook playbook/install_dependencies.yml "$@"
 ansible-playbook playbook/build_inventory_without_cache.yml "$@"
 ansible-inventory -i "${INVENTORY_DIR}" --list --yaml 1>/dev/null
 if ${ANSIBLE_PYTHON_INTERPRETER} -m pip list 2>/dev/null | grep toml >/dev/null 2>&1; then

--- a/tests/integration/targets/inventory_vmware_vm_inventory/runme.sh
+++ b/tests/integration/targets/inventory_vmware_vm_inventory/runme.sh
@@ -5,7 +5,7 @@ set -eux
 export ANSIBLE_PYTHON_INTERPRETER=${ANSIBLE_TEST_PYTHON_INTERPRETER:-$(command -v python)}
 export ANSIBLE_INVENTORY_ENABLED="community.vmware.vmware_vm_inventory,host_list,ini"
 export ANSIBLE_CACHE_PLUGIN_CONNECTION="${PWD}/inventory_cache"
-export ANSIBLE_CACHE_PLUGIN="community.general.jsonfile"
+export ANSIBLE_CACHE_PLUGIN="jsonfile"
 
 export INVENTORY_DIR="${PWD}/_test/hosts"
 mkdir -p "${INVENTORY_DIR}" 2>/dev/null
@@ -36,7 +36,7 @@ trap cleanup INT TERM EXIT
 ansible-playbook playbook/prepare_vmware.yml "$@"
 
 # Test Cache
-# Cache requires community.general.jsonfile
+# Cache requires jsonfile
 ansible-playbook playbook/build_inventory_with_cache.yml "$@"
 ansible-inventory -i "${INVENTORY_DIR}" --list 1>/dev/null
 ansible-playbook -i "${INVENTORY_DIR}" playbook/test_inventory_cache.yml "$@"

--- a/tests/integration/targets/vmware_vm_inventory/ansible.cfg
+++ b/tests/integration/targets/vmware_vm_inventory/ansible.cfg
@@ -5,5 +5,5 @@ roles_path = ..
 enable_plugins = community.vmware.vmware_vm_inventory
 cache = False
 #cache = True
-#cache_plugin = community.general.jsonfile
+#cache_plugin = jsonfile
 #cache_connection = inventory_cache


### PR DESCRIPTION
##### SUMMARY

`jsonfile` moved back into core: https://github.com/ansible/ansible/pull/69337

I found another problem here:

https://github.com/ansible-collections/community.vmware/blob/3cdff25220e132b62418db4b78a977bd3a399cd1/tests/integration/targets/inventory_vmware_vm_inventory/runme.sh#L47-L49

You see, `tomli` is installed as a requirement. But that makes `pip list | grep toml` evaluate to true and execute ansible-inventory with the `--toml` parameter. Which fails because ansible-inventory requirement `toml` is missing.

Fixes #1219 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tests/integration/targets/inventory_vmware_host_inventory/runme.sh
tests/integration/targets/inventory_vmware_vm_inventory/runme.sh
tests/integration/targets/vmware_vm_inventory/ansible.cfg

##### ADDITIONAL INFORMATION
Hopefully fixes some CI failures like #1226.
