### PR TITLE
vmware_guest_powerstate: Use FQCN in examples

### DIFF
--- a/plugins/modules/vmware_guest_powerstate.py
+++ b/plugins/modules/vmware_guest_powerstate.py
@@ -186,7 +186,7 @@ EXAMPLES = r"""
 - name: Automatically answer if a question locked a virtual machine
   block:
     - name: Power on a virtual machine without the answer param
-      vmware_guest_powerstate:
+      community.vmware.vmware_guest_powerstate:
         hostname: "{{ esxi_hostname }}"
         username: "{{ esxi_username }}"
         password: "{{ esxi_password }}"
@@ -196,7 +196,7 @@ EXAMPLES = r"""
         state: powered-on
   rescue:
     - name: Power on a virtual machine with the answer param
-      vmware_guest_powerstate:
+      community.vmware.vmware_guest_powerstate:
         hostname: "{{ esxi_hostname }}"
         username: "{{ esxi_username }}"
         password: "{{ esxi_password }}"


### PR DESCRIPTION
##### SUMMARY
The examples in `vmware_guest_powerstate` should use the FQCN.

Fixes #1253

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
vmware_guest_powerstate

##### ADDITIONAL INFORMATION
