### PR TITLE
vmware_dvs_portgroup: Fix idempotency

### DIFF
--- a/changelogs/fragments/1286-vmware_dvs_portgroup-fix_idempotency.yml
+++ b/changelogs/fragments/1286-vmware_dvs_portgroup-fix_idempotency.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_dvs_portgroup - Fix an idempotency issue when `num_ports` is unset (https://github.com/ansible-collections/community.vmware/pull/1286).

--- a/plugins/modules/vmware_dvs_portgroup.py
+++ b/plugins/modules/vmware_dvs_portgroup.py
@@ -464,7 +464,8 @@ class VMwareDvsPortgroup(PyVmomi):
         # Basic config
         config.name = self.module.params['portgroup_name']
 
-        config.numPorts = self.module.params['num_ports']
+        if self.module.params['num_ports'] is not None:
+            config.numPorts = self.module.params['num_ports']
 
         # Default port config
         config.defaultPortConfig = vim.dvs.VmwareDistributedVirtualSwitch.VmwarePortConfigPolicy()
@@ -709,7 +710,8 @@ class VMwareDvsPortgroup(PyVmomi):
             return 'absent'
 
         # Check config
-        if self.dvs_portgroup.config.numPorts != self.module.params['num_ports']:
+        if self.module.params['num_ports'] is not None and \
+                self.dvs_portgroup.config.numPorts != self.module.params['num_ports']:
             return 'update'
 
         # Default port config


### PR DESCRIPTION
##### SUMMARY
The parameter `num_ports` in `vmware_dvs_portgroup` is not required, but always used to test if a change is needed. This code will always trigger a change since `None` is different from the current number of ports, which is an integer:

https://github.com/ansible-collections/community.vmware/blob/5c15e5504d76ae36e35ccf79bef0d586f72f5c33/plugins/modules/vmware_dvs_portgroup.py#L711-L713

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_dvs_portgroup

##### ADDITIONAL INFORMATION
