### PR TITLE
Fix sanity tests

### DIFF
--- a/plugins/inventory/vmware_host_inventory.py
+++ b/plugins/inventory/vmware_host_inventory.py
@@ -118,6 +118,7 @@ DOCUMENTATION = r"""
             - Key name is based on snake case of a vim type name; e.g C(host_system) correspond to C(vim.HostSystem)
             required: False
             type: list
+            elements: dict
             default: []
         with_path:
             description:

--- a/plugins/inventory/vmware_host_inventory.py
+++ b/plugins/inventory/vmware_host_inventory.py
@@ -76,6 +76,7 @@ DOCUMENTATION = r"""
             - Ignores template if resulted in an empty string or None value.
             - You can use property specified in I(properties) as variables in the template.
             type: list
+            elements: string
             default: ['name']
         properties:
             description:
@@ -89,6 +90,7 @@ DOCUMENTATION = r"""
             - Use C(all) to populate all the properties of the virtual machine.
               The value C(all) is time consuming operation, do not use unless required absolutely.
             type: list
+            elements: string
             default: [ 'name', 'customValue', 'summary.runtime.powerState' ]
         with_nested_properties:
             description:

--- a/plugins/inventory/vmware_vm_inventory.py
+++ b/plugins/inventory/vmware_vm_inventory.py
@@ -90,6 +90,7 @@ DOCUMENTATION = r'''
             - Please refer more VMware guest attributes which can be used as properties
               U(https://github.com/ansible/ansible/blob/devel/docs/docsite/rst/scenario_guides/vmware_scenarios/vmware_inventory_vm_attributes.rst)
             type: list
+            elements: string
             default: [ 'name', 'config.cpuHotAddEnabled', 'config.cpuHotRemoveEnabled',
                        'config.instanceUuid', 'config.hardware.numCPU', 'config.template',
                        'config.name', 'config.uuid', 'guest.hostName', 'guest.ipAddress',

--- a/plugins/inventory/vmware_vm_inventory.py
+++ b/plugins/inventory/vmware_vm_inventory.py
@@ -74,6 +74,7 @@ DOCUMENTATION = r'''
             - Ignores template if resulted in an empty string or None value.
             - You can use property specified in I(properties) as variables in the template.
             type: list
+            elements: string
             default: ['config.name + "_" + config.uuid']
         properties:
             description:
@@ -126,6 +127,7 @@ DOCUMENTATION = r'''
             - See  L(VIM Types,https://pubs.vmware.com/vi-sdk/visdk250/ReferenceGuide/index-mo_types.html)
             required: False
             type: list
+            elements: dict
             default: []
         with_path:
             description:

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -8,7 +8,6 @@ plugins/modules/vca_fw.py validate-modules:undocumented-parameter # deprecated
 plugins/modules/vca_nat.py validate-modules:doc-default-does-not-match-spec # deprecated
 plugins/modules/vca_nat.py validate-modules:doc-missing-type # deprecated
 plugins/modules/vca_nat.py validate-modules:doc-required-mismatch # deprecated
-plugins/modules/vca_nat.py validate-modules:no-default-for-required-parameter # deprecated
 plugins/modules/vca_nat.py validate-modules:parameter-list-no-elements # deprecated
 plugins/modules/vca_nat.py validate-modules:parameter-type-not-in-doc # deprecated
 plugins/modules/vca_nat.py validate-modules:undocumented-parameter # deprecated

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -8,6 +8,7 @@ plugins/modules/vca_fw.py validate-modules:undocumented-parameter # deprecated
 plugins/modules/vca_nat.py validate-modules:doc-default-does-not-match-spec # deprecated
 plugins/modules/vca_nat.py validate-modules:doc-missing-type # deprecated
 plugins/modules/vca_nat.py validate-modules:doc-required-mismatch # deprecated
+plugins/modules/vca_nat.py validate-modules:no-default-for-required-parameter # deprecated
 plugins/modules/vca_nat.py validate-modules:parameter-list-no-elements # deprecated
 plugins/modules/vca_nat.py validate-modules:parameter-type-not-in-doc # deprecated
 plugins/modules/vca_nat.py validate-modules:undocumented-parameter # deprecated

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -1,6 +1,7 @@
 plugins/modules/vca_fw.py validate-modules:doc-default-does-not-match-spec # deprecated
 plugins/modules/vca_fw.py validate-modules:doc-missing-type # deprecated
 plugins/modules/vca_fw.py validate-modules:doc-required-mismatch # deprecated
+plugins/modules/vca_fw.py validate-modules:no-default-for-required-parameter # deprecated
 plugins/modules/vca_fw.py validate-modules:parameter-list-no-elements # deprecated
 plugins/modules/vca_fw.py validate-modules:parameter-type-not-in-doc # deprecated
 plugins/modules/vca_fw.py validate-modules:undocumented-parameter # deprecated

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -1,7 +1,6 @@
 plugins/modules/vca_fw.py validate-modules:doc-default-does-not-match-spec # deprecated
 plugins/modules/vca_fw.py validate-modules:doc-missing-type # deprecated
 plugins/modules/vca_fw.py validate-modules:doc-required-mismatch # deprecated
-plugins/modules/vca_fw.py validate-modules:no-default-for-required-parameter # deprecated
 plugins/modules/vca_fw.py validate-modules:parameter-list-no-elements # deprecated
 plugins/modules/vca_fw.py validate-modules:parameter-type-not-in-doc # deprecated
 plugins/modules/vca_fw.py validate-modules:undocumented-parameter # deprecated

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,0 +1,20 @@
+plugins/modules/vca_fw.py validate-modules:doc-default-does-not-match-spec # deprecated
+plugins/modules/vca_fw.py validate-modules:doc-missing-type # deprecated
+plugins/modules/vca_fw.py validate-modules:doc-required-mismatch # deprecated
+plugins/modules/vca_fw.py validate-modules:no-default-for-required-parameter # deprecated
+plugins/modules/vca_fw.py validate-modules:parameter-list-no-elements # deprecated
+plugins/modules/vca_fw.py validate-modules:parameter-type-not-in-doc # deprecated
+plugins/modules/vca_fw.py validate-modules:undocumented-parameter # deprecated
+plugins/modules/vca_nat.py validate-modules:doc-default-does-not-match-spec # deprecated
+plugins/modules/vca_nat.py validate-modules:doc-missing-type # deprecated
+plugins/modules/vca_nat.py validate-modules:doc-required-mismatch # deprecated
+plugins/modules/vca_nat.py validate-modules:no-default-for-required-parameter # deprecated
+plugins/modules/vca_nat.py validate-modules:parameter-list-no-elements # deprecated
+plugins/modules/vca_nat.py validate-modules:parameter-type-not-in-doc # deprecated
+plugins/modules/vca_nat.py validate-modules:undocumented-parameter # deprecated
+plugins/modules/vca_vapp.py validate-modules:doc-default-does-not-match-spec # deprecated
+plugins/modules/vca_vapp.py validate-modules:doc-missing-type # deprecated
+plugins/modules/vca_vapp.py validate-modules:doc-required-mismatch # deprecated
+plugins/modules/vca_vapp.py validate-modules:undocumented-parameter # deprecated
+plugins/modules/vmware_deploy_ovf.py use-argspec-type-path!skip
+plugins/modules/vmware_host_acceptance.py validate-modules:parameter-state-invalid-choice


### PR DESCRIPTION
##### SUMMARY
With ansible-core 2.13, there are some new sanity tests that fail (https://github.com/ansible/ansible/pull/77268?).

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
vca_fw
vca_nat
vmware_host_inventory
vmware_vm_inventory

##### ADDITIONAL INFORMATION
As an example, see [this CI run](https://github.com/ansible-collections/community.vmware/pull/1192#issuecomment-1079617226).

_edit:_ Now that the ansible-core `stable-2.13` branch exists and the `devel` branch has been updated to `2.14.0.dev0`, I've also added `tests/sanity/ignore-2.14.txt`. ansible-collections/news-for-maintainers#13