### PR TITLE
added support for configuring heartbeat on datastores

### DIFF
--- a/plugins/modules/vmware_cluster_ha.py
+++ b/plugins/modules/vmware_cluster_ha.py
@@ -302,11 +302,11 @@ class VMwareCluster(PyVmomi):
         self.heartbeat_datastores = []
         self.heartbeat_datastores_changed = False
         if self.datastore_names:
-          for ds_name in self.datastore_names:
-              ds_found = find_datastore_by_name(self.content, ds_name)
-              if ds_found is None:
-                  self.module.fail_json(msg="Failed to find datastore %s" % ds_name)
-              self.heartbeat_datastores.append(ds_found)
+            for ds_name in self.datastore_names:
+                ds_found = find_datastore_by_name(self.content, ds_name)
+                if ds_found is None:
+                    self.module.fail_json(msg="Failed to find datastore %s" % ds_name)
+                self.heartbeat_datastores.append(ds_found)
 
     def get_failover_hosts(self):
         """
@@ -462,12 +462,12 @@ class VMwareCluster(PyVmomi):
                 cluster_config_spec.dasConfig.vmMonitoring = self.params.get('ha_vm_monitoring')
 
                 if self.heartbeat_datastores_changed:
-                  cluster_config_spec.dasConfig.heartbeatDatastore = self.heartbeat_datastores
+                    cluster_config_spec.dasConfig.heartbeatDatastore = self.heartbeat_datastores
 
                 if self.heartbeat_datastore_selection_policy_changed:
-                  cluster_config_spec.dasConfig.hBDatastoreCandidatePolicy = self.heartbeat_datastore_selection_policy
-                  if self.heartbeat_datastore_selection_policy == "allFeasibleDs":
-                    cluster_config_spec.dasConfig.heartbeatDatastore = []
+                    cluster_config_spec.dasConfig.hBDatastoreCandidatePolicy = self.heartbeat_datastore_selection_policy
+                    if self.heartbeat_datastore_selection_policy == "allFeasibleDs":
+                        cluster_config_spec.dasConfig.heartbeatDatastore = []
 
                 if self.changed_advanced_settings:
                     cluster_config_spec.dasConfig.option = self.changed_advanced_settings
@@ -537,8 +537,8 @@ def main():
                           default='warning'),
         heartbeat_datastores=dict(type='list', elements='str', default=[]),
         heartbeat_datastore_selection_policy=dict(type='str',
-                                                 choices=['allFeasibleDs', 'allFeasibleDsWithUserPreference', 'userSelectedDs'],
-                                                 default='allFeasibleDsWithUserPreference'),
+                                                  choices=['allFeasibleDs', 'allFeasibleDsWithUserPreference', 'userSelectedDs'],
+                                                  default='allFeasibleDsWithUserPreference'),
     ))
 
     module = AnsibleModule(

--- a/tests/integration/targets/vmware_cluster_ha/tasks/main.yml
+++ b/tests/integration/targets/vmware_cluster_ha/tasks/main.yml
@@ -303,7 +303,7 @@
         - change_heartbeat_selection_policy_result_again.changed
 
   - name: Change Heartbeat Datastores
-    vmware_cluster_ha: &change_heartbeat_selection_policy
+    vmware_cluster_ha: &change_heartbeat_datastore
       validate_certs: false
       hostname: "{{ vcenter_hostname }}"
       username: "{{ vcenter_username }}"
@@ -322,7 +322,7 @@
 
   - name: Change Heartbeat Datastores Again
     vmware_cluster_ha:
-      <<: *change_heartbeat_selection_policy
+      <<: *change_heartbeat_datastore
       heartbeat_datastore_selection_policy: allFeasibleDs
       heartbeat_datastores: []
     register: change_heartbeat_datastores_result_again

--- a/tests/integration/targets/vmware_cluster_ha/tasks/main.yml
+++ b/tests/integration/targets/vmware_cluster_ha/tasks/main.yml
@@ -277,6 +277,60 @@
       that:
         - not change_includeFTcomplianceChecks_again.changed
 
+  - name: Change Heartbeat Datastore Selection Policy
+    vmware_cluster_ha: &change_heartbeat_selection_policy
+      validate_certs: false
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      datacenter_name: "{{ dc1 }}"
+      cluster_name: test_cluster_ha
+      heartbeat_datastore_selection_policy: allFeasibleDs
+    register: change_heartbeat_selection_policy_result
+
+  - assert:
+      that:
+        - change_heartbeat_selection_policy_result.changed
+
+  - name: Change Heartbeat Datastore Selection Policy
+    vmware_cluster_ha:
+      <<: *change_heartbeat_selection_policy
+      heartbeat_datastore_selection_policy: allFeasibleDsWithUserPreference
+    register: change_heartbeat_selection_policy_result_again
+
+  - assert:
+      that:
+        - change_heartbeat_selection_policy_result_again.changed
+
+  - name: Change Heartbeat Datastores
+    vmware_cluster_ha: &change_heartbeat_selection_policy
+      validate_certs: false
+      hostname: "{{ vcenter_hostname }}"
+      username: "{{ vcenter_username }}"
+      password: "{{ vcenter_password }}"
+      datacenter_name: "{{ dc1 }}"
+      cluster_name: test_cluster_ha
+      heartbeat_datastore_selection_policy: allFeasibleDsWithUserPreference
+      heartbeat_datastores:
+        - "{{ ro_datastore }}"
+        - "{{ rw_datastore }}"
+    register: change_heartbeat_datastores_result
+
+  - assert:
+      that:
+        - change_heartbeat_datastores_result.changed
+
+  - name: Change Heartbeat Datastores Again
+    vmware_cluster_ha:
+      <<: *change_heartbeat_selection_policy
+      heartbeat_datastore_selection_policy: allFeasibleDs
+      heartbeat_datastores: []
+    register: change_heartbeat_datastores_result_again
+
+  - assert:
+      that:
+        - change_heartbeat_datastores_result_again.changed
+
   - name: Disable HA
     vmware_cluster_ha:
       validate_certs: false

--- a/tests/integration/targets/vmware_cluster_ha/tasks/main.yml
+++ b/tests/integration/targets/vmware_cluster_ha/tasks/main.yml
@@ -4,6 +4,9 @@
 
 - import_role:
     name: prepare_vmware_tests
+  vars:
+    setup_attach_host: true
+    setup_datastore: true
 
 # Setup: Create test cluster
 - name: Create test cluster
@@ -284,7 +287,7 @@
       username: "{{ vcenter_username }}"
       password: "{{ vcenter_password }}"
       datacenter_name: "{{ dc1 }}"
-      cluster_name: test_cluster_ha
+      cluster_name: "{{ ccr1 }}"
       heartbeat_datastore_selection_policy: allFeasibleDs
     register: change_heartbeat_selection_policy_result
 
@@ -295,7 +298,9 @@
   - name: Change Heartbeat Datastore Selection Policy
     vmware_cluster_ha:
       <<: *change_heartbeat_selection_policy
-      heartbeat_datastore_selection_policy: allFeasibleDsWithUserPreference
+      heartbeat_datastore_selection_policy: userSelectedDs
+      heartbeat_datastores:
+        - "{{ rw_datastore }}"
     register: change_heartbeat_selection_policy_result_again
 
   - assert:
@@ -309,11 +314,11 @@
       username: "{{ vcenter_username }}"
       password: "{{ vcenter_password }}"
       datacenter_name: "{{ dc1 }}"
-      cluster_name: test_cluster_ha
+      cluster_name: "{{ ccr1 }}"
       heartbeat_datastore_selection_policy: allFeasibleDsWithUserPreference
       heartbeat_datastores:
-        - "{{ ro_datastore }}"
         - "{{ rw_datastore }}"
+        - "{{ ro_datastore }}"
     register: change_heartbeat_datastores_result
 
   - assert:


### PR DESCRIPTION
##### SUMMARY
This adds support for configuring the datastores to heartbeat as well as setting the heartbeat datastore selection policy.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_cluster_ha
