### PR TITLE
vmware_datastore_cluster: Add automation levels, vm overrides, Space and IO Load Balance Config

### DIFF
--- a/changelogs/fragments/1278-vmware_datastore_cluster.yaml
+++ b/changelogs/fragments/1278-vmware_datastore_cluster.yaml
@@ -1,3 +1,3 @@
 minor_changes:
-  - vmware_datastore_cluster - Add automation levels, Space Load Balance Config and vm overrides to this module.
+  - vmware_datastore_cluster - Add automation levels, vm overrides, Space and IO Load Balance Config to this module.
     (https://github.com/ansible-collections/community.vmware/pull/1278)

--- a/changelogs/fragments/1278-vmware_datastore_cluster.yaml
+++ b/changelogs/fragments/1278-vmware_datastore_cluster.yaml
@@ -1,3 +1,3 @@
 minor_changes:
-  - vmware_datastore_cluster - Add automation levels and vm overrides to this module.
+  - vmware_datastore_cluster - Add automation levels, Space Load Balance Config and vm overrides to this module.
     (https://github.com/ansible-collections/community.vmware/pull/1278)

--- a/changelogs/fragments/1278-vmware_datastore_cluster.yaml
+++ b/changelogs/fragments/1278-vmware_datastore_cluster.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+  - vmware_datastore_cluster: Add automation levels and vm overrides to this module.
+    (https://github.com/ansible-collections/community.vmware/pull/1278)

--- a/changelogs/fragments/1278-vmware_datastore_cluster.yaml
+++ b/changelogs/fragments/1278-vmware_datastore_cluster.yaml
@@ -1,3 +1,3 @@
 minor_changes:
-  - vmware_datastore_cluster: Add automation levels and vm overrides to this module.
+  - vmware_datastore_cluster - Add automation levels and vm overrides to this module.
     (https://github.com/ansible-collections/community.vmware/pull/1278)

--- a/plugins/modules/vmware_datastore_cluster.py
+++ b/plugins/modules/vmware_datastore_cluster.py
@@ -206,7 +206,7 @@ EXAMPLES = r'''
     state: present
   delegate_to: localhost
 
- - name: Create/Modify datastore cluster with enable SDRS
+- name: Create/Modify datastore cluster with enable SDRS
   community.vmware.vmware_datastore_cluster:
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'

--- a/plugins/modules/vmware_datastore_cluster.py
+++ b/plugins/modules/vmware_datastore_cluster.py
@@ -165,17 +165,16 @@ options:
                 required: True
             keep_vmdks_together:
                 description:
-                - None: No override
-                - True: This VM should have its virtual disks on the same datastore.
-                - False: This VM should not have its virtual disks on the same datastore.
-                default: None
+                - None (Not set) -> No override
+                - True -> This VM should have its virtual disks on the same datastore.
+                - False -> This VM should not have its virtual disks on the same datastore.
                 type: bool
             automation_level:
                 description:
-                - none: No override
-                - automated: Placement and migration recommendations run automatically.
-                - manual: Placement and migration recommendations are displayed, but do not run until you manually apply the recommendation.
-                - disabled: vCenter Server does not migrate the virtual machine or provide migration recommendations for it.
+                - none (or Not set) -> No override
+                - automated -> Placement and migration recommendations run automatically.
+                - manual -> Placement and migration recommendations are displayed, but do not run until you manually apply the recommendation.
+                - disabled -> vCenter Server does not migrate the virtual machine or provide migration recommendations for it.
                 choices: [none, automated, manual, disabled]
                 default: none
                 type: str
@@ -216,11 +215,11 @@ EXAMPLES = r'''
     datastore_cluster_name: '{{ datastore_cluster_name }}'
     enable_sdrs: True
     state: present
-    space_balance_automation_level=manual
-    io_balance_automation_level=manual
-    rule_enforcement_automation_level=manual
-    policy_enforcement_automation_level=manual
-    vm_evacuation_automation_level=manual
+    space_balance_automation_level: manual
+    io_balance_automation_level: manual
+    rule_enforcement_automation_level: manual
+    policy_enforcement_automation_level: manual
+    vm_evacuation_automation_level: manual
   delegate_to: localhost
 
 - name: Create datastore cluster using folder
@@ -427,7 +426,7 @@ class VMwareDatastoreClusterManager(PyVmomi):
                             if foundVm.behavior != None:
                                 vmConfigSpec.info.behavior = None
                                 changed = True
-                            if foundVm.enabled != False:
+                            if foundVm.enabled is not False:
                                 vmConfigSpec.info.enabled = False
                                 changed = True
                         elif vm['automation_level'] == "none":

--- a/plugins/modules/vmware_datastore_cluster.py
+++ b/plugins/modules/vmware_datastore_cluster.py
@@ -160,6 +160,7 @@ options:
         - When you use an aggressive setting (Small value), Storage DRS corrects small imbalances if possible.
         - When you use a conservative setting (Big value), Storage DRS produces recommendations only when the imbalance across datastores is very high.
         - Value between 1 and 100.
+        type: int
     vm_overrides:
         description:
         - Override the datastore cluster-wide automation level for individual virtual machines.

--- a/plugins/modules/vmware_datastore_cluster.py
+++ b/plugins/modules/vmware_datastore_cluster.py
@@ -191,7 +191,6 @@ options:
                 type: str
 extends_documentation_fragment:
 - community.vmware.vmware.documentation
-
 '''
 
 EXAMPLES = r'''
@@ -205,7 +204,6 @@ EXAMPLES = r'''
     enable_sdrs: True
     state: present
   delegate_to: localhost
-
 - name: Create/Modify datastore cluster with enable SDRS
   community.vmware.vmware_datastore_cluster:
     hostname: '{{ vcenter_hostname }}'
@@ -216,7 +214,6 @@ EXAMPLES = r'''
     enable_sdrs: True
     state: present
   delegate_to: localhost
-
 - name: Create/Modify datastore cluster with enable SDRS and set the automation levels to manual
   community.vmware.vmware_datastore_cluster:
     hostname: '{{ vcenter_hostname }}'
@@ -232,7 +229,6 @@ EXAMPLES = r'''
     policy_enforcement_automation_level: manual
     vm_evacuation_automation_level: manual
   delegate_to: localhost
-
 - name: Create datastore cluster using folder
   community.vmware.vmware_datastore_cluster:
     hostname: '{{ vcenter_hostname }}'
@@ -242,7 +238,6 @@ EXAMPLES = r'''
     datastore_cluster_name: '{{ datastore_cluster_name }}'
     state: present
   delegate_to: localhost
-
 - name: Delete datastore cluster
   community.vmware.vmware_datastore_cluster:
     hostname: '{{ vcenter_hostname }}'
@@ -294,7 +289,6 @@ class VMwareDatastoreClusterManager(PyVmomi):
     def ensure(self):
         """
         Manage internal state of datastore cluster
-
         """
         results = dict(changed=False, result='')
         state = self.module.params.get('state')
@@ -367,25 +361,25 @@ class VMwareDatastoreClusterManager(PyVmomi):
                     change = True
 
                 # Automation overrides
-                if space_balance_automation_level != currentPodConfig.automationOverrides.spaceLoadBalanceAutomationMode:
+                if currentPodConfig.automationOverrides.spaceLoadBalanceAutomationMode is None or space_balance_automation_level != currentPodConfig.automationOverrides.spaceLoadBalanceAutomationMode:
                     sdrs_spec.podConfigSpec.automationOverrides.spaceLoadBalanceAutomationMode = space_balance_automation_level \
                         if space_balance_automation_level != "cluster_settings" else None
                     results['result'] += " Changed Space balance automation level to '%s'." % space_balance_automation_level
                     change = True
 
-                if rule_enforcement_automation_level != currentPodConfig.automationOverrides.ruleEnforcementAutomationMode:
+                if currentPodConfig.automationOverrides.ruleEnforcementAutomationMode is None or rule_enforcement_automation_level != currentPodConfig.automationOverrides.ruleEnforcementAutomationMode:
                     sdrs_spec.podConfigSpec.automationOverrides.ruleEnforcementAutomationMode = rule_enforcement_automation_level \
                         if rule_enforcement_automation_level != "cluster_settings" else None
                     results['result'] += " Changed Rule enforcement automation level to '%s'." % rule_enforcement_automation_level
                     change = True
 
-                if policy_enforcement_automation_level != currentPodConfig.automationOverrides.policyEnforcementAutomationMode:
+                if currentPodConfig.automationOverrides.policyEnforcementAutomationMode is None or policy_enforcement_automation_level != currentPodConfig.automationOverrides.policyEnforcementAutomationMode:
                     sdrs_spec.podConfigSpec.automationOverrides.policyEnforcementAutomationMode = policy_enforcement_automation_level \
                         if policy_enforcement_automation_level != "cluster_settings" else None
                     results['result'] += " Changed Policy enforcement automation level to '%s'." % policy_enforcement_automation_level
                     change = True
 
-                if vm_evacuation_automation_level != currentPodConfig.automationOverrides.vmEvacuationAutomationMode:
+                if currentPodConfig.automationOverrides.vmEvacuationAutomationMode is None or vm_evacuation_automation_level != currentPodConfig.automationOverrides.vmEvacuationAutomationMode:
                     sdrs_spec.podConfigSpec.automationOverrides.vmEvacuationAutomationMode = vm_evacuation_automation_level \
                         if vm_evacuation_automation_level != "cluster_settings" else None
                     results['result'] += " Changed VM evacuation automation level to '%s'." % vm_evacuation_automation_level

--- a/plugins/modules/vmware_datastore_cluster.py
+++ b/plugins/modules/vmware_datastore_cluster.py
@@ -392,7 +392,7 @@ class VMwareDatastoreClusterManager(PyVmomi):
 
                 # Space Load Balance Config
                 if min_space_utilization_difference is not None and \
-                    min_space_utilization_difference != currentPodConfig.spaceLoadBalanceConfig.minSpaceUtilizationDifference:
+                        min_space_utilization_difference != currentPodConfig.spaceLoadBalanceConfig.minSpaceUtilizationDifference:
                     sdrs_spec.podConfigSpec.spaceLoadBalanceConfig.minSpaceUtilizationDifference = min_space_utilization_difference
                     results['result'] += " Changed minimum space utilization difference to '%s' prozent." % min_space_utilization_difference
                     change = True

--- a/plugins/modules/vmware_datastore_cluster.py
+++ b/plugins/modules/vmware_datastore_cluster.py
@@ -302,7 +302,7 @@ class VMwareDatastoreClusterManager(PyVmomi):
 
         # Space Load Balance Config
         min_space_utilization_difference = self.params.get('min_space_utilization_difference')
-        if min_space_utilization_difference is not None and min_space_utilization_difference not in range(1,51):  # between 1% and 50%
+        if min_space_utilization_difference is not None and min_space_utilization_difference not in range(1, 51):  # between 1% and 50%
             self.module.fail_json(msg="min_space_utilization_difference can only be set between 1% and 50%.")
         free_space_threshold_gb = self.params.get('free_space_threshold_gb')
         space_utilization_threshold = self.params.get('space_utilization_threshold')
@@ -351,7 +351,7 @@ class VMwareDatastoreClusterManager(PyVmomi):
                 # Automation overrides
                 if space_balance_automation_level != currentPodConfig.automationOverrides.spaceLoadBalanceAutomationMode:
                     sdrs_spec.podConfigSpec.automationOverrides.spaceLoadBalanceAutomationMode = space_balance_automation_level \
-                            if space_balance_automation_level != "cluster_settings" else None
+                        if space_balance_automation_level != "cluster_settings" else None
                     results['result'] += " Changed Space balance automation level to '%s'." % space_balance_automation_level
                     change = True
 
@@ -423,24 +423,24 @@ class VMwareDatastoreClusterManager(PyVmomi):
 
                     if foundVm:
                         if vm['automation_level'] == "disabled":
-                            if foundVm.behavior != None:
+                            if foundVm.behavior is not None:
                                 vmConfigSpec.info.behavior = None
                                 changed = True
                             if foundVm.enabled is not False:
                                 vmConfigSpec.info.enabled = False
                                 changed = True
                         elif vm['automation_level'] == "none":
-                            if foundVm.behavior != None:
+                            if foundVm.behavior is not None:
                                 vmConfigSpec.info.behavior = None
                                 changed = True
-                            if foundVm.enabled != None:
+                            if foundVm.enabled is not None:
                                 vmConfigSpec.info.enabled = None
                                 changed = True
                         else:
-                            if foundVm.behavior != None:
+                            if foundVm.behavior is not None:
                                 vmConfigSpec.info.behavior = vm['automation_level']
                                 changed = True
-                            if foundVm.enabled != False:
+                            if foundVm.enabled is not False:
                                 vmConfigSpec.info.enabled = False
                                 changed = True
 
@@ -587,7 +587,7 @@ def main():
             enable_io_loadbalance=dict(type='bool', default=False, required=False),
             loadbalance_interval=dict(type='int', default=480, required=False),
             # Automation overrides
-            space_balance_automation_level=dict(type='str', choices=['automated', 'manual','cluster_settings'], default='automated'),
+            space_balance_automation_level=dict(type='str', choices=['automated', 'manual', 'cluster_settings'], default='automated'),
             io_balance_automation_level=dict(type='str', choices=['automated', 'manual', 'cluster_settings'], default='automated'),
             rule_enforcement_automation_level=dict(type='str', choices=['automated', 'manual', 'cluster_settings'], default='automated'),
             policy_enforcement_automation_level=dict(type='str', choices=['automated', 'manual', 'cluster_settings'], default='automated'),
@@ -597,11 +597,10 @@ def main():
             free_space_threshold_gb=dict(type='int', required=False),
             space_utilization_threshold=dict(type='int', required=False),
             # VM overrides
-            vm_overrides=dict(type='list', elements='dict', required=False,
-                options=dict(
+            vm_overrides=dict(type='list', elements='dict', required=False, options=dict(
                     vm_name=dict(type='str', required=True),
                     keep_vmdks_together=dict(type='bool', default=None),
-                    automation_level=dict(type='str', choices=['none','automated', 'manual', 'disabled'], default='none')
+                    automation_level=dict(type='str', choices=['none', 'automated', 'manual', 'disabled'], default='none')
                 )
             )
         )

--- a/plugins/modules/vmware_datastore_cluster.py
+++ b/plugins/modules/vmware_datastore_cluster.py
@@ -381,7 +381,7 @@ class VMwareDatastoreClusterManager(PyVmomi):
                             if foundVm.behavior is not None:
                                 vmConfigSpec.info.behavior = None
                                 changed = True
-                            if foundVm.enabled != False:
+                            if foundVm.enabled is not False:
                                 vmConfigSpec.info.enabled = False
                                 changed = True
                         elif vm['automation_level'] == "none":
@@ -536,10 +536,9 @@ def main():
             policy_enforcement_automation_level=dict(type='str', choices=['automated', 'manual', 'cluster_settings'], default='automated'),
             vm_evacuation_automation_level=dict(type='str', choices=['automated', 'manual', 'cluster_settings'], default='automated'),
             vm_overrides=dict(type='list', elements='dict', required=False, options=dict(
-                    vm_name=dict(type='str', required=True),
-                    keep_vmdks_together=dict(type='bool', default=None),
-                    automation_level=dict(type='str', choices=['none', 'automated', 'manual', 'disabled'], default='none')
-                )
+                vm_name=dict(type='str', required=True),
+                keep_vmdks_together=dict(type='bool', default=None),
+                automation_level=dict(type='str', choices=['none', 'automated', 'manual', 'disabled'], default='none'))
             )
         )
     )

--- a/plugins/modules/vmware_datastore_cluster.py
+++ b/plugins/modules/vmware_datastore_cluster.py
@@ -598,10 +598,9 @@ def main():
             space_utilization_threshold=dict(type='int', required=False),
             # VM overrides
             vm_overrides=dict(type='list', elements='dict', required=False, options=dict(
-                    vm_name=dict(type='str', required=True),
-                    keep_vmdks_together=dict(type='bool', default=None),
-                    automation_level=dict(type='str', choices=['none', 'automated', 'manual', 'disabled'], default='none')
-                )
+                vm_name=dict(type='str', required=True),
+                keep_vmdks_together=dict(type='bool', default=None),
+                automation_level=dict(type='str', choices=['none', 'automated', 'manual', 'disabled'], default='none'))
             )
         )
     )

--- a/plugins/modules/vmware_datastore_cluster.py
+++ b/plugins/modules/vmware_datastore_cluster.py
@@ -381,7 +381,7 @@ class VMwareDatastoreClusterManager(PyVmomi):
                             if foundVm.behavior is not None:
                                 vmConfigSpec.info.behavior = None
                                 changed = True
-                            if foundVm.enabled != False:
+                            if foundVm.enabled is not False:
                                 vmConfigSpec.info.enabled = False
                                 changed = True
                         elif vm['automation_level'] == "none":

--- a/plugins/modules/vmware_datastore_cluster.py
+++ b/plugins/modules/vmware_datastore_cluster.py
@@ -381,7 +381,7 @@ class VMwareDatastoreClusterManager(PyVmomi):
                             if foundVm.behavior is not None:
                                 vmConfigSpec.info.behavior = None
                                 changed = True
-                            if foundVm.enabled is not False:
+                            if foundVm.enabled != False:
                                 vmConfigSpec.info.enabled = False
                                 changed = True
                         elif vm['automation_level'] == "none":
@@ -538,8 +538,8 @@ def main():
             vm_overrides=dict(type='list', elements='dict', required=False, options=dict(
                 vm_name=dict(type='str', required=True),
                 keep_vmdks_together=dict(type='bool', default=None),
-                automation_level=dict(type='str', choices=['none', 'automated', 'manual', 'disabled'], default='none'))
-            )
+                automation_level=dict(type='str', choices=['none', 'automated', 'manual', 'disabled'], default='none')
+            ))
         )
     )
     module = AnsibleModule(

--- a/plugins/modules/vmware_datastore_cluster.py
+++ b/plugins/modules/vmware_datastore_cluster.py
@@ -338,6 +338,7 @@ class VMwareDatastoreClusterManager(PyVmomi):
                 sdrs_spec.podConfigSpec = vim.storageDrs.PodConfigSpec()
                 sdrs_spec.podConfigSpec.automationOverrides = currentPodConfig.automationOverrides
                 sdrs_spec.podConfigSpec.spaceLoadBalanceConfig = currentPodConfig.spaceLoadBalanceConfig
+                sdrs_spec.podConfigSpec.ioLoadBalanceConfig = currentPodConfig.ioLoadBalanceConfig
                 sdrs_spec.podConfigSpec.enabled = enable_sdrs  # Must be set because automationOverrides not be written otherwise
 
                 if enable_sdrs != currentPodConfig.enabled:
@@ -417,12 +418,12 @@ class VMwareDatastoreClusterManager(PyVmomi):
 
                 if io_latency_threshold is not None and io_latency_threshold != currentPodConfig.ioLoadBalanceConfig.ioLatencyThreshold:
                     sdrs_spec.podConfigSpec.ioLoadBalanceConfig.ioLatencyThreshold = io_latency_threshold
-                    results['result'] += " Changed Space threshold to '%s'." % io_latency_threshold
+                    results['result'] += " Changed latency_ threshold to '%s'." % io_latency_threshold
                     change = True
 
                 if io_load_imbalanc_threshold is not None and io_load_imbalanc_threshold != currentPodConfig.ioLoadBalanceConfig.ioLoadImbalanceThreshold:
                     sdrs_spec.podConfigSpec.ioLoadBalanceConfig.ioLoadImbalanceThreshold = io_load_imbalanc_threshold
-                    results['result'] += " Changed Space threshold to '%s'." % io_load_imbalanc_threshold
+                    results['result'] += " Changed load imbalance threshold to '%s'." % io_load_imbalanc_threshold
                     change = True
 
                 # Storage DRS VM Config

--- a/plugins/modules/vmware_datastore_cluster.py
+++ b/plugins/modules/vmware_datastore_cluster.py
@@ -143,17 +143,16 @@ options:
                 required: True
             keep_vmdks_together:
                 description:
-                - None: No override
-                - True: This VM should have its virtual disks on the same datastore.
-                - False: This VM should not have its virtual disks on the same datastore.
-                default: None
+                - None (Not set) -> No override
+                - True -> This VM should have its virtual disks on the same datastore.
+                - False -> This VM should not have its virtual disks on the same datastore.
                 type: bool
             automation_level:
                 description:
-                - none: No override
-                - automated: Placement and migration recommendations run automatically.
-                - manual: Placement and migration recommendations are displayed, but do not run until you manually apply the recommendation.
-                - disabled: vCenter Server does not migrate the virtual machine or provide migration recommendations for it.
+                - none (or Not set) -> No override
+                - automated -> Placement and migration recommendations run automatically.
+                - manual -> Placement and migration recommendations are displayed, but do not run until you manually apply the recommendation.
+                - disabled -> vCenter Server does not migrate the virtual machine or provide migration recommendations for it.
                 choices: [none, automated, manual, disabled]
                 default: none
                 type: str
@@ -198,11 +197,11 @@ EXAMPLES = r'''
     datastore_cluster_name: '{{ datastore_cluster_name }}'
     enable_sdrs: True
     state: present
-    space_balance_automation_level=manual
-    io_balance_automation_level=manual
-    rule_enforcement_automation_level=manual
-    policy_enforcement_automation_level=manual
-    vm_evacuation_automation_level=manual
+    space_balance_automation_level: manual
+    io_balance_automation_level: manual
+    rule_enforcement_automation_level: manual
+    policy_enforcement_automation_level: manual
+    vm_evacuation_automation_level: manual
   delegate_to: localhost
 
 - name: Create datastore cluster using folder

--- a/plugins/modules/vmware_datastore_cluster.py
+++ b/plugins/modules/vmware_datastore_cluster.py
@@ -378,24 +378,24 @@ class VMwareDatastoreClusterManager(PyVmomi):
 
                     if foundVm:
                         if vm['automation_level'] == "disabled":
-                            if foundVm.behavior != None:
+                            if foundVm.behavior is not None:
                                 vmConfigSpec.info.behavior = None
                                 changed = True
                             if foundVm.enabled != False:
                                 vmConfigSpec.info.enabled = False
                                 changed = True
                         elif vm['automation_level'] == "none":
-                            if foundVm.behavior != None:
+                            if foundVm.behavior is not None:
                                 vmConfigSpec.info.behavior = None
                                 changed = True
-                            if foundVm.enabled != None:
+                            if foundVm.enabled is not None:
                                 vmConfigSpec.info.enabled = None
                                 changed = True
                         else:
-                            if foundVm.behavior != None:
+                            if foundVm.behavior is not None:
                                 vmConfigSpec.info.behavior = vm['automation_level']
                                 changed = True
-                            if foundVm.enabled != False:
+                            if foundVm.enabled is not False:
                                 vmConfigSpec.info.enabled = False
                                 changed = True
 
@@ -535,11 +535,10 @@ def main():
             rule_enforcement_automation_level=dict(type='str', choices=['automated', 'manual', 'cluster_settings'], default='automated'),
             policy_enforcement_automation_level=dict(type='str', choices=['automated', 'manual', 'cluster_settings'], default='automated'),
             vm_evacuation_automation_level=dict(type='str', choices=['automated', 'manual', 'cluster_settings'], default='automated'),
-            vm_overrides=dict(type='list', elements='dict', required=False,
-                options=dict(
+            vm_overrides=dict(type='list', elements='dict', required=False, options=dict(
                     vm_name=dict(type='str', required=True),
                     keep_vmdks_together=dict(type='bool', default=None),
-                    automation_level=dict(type='str', choices=['none', 'automated', 'manual', 'disabled'],default='none')
+                    automation_level=dict(type='str', choices=['none', 'automated', 'manual', 'disabled'], default='none')
                 )
             )
         )


### PR DESCRIPTION
##### SUMMARY
Add the automation levels:
- Space balance
- I/O balance
- Rule enforcement
- Vm evacuation

and add Space Load Balance Config

and the possibility to override the datastore cluster settings (keep vmdks together and automation level) for Virtual Machines.

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
vmware_datastore_cluster

##### ADDITIONAL INFORMATION

