### PR TITLE
[WIP] vmware_host_powerstate: Wait for host to reboot.

### DIFF
--- a/plugins/modules/vmware_host_powerstate.py
+++ b/plugins/modules/vmware_host_powerstate.py
@@ -107,6 +107,8 @@ result:
     }
 '''
 
+import time
+import datetime
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, vmware_argument_spec, wait_for_task, TaskError
 from ansible.module_utils._text import to_native
@@ -176,6 +178,21 @@ class VmwareHostPowerManager(PyVmomi):
                         results['result'][host.name]['msg'] = verb
                     else:
                         results['result'][host.name]['error'] = result
+
+                    if state == 'reboot-host':
+                        timeout = datetime.timedelta(seconds=timeout)
+
+                        start_at = datetime.datetime.now()
+                        old_boot_time = host.runtime.bootTime
+
+                        while start_at + timeout > datetime.datetime.now():
+                            if host.runtime.bootTime and old_boot_time < host.runtime.bootTime:
+                                break
+                            time.sleep(5)
+
+                        if not host.runtime.bootTime or old_boot_time >= host.runtime.bootTime:
+                            self.module.fail_json(msg="Current host system '%s' has not rebooted successfully." % (host.name))
+
                 except TaskError as task_error:
                     self.module.fail_json(msg="Failed to %s as host system due to : %s" % (verb,
                                                                                            str(task_error)))


### PR DESCRIPTION
##### SUMMARY
When triggering a reboot of a host, ansible should wait for the host to reboot.

I am unsure if waiting for the reboot is always recommended, particularly as this is a change from what the module does now. Would it be preferred to add a new state `reboot-host-wait` or ad a new parameter `wait` to actively select this behavior?


##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_host_powerstate

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
