### PR TITLE
Update vmware_vswitch to support policies

### DIFF
--- a/changelogs/fragments/1298-vmware_vswitch-add_network_policy_support.yml
+++ b/changelogs/fragments/1298-vmware_vswitch-add_network_policy_support.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - vmware_vswitch - Add support to manage security, teaming and traffic shaping policies on vSwitches.
+    (https://github.com/ansible-collections/community.vmware/pull/1298).

--- a/plugins/modules/vmware_vswitch.py
+++ b/plugins/modules/vmware_vswitch.py
@@ -311,6 +311,7 @@ class VMwareHostVirtualSwitch(PyVmomi):
         """
         changed = False
         results = dict(changed=False, result="No change in vSwitch '%s'" % self.switch)
+        spec = self.vss.spec
         vswitch_pnic_info = self.available_vswitches[self.switch]
         pnic_add = []
         for desired_pnic in self.nics:
@@ -339,14 +340,13 @@ class VMwareHostVirtualSwitch(PyVmomi):
                 results['msg'] = "vSwitch '%s' would be updated" %  self.switch
             else:
                 try:
-                    vss_spec = vim.host.VirtualSwitch.Specification()
                     if all_nics:
-                        vss_spec.bridge = vim.host.VirtualSwitch.BondBridge(nicDevice=all_nics)
-                    vss_spec.numPorts = self.number_of_ports
-                    vss_spec.mtu = self.mtu
+                        spec.bridge = vim.host.VirtualSwitch.BondBridge(nicDevice=all_nics)
+                    spec.numPorts = self.number_of_ports
+                    spec.mtu = self.mtu
 
                     self.network_mgr.UpdateVirtualSwitch(vswitchName=self.switch,
-                                                        spec=vss_spec)
+                                                        spec=spec)
                     results['result'] = "vSwitch '%s' is updated successfully" % self.switch
                 except vim.fault.ResourceInUse as resource_used:
                     self.module.fail_json(msg="Failed to update vSwitch '%s' as physical network adapter"

--- a/plugins/modules/vmware_vswitch.py
+++ b/plugins/modules/vmware_vswitch.py
@@ -479,7 +479,6 @@ class VMwareHostVirtualSwitch(PyVmomi):
                 if nicOrder.standbyNic != [i for i in nicOrder.standbyNic if i in self.nics]:
                     nicOrder.standbyNic = [i for i in nicOrder.standbyNic if i in self.nics]
                     changed = True
-                return changed
 
         # Check Security Policy
         if self.update_security_policy(spec, results):

--- a/plugins/modules/vmware_vswitch.py
+++ b/plugins/modules/vmware_vswitch.py
@@ -331,8 +331,14 @@ class VMwareHostVirtualSwitch(PyVmomi):
                 for pnic in pnic_remove:
                     all_nics.remove(pnic)
 
-        if vswitch_pnic_info['mtu'] != self.mtu or \
-                vswitch_pnic_info['num_ports'] != self.number_of_ports:
+        # Check MTU
+        if self.vss.mtu != self.mtu:
+            spec.mtu = self.mtu
+            changed = True
+
+        # Check Number of Ports
+        if  spec.numPorts != self.number_of_ports:
+            spec.numPorts = self.number_of_ports
             changed = True
 
         if changed:
@@ -342,8 +348,6 @@ class VMwareHostVirtualSwitch(PyVmomi):
                 try:
                     if all_nics:
                         spec.bridge = vim.host.VirtualSwitch.BondBridge(nicDevice=all_nics)
-                    spec.numPorts = self.number_of_ports
-                    spec.mtu = self.mtu
 
                     self.network_mgr.UpdateVirtualSwitch(vswitchName=self.switch,
                                                         spec=spec)

--- a/plugins/modules/vmware_vswitch.py
+++ b/plugins/modules/vmware_vswitch.py
@@ -464,7 +464,10 @@ class VMwareHostVirtualSwitch(PyVmomi):
 
         # Check nics
         if set(map(lambda n: n.rsplit('-', 1)[1], self.vss.pnic)) != set(self.nics):
-            spec.bridge = vim.host.VirtualSwitch.BondBridge(nicDevice=self.nics)
+            if self.nics:
+                spec.bridge = vim.host.VirtualSwitch.BondBridge(nicDevice=self.nics)
+            else:
+                spec.bridge = None
             changed = True
 
             # Remove nics from policy if no teaming policy is set and nic is removed

--- a/plugins/modules/vmware_vswitch.py
+++ b/plugins/modules/vmware_vswitch.py
@@ -467,6 +467,17 @@ class VMwareHostVirtualSwitch(PyVmomi):
             spec.bridge = vim.host.VirtualSwitch.BondBridge(nicDevice=self.nics)
             changed = True
 
+            # Remove nics from policy if no teaming policy is set and nic is removed
+            if not self.params['teaming']:
+                nicOrder = spec.policy.nicTeaming.nicOrder
+                if nicOrder.activeNic != [i for i in nicOrder.activeNic if i in self.nics]:
+                    nicOrder.activeNic = [i for i in nicOrder.activeNic if i in self.nics]
+                    changed = True
+                if nicOrder.standbyNic != [i for i in nicOrder.standbyNic if i in self.nics]:
+                    nicOrder.standbyNic = [i for i in nicOrder.standbyNic if i in self.nics]
+                    changed = True
+                return changed
+
         # Check Security Policy
         if self.update_security_policy(spec, results):
             changed = True

--- a/plugins/modules/vmware_vswitch.py
+++ b/plugins/modules/vmware_vswitch.py
@@ -345,13 +345,13 @@ class VMwareHostVirtualSwitch(PyVmomi):
         vss_spec.mtu = self.mtu
         if self.nics:
             vss_spec.bridge = vim.host.VirtualSwitch.BondBridge(nicDevice=self.nics)
-        
+
         if self.module.check_mode:
-            results['msg'] = "vSwitch '%s' would be created" %  self.switch
+            results['msg'] = "vSwitch '%s' would be created" % self.switch
         else:
             try:
                 self.network_mgr.AddVirtualSwitch(vswitchName=self.switch,
-                                                spec=vss_spec)
+                                                  spec=vss_spec)
 
                 changed = False
                 spec = self.find_vswitch_by_name(self.host_system, self.switch).spec
@@ -375,29 +375,29 @@ class VMwareHostVirtualSwitch(PyVmomi):
                 results['result'] = "vSwitch '%s' is created successfully" % self.switch
             except vim.fault.AlreadyExists as already_exists:
                 results['result'] = "vSwitch with name %s already exists: %s" % (self.switch,
-                                                                                to_native(already_exists.msg))
+                                                                                 to_native(already_exists.msg))
             except vim.fault.ResourceInUse as resource_used:
                 self.module.fail_json(msg="Failed to add vSwitch '%s' as physical network adapter"
-                                        " being bridged is already in use: %s" % (self.switch,
+                                          " being bridged is already in use: %s" % (self.switch,
                                                                                     to_native(resource_used.msg)))
             except vim.fault.HostConfigFault as host_config_fault:
                 self.module.fail_json(msg="Failed to add vSwitch '%s' due to host"
-                                        " configuration fault : %s" % (self.switch,
-                                                                        to_native(host_config_fault.msg)))
+                                          " configuration fault : %s" % (self.switch,
+                                                                         to_native(host_config_fault.msg)))
             except vmodl.fault.InvalidArgument as invalid_argument:
                 self.module.fail_json(msg="Failed to add vSwitch '%s', this can be due to either of following :"
-                                        " 1. vSwitch Name exceeds the maximum allowed length,"
-                                        " 2. Number of ports specified falls out of valid range,"
-                                        " 3. Network policy is invalid,"
-                                        " 4. Beacon configuration is invalid : %s" % (self.switch,
+                                          " 1. vSwitch Name exceeds the maximum allowed length,"
+                                          " 2. Number of ports specified falls out of valid range,"
+                                          " 3. Network policy is invalid,"
+                                          " 4. Beacon configuration is invalid : %s" % (self.switch,
                                                                                         to_native(invalid_argument.msg)))
             except vmodl.fault.SystemError as system_error:
                 self.module.fail_json(msg="Failed to add vSwitch '%s' due to : %s" % (self.switch,
-                                                                                    to_native(system_error.msg)))
+                                                                                      to_native(system_error.msg)))
             except Exception as generic_exc:
                 self.module.fail_json(msg="Failed to add vSwitch '%s' due to"
-                                        " generic exception : %s" % (self.switch,
-                                                                    to_native(generic_exc)))
+                                          " generic exception : %s" % (self.switch,
+                                                                       to_native(generic_exc)))
 
         results['changed'] = True
 
@@ -417,7 +417,7 @@ class VMwareHostVirtualSwitch(PyVmomi):
         results = dict(changed=False, result="")
 
         if self.module.check_mode:
-            results['msg'] = "vSwitch '%s' would be removed" %  self.vss.name
+            results['msg'] = "vSwitch '%s' would be removed" % self.vss.name
         else:
             try:
                 self.host_system.configManager.networkSystem.RemoveVirtualSwitch(self.vss.name)
@@ -427,19 +427,19 @@ class VMwareHostVirtualSwitch(PyVmomi):
                                                                         to_native(vswitch_not_found.msg))
             except vim.fault.ResourceInUse as vswitch_in_use:
                 self.module.fail_json(msg="Failed to remove vSwitch '%s' as vSwitch"
-                                        " is used by several virtual"
-                                        " network adapters: %s" % (self.switch,
-                                                                    to_native(vswitch_in_use.msg)))
+                                          " is used by several virtual"
+                                          " network adapters: %s" % (self.switch,
+                                                                     to_native(vswitch_in_use.msg)))
             except vim.fault.HostConfigFault as host_config_fault:
                 self.module.fail_json(msg="Failed to remove vSwitch '%s' due to host"
-                                        " configuration fault : %s" % (self.switch,
-                                                                        to_native(host_config_fault.msg)))
+                                          " configuration fault : %s" % (self.switch,
+                                                                         to_native(host_config_fault.msg)))
             except Exception as generic_exc:
                 self.module.fail_json(msg="Failed to remove vSwitch '%s' due to generic"
-                                        " exception : %s" % (self.switch,
-                                                            to_native(generic_exc)))
-        
-        results['changed'] = True    
+                                          " exception : %s" % (self.switch,
+                                                               to_native(generic_exc)))
+
+        results['changed'] = True
 
         self.module.exit_json(**results)
 
@@ -458,12 +458,12 @@ class VMwareHostVirtualSwitch(PyVmomi):
             changed = True
 
         # Check Number of Ports
-        if  spec.numPorts != self.number_of_ports:
+        if spec.numPorts != self.number_of_ports:
             spec.numPorts = self.number_of_ports
             changed = True
 
         # Check nics
-        if set(map(lambda n: n.rsplit('-',1)[1] ,self.vss.pnic)) != set(self.nics):
+        if set(map(lambda n: n.rsplit('-', 1)[1], self.vss.pnic)) != set(self.nics):
             spec.bridge = vim.host.VirtualSwitch.BondBridge(nicDevice=self.nics)
             changed = True
 
@@ -492,44 +492,44 @@ class VMwareHostVirtualSwitch(PyVmomi):
 
         if changed:
             if self.module.check_mode:
-                results['msg'] = "vSwitch '%s' would be updated" %  self.switch
+                results['msg'] = "vSwitch '%s' would be updated" % self.switch
             else:
                 try:
                     self.network_mgr.UpdateVirtualSwitch(vswitchName=self.switch,
-                                                        spec=spec)
+                                                         spec=spec)
                     results['result'] = "vSwitch '%s' is updated successfully" % self.switch
                 except vim.fault.ResourceInUse as resource_used:
                     self.module.fail_json(msg="Failed to update vSwitch '%s' as physical network adapter"
-                                            " being bridged is already in use: %s" % (self.switch,
+                                              " being bridged is already in use: %s" % (self.switch,
                                                                                         to_native(resource_used.msg)))
                 except vim.fault.NotFound as not_found:
                     self.module.fail_json(msg="Failed to update vSwitch with name '%s'"
-                                            " as it does not exists: %s" % (self.switch,
-                                                                            to_native(not_found.msg)))
+                                              " as it does not exists: %s" % (self.switch,
+                                                                              to_native(not_found.msg)))
 
                 except vim.fault.HostConfigFault as host_config_fault:
                     self.module.fail_json(msg="Failed to update vSwitch '%s' due to host"
-                                            " configuration fault : %s" % (self.switch,
-                                                                            to_native(host_config_fault.msg)))
+                                              " configuration fault : %s" % (self.switch,
+                                                                             to_native(host_config_fault.msg)))
                 except vmodl.fault.InvalidArgument as invalid_argument:
                     self.module.fail_json(msg="Failed to update vSwitch '%s', this can be due to either of following :"
-                                            " 1. vSwitch Name exceeds the maximum allowed length,"
-                                            " 2. Number of ports specified falls out of valid range,"
-                                            " 3. Network policy is invalid,"
-                                            " 4. Beacon configuration is invalid : %s" % (self.switch,
+                                              " 1. vSwitch Name exceeds the maximum allowed length,"
+                                              " 2. Number of ports specified falls out of valid range,"
+                                              " 3. Network policy is invalid,"
+                                              " 4. Beacon configuration is invalid : %s" % (self.switch,
                                                                                             to_native(invalid_argument.msg)))
                 except vmodl.fault.SystemError as system_error:
                     self.module.fail_json(msg="Failed to update vSwitch '%s' due to : %s" % (self.switch,
-                                                                                            to_native(system_error.msg)))
+                                                                                             to_native(system_error.msg)))
                 except vmodl.fault.NotSupported as not_supported:
                     self.module.fail_json(msg="Failed to update vSwitch '%s' as network adapter teaming policy"
-                                            " is set but is not supported : %s" % (self.switch,
-                                                                                    to_native(not_supported.msg)))
+                                              " is set but is not supported : %s" % (self.switch,
+                                                                                     to_native(not_supported.msg)))
                 except Exception as generic_exc:
                     self.module.fail_json(msg="Failed to update vSwitch '%s' due to"
-                                            " generic exception : %s" % (self.switch,
-                                                                        to_native(generic_exc)))
-                                                                        
+                                              " generic exception : %s" % (self.switch,
+                                                                           to_native(generic_exc)))
+
             results['changed'] = True
 
         self.module.exit_json(**results)
@@ -579,7 +579,7 @@ class VMwareHostVirtualSwitch(PyVmomi):
         sec_promiscuous_mode = self.params['security'].get('promiscuous_mode')
         sec_forged_transmits = self.params['security'].get('forged_transmits')
         sec_mac_changes = self.params['security'].get('mac_changes')
-        
+
         if sec_promiscuous_mode is not None:
             results['sec_promiscuous_mode'] = sec_promiscuous_mode
             if security_policy.allowPromiscuous is not sec_promiscuous_mode:
@@ -649,7 +649,7 @@ class VMwareHostVirtualSwitch(PyVmomi):
                 changed = True
 
         # Check teaming failover order
-        if teaming_failover_order_active is not None :
+        if teaming_failover_order_active is not None:
             results['failover_active'] = teaming_failover_order_active
             if teaming_policy.nicOrder.activeNic != teaming_failover_order_active:
                 results['failover_active_previous'] = teaming_policy.nicOrder.activeNic
@@ -732,6 +732,7 @@ class VMwareHostVirtualSwitch(PyVmomi):
 
         return changed
 
+
 def main():
     argument_spec = vmware_argument_spec()
     argument_spec.update(dict(
@@ -739,7 +740,7 @@ def main():
         nics=dict(type='list', aliases=['nic_name'], default=[], elements='str'),
         number_of_ports=dict(type='int', default=128),
         mtu=dict(type='int', default=1500),
-        state=dict(type='str', default='present', choices=['absent', 'present'])),
+        state=dict(type='str', default='present', choices=['absent', 'present']),
         esxi_hostname=dict(type='str', aliases=['host']),
         security=dict(
             type='dict',
@@ -784,7 +785,7 @@ def main():
                 burst_size=dict(type='int'),
             ),
         ),
-    )
+    ))
 
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True)

--- a/plugins/modules/vmware_vswitch.py
+++ b/plugins/modules/vmware_vswitch.py
@@ -265,6 +265,18 @@ class VMwareHostVirtualSwitch(PyVmomi):
             try:
                 self.network_mgr.AddVirtualSwitch(vswitchName=self.switch,
                                                 spec=vss_spec)
+
+                changed = False
+                spec = self.find_vswitch_by_name(self.host_system, self.switch).spec
+
+                # Check Security Policy
+                if self.update_security_policy(spec, results):
+                    changed = True
+
+                if changed:
+                    self.network_mgr.UpdateVirtualSwitch(vswitchName=self.switch,
+                                                         spec=spec)
+
                 results['result'] = "vSwitch '%s' is created successfully" % self.switch
             except vim.fault.AlreadyExists as already_exists:
                 results['result'] = "vSwitch with name %s already exists: %s" % (self.switch,

--- a/plugins/modules/vmware_vswitch.py
+++ b/plugins/modules/vmware_vswitch.py
@@ -309,6 +309,7 @@ class VMwareHostVirtualSwitch(PyVmomi):
         Update vSwitch
 
         """
+        changed = False
         results = dict(changed=False, result="No change in vSwitch '%s'" % self.switch)
         vswitch_pnic_info = self.available_vswitches[self.switch]
         pnic_add = []
@@ -319,11 +320,10 @@ class VMwareHostVirtualSwitch(PyVmomi):
         for configured_pnic in vswitch_pnic_info['pnic']:
             if configured_pnic not in self.nics:
                 pnic_remove.append(configured_pnic)
-        diff = False
         # Update all nics
         all_nics = vswitch_pnic_info['pnic']
         if pnic_add or pnic_remove:
-            diff = True
+            changed = True
             if pnic_add:
                 all_nics += pnic_add
             if pnic_remove:
@@ -332,9 +332,9 @@ class VMwareHostVirtualSwitch(PyVmomi):
 
         if vswitch_pnic_info['mtu'] != self.mtu or \
                 vswitch_pnic_info['num_ports'] != self.number_of_ports:
-            diff = True
+            changed = True
 
-        if diff:
+        if changed:
             if self.module.check_mode:
                 results['msg'] = "vSwitch '%s' would be updated" %  self.switch
             else:

--- a/plugins/modules/vmware_vswitch.py
+++ b/plugins/modules/vmware_vswitch.py
@@ -67,6 +67,7 @@ options:
       portgroup such as promiscuous mode, where guest adapter listens
       to all the packets, MAC address changes and forged transmits.
     - Dict which configures the different security values for portgroup.
+    version_added: '2.4.0'
     suboptions:
       promiscuous_mode:
         type: bool
@@ -83,6 +84,7 @@ options:
   teaming:
     description:
       - Dictionary which configures the different teaming values for portgroup.
+    version_added: '2.4.0'
     suboptions:
       load_balancing:
         type: str
@@ -118,6 +120,7 @@ options:
   traffic_shaping:
     description:
       - Dictionary which configures traffic shaping for the switch.
+    version_added: '2.4.0'
     suboptions:
       enabled:
         type: bool

--- a/tests/integration/targets/vmware_vswitch/tasks/main.yml
+++ b/tests/integration/targets/vmware_vswitch/tasks/main.yml
@@ -109,6 +109,115 @@
   - assert:
       that:
       - add_vswitch_with_host_system is changed
+
+  - name: Add a vSwitch with a network policy
+    vmware_vswitch:
+      hostname: '{{ esxi1 }}'
+      username: '{{ esxi_user }}'
+      password: '{{ esxi_password }}'
+      validate_certs: false
+      switch: vmswitch_0001
+      nics:
+        - vmnic1
+        - vmnic2
+      state: present
+      security:
+        forged_transmits: true
+        mac_changes: true
+      traffic_shaping:
+        enabled: true
+        average_bandwidth: 100000
+        peak_bandwidth: 100000
+        burst_size: 102400
+      teaming:
+        active_adapters: vmnic1
+        standby_adapters: vmnic2
+    register: add_vswitch_netpol_run
+  - debug: var=add_vswitch_netpol_run
+  - assert:
+      that:
+      - add_vswitch_netpol_run.changed == true
+
+  - name: Add a vSwitch with a network policy again (idempotency check)
+    vmware_vswitch:
+      hostname: '{{ esxi1 }}'
+      username: '{{ esxi_user }}'
+      password: '{{ esxi_password }}'
+      validate_certs: false
+      switch: vmswitch_0001
+      nics:
+        - vmnic1
+        - vmnic2
+      state: present
+      security:
+        forged_transmits: true
+        mac_changes: true
+      traffic_shaping:
+        enabled: true
+        average_bandwidth: 100000
+        peak_bandwidth: 100000
+        burst_size: 102400
+      teaming:
+        active_adapters: vmnic1
+        standby_adapters: vmnic2
+    register: add_vswitch_netpol_again_run
+  - assert:
+      that:
+      - add_vswitch_netpol_again_run.changed == false
+
+  - name: Update a vSwitch network policy
+    vmware_vswitch:
+      hostname: '{{ esxi1 }}'
+      username: '{{ esxi_user }}'
+      password: '{{ esxi_password }}'
+      validate_certs: false
+      switch: vmswitch_0001
+      nics:
+        - vmnic1
+        - vmnic2
+      state: present
+      security:
+        forged_transmits: false
+        mac_changes: true
+      traffic_shaping:
+        enabled: false
+      teaming:
+        active_adapters:
+          - vmnic1
+          - vmnic2
+        standby_adapters: []
+    register: update_vswitch_netpol_run
+  - debug: var=update_vswitch_netpol_run
+  - assert:
+      that:
+      - update_vswitch_netpol_run.changed == true
+
+  - name: Update a vSwitch network policy again (idempotency check)
+    vmware_vswitch:
+      hostname: '{{ esxi1 }}'
+      username: '{{ esxi_user }}'
+      password: '{{ esxi_password }}'
+      validate_certs: false
+      switch: vmswitch_0001
+      nics:
+        - vmnic1
+        - vmnic2
+      state: present
+      security:
+        forged_transmits: false
+        mac_changes: true
+      traffic_shaping:
+        enabled: false
+      teaming:
+        active_adapters:
+          - vmnic1
+          - vmnic2
+        standby_adapters: []
+    register: update_vswitch_netpol_again_run
+  - assert:
+      that:
+      - update_vswitch_netpol_again_run.changed == false
+
   always:
   - include_tasks: teardown.yml
 


### PR DESCRIPTION
##### SUMMARY
Add support to manage `security`, `teaming` and `traffic shaping` policies on vSwitches.

 - Fixes #1035 
   - Fixes #1034 
   - Fixes #203 

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_vswitch

##### ADDITIONAL INFORMATION

