### PR TITLE
vmware_guest_powerstate: Ignore trailing slash in folder parameter

### DIFF
--- a/changelogs/fragments/1238-vmware_guest_powerstate-ignore_trailing_slash_in_folder.yml
+++ b/changelogs/fragments/1238-vmware_guest_powerstate-ignore_trailing_slash_in_folder.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_guest_powerstate - Ignore trailing `/` in `folder` parameter like other guest modules do (https://github.com/ansible-collections/community.vmware/issues/1238).

--- a/plugins/modules/vmware_guest_powerstate.py
+++ b/plugins/modules/vmware_guest_powerstate.py
@@ -261,8 +261,8 @@ def main():
 
     result = dict(changed=False,)
 
-    # if module.params['folder']:
-    #     module.params['folder'] = module.params['folder'].rstrip('/')
+    if module.params['folder']:
+        module.params['folder'] = module.params['folder'].rstrip('/')
 
     pyv = PyVmomi(module)
 

--- a/plugins/modules/vmware_guest_powerstate.py
+++ b/plugins/modules/vmware_guest_powerstate.py
@@ -261,6 +261,9 @@ def main():
 
     result = dict(changed=False,)
 
+    # if module.params['folder']:
+    #     module.params['folder'] = module.params['folder'].rstrip('/')
+
     pyv = PyVmomi(module)
 
     # Check if the VM exists before continuing

--- a/tests/integration/targets/vmware_guest_powerstate/tasks/main.yml
+++ b/tests/integration/targets/vmware_guest_powerstate/tasks/main.yml
@@ -40,7 +40,7 @@
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     name: test_vm1
-    folder: '{{ f0 }}'
+    folder: '{{ f0 }}/' # Test with a trailing / because of issue 1238
     state: powered-off
   register: poweroff_d1_c1_f0
 


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1478

##### SUMMARY
Other `vmware_guest` modules ignore a trailing `/` in the folder parameter, but `vmware_guest_powerstate ` doesn't. For a consistent user experience, it should do this also.

Fixes #1238

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_guest_powerstate

##### ADDITIONAL INFORMATION
As an example, see `vmware_guest_snapshot`:

https://github.com/ansible-collections/community.vmware/blob/fd46931c7f38effa7d0a28844a1e94ea395374ff/plugins/modules/vmware_guest_snapshot.py#L437-L440
