### PR TITLE
Bugfix vmware_vmotion: Only Storage vmotion

### DIFF
--- a/changelogs/fragments/1236-vmware_vmotion-svmotion_without_resourcepool.yml
+++ b/changelogs/fragments/1236-vmware_vmotion-svmotion_without_resourcepool.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - vmware_vmotion - Like already define in the examples, allow Storage vMotion without defining a resource pool. 
+    (https://github.com/ansible-collections/community.vmware/pull/1236).

--- a/plugins/modules/vmware_vmotion.py
+++ b/plugins/modules/vmware_vmotion.py
@@ -202,6 +202,10 @@ class VmotionManager(PyVmomi):
         if dest_resourcepool:
             self.resourcepool_object = find_resource_pool_by_name(content=self.content,
                                                                   resource_pool_name=dest_resourcepool)
+            # Fail if resourcePool object is not found
+            if self.resourcepool_object is None:
+                self.module.fail_json(msg="Unable to find destination resource pool object for %s." % dest_resourcepool)
+            
         elif not dest_resourcepool and dest_host_name:
             self.resourcepool_object = self.host_object.parent.resourcePool
 

--- a/plugins/modules/vmware_vmotion.py
+++ b/plugins/modules/vmware_vmotion.py
@@ -204,9 +204,6 @@ class VmotionManager(PyVmomi):
                                                                   resource_pool_name=dest_resourcepool)
         elif not dest_resourcepool and dest_host_name:
             self.resourcepool_object = self.host_object.parent.resourcePool
-        # Fail if resourcePool object is not found
-        if self.resourcepool_object is None:
-            self.module.fail_json(msg="Unable to find destination resource pool object which is required")
 
         # Check if datastore is required, this check is required if destination
         # and source host system does not share same datastore.

--- a/plugins/modules/vmware_vmotion.py
+++ b/plugins/modules/vmware_vmotion.py
@@ -205,7 +205,6 @@ class VmotionManager(PyVmomi):
             # Fail if resourcePool object is not found
             if self.resourcepool_object is None:
                 self.module.fail_json(msg="Unable to find destination resource pool object for %s." % dest_resourcepool)
-            
         elif not dest_resourcepool and dest_host_name:
             self.resourcepool_object = self.host_object.parent.resourcePool
 


### PR DESCRIPTION
##### SUMMARY
The Example Below didn't work:
- name: Perform storage vMotion of virtual machine
  community.vmware.vmware_vmotion:
    hostname: '{{ vcenter_hostname }}'
    username: '{{ vcenter_username }}'
    password: '{{ vcenter_password }}'
    vm_name: 'vm_name_as_per_vcenter'
    destination_datastore: 'destination_datastore_as_per_vcenter'
  delegate_to: localhost

With removing this from the code it works:
if self.resourcepool_object is None:
  self.module.fail_json(msg="Unable to find destination resource pool object which is required")

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
wmware_vmotion.py
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
