### PR TITLE
[WIP] fix(vmware_guest): parameter not correct nicsettings:adapter:ip

### DIFF
--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -2104,9 +2104,9 @@ class PyVmomiHelper(PyVmomi):
                 self.content.customFieldsManager.SetField(entity=vm_obj, key=key_id, value=kv['value'])
                 self.change_detected = True
 
-    def valid_hostname(hostname):
+    def valid_hostname(self, hostname):
         # Remove all characters except alphanumeric and minus which is allowed by RFC 952
-			  return re.sub(r"[^a-zA-Z0-9\-]", "", hostname)
+        return re.sub(r"[^a-zA-Z0-9\-]", "", hostname)
 
     def customize_vm(self, vm_obj):
 
@@ -2127,7 +2127,7 @@ class PyVmomiHelper(PyVmomi):
                     spec_adapter_counter += 1
                 if 'name' in self.params and self.params['name']:
                     temp_spec.spec.identity.hostName = vim.vm.customization.FixedName()
-                    temp_spec.spec.identity.hostName.name = valid_hostname(self.params['name'])
+                    temp_spec.spec.identity.hostName.name = self.valid_hostname(self.params['name'])
                 else:
                     self.module.fail_json(msg="Name of the virtual machine not defined, please set 'name' parameter")
                 self.customspec = temp_spec.spec
@@ -2282,7 +2282,7 @@ class PyVmomiHelper(PyVmomi):
             else:
                 hostname = default_name.split('.')[0]
 
-            ident.hostName.name = valid_hostname(hostname)
+            ident.hostName.name = self.valid_hostname(hostname)
 
             # List of supported time zones for different vSphere versions in Linux/Unix systems
             # https://kb.vmware.com/s/article/2145518

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -2124,6 +2124,8 @@ class PyVmomiHelper(PyVmomi):
                         guest_map.adapter.ip = vim.vm.customization.FixedIp()
                         guest_map.adapter.ip.ipAddress = str(self.params['networks'][spec_adapter_counter]['ip'])
                         guest_map.adapter.subnetMask = str(self.params['networks'][spec_adapter_counter]['netmask'])
+                    if 'gateway' in self.params['networks'][spec_adapter_counter]:
+                        guest_map.adapter.gateway = str(self.params['networks'][spec_adapter_counter]['gateway'])
                     spec_adapter_counter += 1
                 if 'name' in self.params and self.params['name']:
                     temp_spec.spec.identity.hostName = vim.vm.customization.FixedName()


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Usage of Customization Spec, when configured to `prompt user` for Network settings, caused error `Failed to create a virtual machine: A specified parameter was not correct: nicsettings:adapter:ip`.

This fix ensure IP Address, Subnet Mask and Hostname will be set based on parameter `networks` and `name` if parameter `customization_spec` is used.

Based on not merged PR https://github.com/ansible/ansible/pull/61329/
Fixes https://github.com/ansible-collections/community.vmware/issues/599
Fixes https://github.com/ansible/ansible/issues/55560
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_guest

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
