### PR TITLE
vmware_host_powerstate: Do not execute the tasks in check mode

### DIFF
--- a/changelogs/fragments/1299-vnware_host_powerstate-fix_check_mode.yml
+++ b/changelogs/fragments/1299-vnware_host_powerstate-fix_check_mode.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  -  vmware_host_powerstate - Do not execute the powerstate changes in check_mode. (https://github.com/ansible-collections/community.vmware/pull/1299).

--- a/plugins/modules/vmware_host_powerstate.py
+++ b/plugins/modules/vmware_host_powerstate.py
@@ -152,16 +152,20 @@ class VmwareHostPowerManager(PyVmomi):
                                           " does not have capability to standby supported." % (host.name, state))
 
             if state == 'reboot-host':
-                task = host.RebootHost_Task(force)
+                if not self.module.check_mode:
+                    task = host.RebootHost_Task(force)
                 verb = "reboot '%s'" % host.name
             elif state == 'shutdown-host':
-                task = host.ShutdownHost_Task(force)
+                if not self.module.check_mode:
+                    task = host.ShutdownHost_Task(force)
                 verb = "shutdown '%s'" % host.name
             elif state == 'power-down-to-standby':
-                task = host.PowerDownHostToStandBy_Task(timeout, force)
+                if not self.module.check_mode:
+                    task = host.PowerDownHostToStandBy_Task(timeout, force)
                 verb = "power down '%s' to standby" % host.name
             elif state == 'power-up-from-standby':
-                task = host.PowerUpHostFromStandBy_Task(timeout)
+                if not self.module.check_mode:
+                    task = host.PowerUpHostFromStandBy_Task(timeout)
                 verb = "power up '%s' from standby" % host.name
 
             if not self.module.check_mode:


### PR DESCRIPTION
##### SUMMARY
In `check_mode`the module  `vmware_host_powerstate` triggers the reboot, etc.

It just does not wait for the task to be done.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_host_powerstate

##### ADDITIONAL INFORMATION

