### PR TITLE
Prepare for distutils.version being removed in Python 3.12

### DIFF
--- a/changelogs/fragments/disutils.version.yml
+++ b/changelogs/fragments/disutils.version.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Various modules and plugins - use vendored version of ``distutils.version`` included in ansible-core 2.12 if available. This avoids breakage when ``distutils`` is removed from the standard library of Python 3.12. Note that ansible-core 2.11, ansible-base 2.10 and Ansible 2.9 are right now not compatible with Python 3.12, hence this fix does not target these ansible-core/-base/2.9 versions."

--- a/plugins/module_utils/version.py
+++ b/plugins/module_utils/version.py
@@ -17,3 +17,11 @@ except ImportError:
         from distutils.version import LooseVersion  # noqa: F401
     except ImportError as exc:
         raise_from(ImportError('To use this plugin or module with ansible-core < 2.11, you need to use Python < 3.12 with distutils.version present'), exc)
+
+try:
+    from ansible.module_utils.compat.version import StrictVersion  # noqa: F401
+except ImportError:
+    try:
+        from distutils.version import StrictVersion  # noqa: F401
+    except ImportError as exc:
+        raise_from(ImportError('To use this plugin or module with ansible-core < 2.11, you need to use Python < 3.12 with distutils.version present'), exc)

--- a/plugins/module_utils/vmware.py
+++ b/plugins/module_utils/vmware.py
@@ -17,7 +17,7 @@ import time
 import traceback
 import datetime
 from collections import OrderedDict
-from distutils.version import StrictVersion
+from ansible_collections.community.vmware.plugins.module_utils.version import StrictVersion
 from random import randint
 
 REQUESTS_IMP_ERR = None


### PR DESCRIPTION
##### SUMMARY
This is a follow-up PR to #1165 and replaces the use of `distutils.version.StrictVersion` with `ansible.module_utils.compat.version.StrictVersion`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/module_utils/version.py
plugins/module_utils/vmware.py

##### ADDITIONAL INFORMATION
distutils has been deprecated and will be removed from
Python's stdlib in Python 3.12 (see [PEP 632](https://python.org/dev/peps/pep-0632)).

Also, see [here](https://github.com/ansible-community/community-topics/issues/96#issuecomment-1116661339) and the following comments.