### PR TITLE
Order uplink ports by uplink name

### DIFF
--- a/plugins/modules/vmware_dvs_host.py
+++ b/plugins/modules/vmware_dvs_host.py
@@ -300,7 +300,7 @@ class VMwareDvsHost(PyVmomi):
                         switch_uplink_ports[name].append(port.key)
                         lag_uplinks.append(port.key)
 
-        for port in ports:
+        for port in sorted(ports, key=lambda port: port.config.name):
             if port.key in self.uplink_portgroup.portKeys and port.key not in lag_uplinks:
                 switch_uplink_ports['non_lag'].append(port.key)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When attaching pNics to Distributed Virtual Switches, the vSphere administrator may expect the pNic to be attached to the host uplinks in order.   For example, vmnic0 to "Uplink 1", vmnic1 to "Uplink 2" and so on.  

The current behavior of the module attaches the first pNic to the first uplink port that it finds for the host, which might not be the first uplink for the host by name.

This change simply sorts the fetched uplink ports for the host by the name of the port.  The the vmnics will the be attached in the expected order.

Fixes #1242  and #1070
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_dvs_host

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
