### PR TITLE
vmware_vmotion: Add cluster and datastore cluster

### DIFF
--- a/changelogs/fragments/1240-vmware_vmotion-add_cluster_storage_cluster.yaml
+++ b/changelogs/fragments/1240-vmware_vmotion-add_cluster_storage_cluster.yaml
@@ -1,3 +1,3 @@
-breaking_changes:
+minor_changes:
   - vmware_vmotion - Add the feature to use cluster and datastore cluster (storage pods) to define where the vmotion shold go.
     (https://github.com/ansible-collections/community.vmware/pull/1240)

--- a/changelogs/fragments/1240-vmware_vmotion-add_cluster_storage_cluster.yaml
+++ b/changelogs/fragments/1240-vmware_vmotion-add_cluster_storage_cluster.yaml
@@ -1,0 +1,3 @@
+breaking_changes:
+  - vmware_vmotion - Add the feature to use cluster and datastore cluster (storage pods) to define where the vmotion shold go.
+    (https://github.com/ansible-collections/community.vmware/pull/1240)

--- a/plugins/modules/vmware_vmotion.py
+++ b/plugins/modules/vmware_vmotion.py
@@ -157,7 +157,7 @@ running_host:
     type: str
     sample: 'host1.example.com'
 datastore:
-    description: List the datastore the virtual machine is on. 
+    description: List the datastore the virtual machine is on.
     Only returned if there is asked for a Storage vMotion (Datastore or Datastore Cluster).
     returned: changed or success
     type: str

--- a/plugins/modules/vmware_vmotion.py
+++ b/plugins/modules/vmware_vmotion.py
@@ -58,11 +58,13 @@ options:
       aliases: ['destination']
       type: str
     destination_cluster:
+      version_added: '2.5.0'
       description:
       - Name of the destination cluster the virtual machine should be running on.
       - Only works if drs is enabled for this cluster.
       type: str
     destination_datastore_cluster:
+      version_added: '2.5.0'
       description:
       - Name of the destination datastore cluster (storage pod) the virtual machine's vmdk should be moved on.
       - Only works if drs is enabled for the cluster the vm is running / should run.

--- a/plugins/modules/vmware_vmotion.py
+++ b/plugins/modules/vmware_vmotion.py
@@ -246,7 +246,6 @@ class VmotionManager(PyVmomi):
             self.datastore_object = find_datastore_by_name(content=self.content,
                                                            datastore_name=dest_datastore,
                                                            datacenter_name=dest_datacenter)
-                                           
         if dest_datastore_cluster is not None:
             # unable to use find_datastore_cluster_by_name module
             data_store_clusters = get_all_objs(self.content, [vim.StoragePod], folder=self.content.rootFolder)

--- a/plugins/modules/vmware_vmotion.py
+++ b/plugins/modules/vmware_vmotion.py
@@ -158,7 +158,7 @@ running_host:
     type: str
     sample: 'host1.example.com'
 datastore:
-    description: 
+    description:
     - List the datastore the virtual machine is on.
     - Only returned if there is asked for a Storage vMotion (Datastore or Datastore Cluster).
     returned: changed or success

--- a/plugins/modules/vmware_vmotion.py
+++ b/plugins/modules/vmware_vmotion.py
@@ -159,7 +159,7 @@ running_host:
     sample: 'host1.example.com'
 datastore:
     description: 
-    - List the datastore the virtual machine is on. 
+    - List the datastore the virtual machine is on.
     - Only returned if there is asked for a Storage vMotion (Datastore or Datastore Cluster).
     returned: changed or success
     type: str

--- a/plugins/modules/vmware_vmotion.py
+++ b/plugins/modules/vmware_vmotion.py
@@ -151,7 +151,7 @@ EXAMPLES = r'''
 
 RETURN = r'''
 running_host:
-    description: 
+    description:
     - List the host the virtual machine is registered to.
     - Only returned if there is asked for a vMotion (Cluster or Host).
     returned: changed or success

--- a/plugins/modules/vmware_vmotion.py
+++ b/plugins/modules/vmware_vmotion.py
@@ -266,11 +266,14 @@ class VmotionManager(PyVmomi):
                 host_datastore_required.append(False)
 
         if any(host_datastore_required) and (dest_datastore is None or dest_datastore_cluster is None):
+            if self.host_object:
+                datastores = self.host_object.datastore
+            elif self.cluster_object:
+                datastores = self.cluster_object.datastore
             msg = "Destination host system or cluster does not share" \
                   " datastore ['%s'] with source host system ['%s'] on which" \
                   " virtual machine is located.  Please specify destination_datastore or destination_datastore_cluster" \
-                  " to rectify this problem." % ("', '".join([ds.name for ds in (self.host_object.datastore
-                                                                                 or self.cluster_object.datastore)]),
+                  " to rectify this problem." % ("', '".join([ds.name for ds in datastores]),
                                                  "', '".join([ds.name for ds in self.vm.datastore]))
 
             self.module.fail_json(msg=msg)

--- a/plugins/modules/vmware_vmotion.py
+++ b/plugins/modules/vmware_vmotion.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright: (c) 2015, Bede Carroll <bc+github () bedecarroll.com>
+
 # Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
 # Copyright: (c) 2018, Ansible Project
 #
@@ -150,14 +151,12 @@ EXAMPLES = r'''
 
 RETURN = r'''
 running_host:
-    description: List the host the virtual machine is registered to. 
-    Only returned if there is asked for a vMotion (Cluster or Host).
+    description: List the host the virtual machine is registered to. Only returned if there is asked for a vMotion (Cluster or Host).
     returned: changed or success
     type: str
     sample: 'host1.example.com'
 datastore:
-    description: List the datastore the virtual machine is on.
-    Only returned if there is asked for a Storage vMotion (Datastore or Datastore Cluster).
+    description: List the datastore the virtual machine is on. Only returned if there is asked for a Storage vMotion (Datastore or Datastore Cluster).
     returned: changed or success
     type: str
     sample: 'datastore1'

--- a/plugins/modules/vmware_vmotion.py
+++ b/plugins/modules/vmware_vmotion.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 # Copyright: (c) 2015, Bede Carroll <bc+github () bedecarroll.com>
-
 # Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
 # Copyright: (c) 2018, Ansible Project
 #

--- a/plugins/modules/vmware_vmotion.py
+++ b/plugins/modules/vmware_vmotion.py
@@ -152,7 +152,7 @@ EXAMPLES = r'''
 RETURN = r'''
 running_host:
     description: 
-    - List the host the virtual machine is registered to. 
+    - List the host the virtual machine is registered to.
     - Only returned if there is asked for a vMotion (Cluster or Host).
     returned: changed or success
     type: str


### PR DESCRIPTION
##### SUMMARY
Add the possibility to use cluster and datastore cluster (storage pods).
So DRS will tell the best host to move the vm and a ds will selected form the  datastore cluster. 

Build on the Bugfix #1236.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_vmotion

##### ADDITIONAL INFORMATION
The return also chaned. 
Storage and Host will be returnd.
