### PR TITLE
Add a documentation example for selecting a specific NIC

### DIFF
--- a/plugins/inventory/vmware_vm_inventory.py
+++ b/plugins/inventory/vmware_vm_inventory.py
@@ -340,6 +340,26 @@ EXAMPLES = r'''
       - 'guest.ipAddress'
       - 'guest.guestFamily'
       - 'guest.ipStack'
+
+# Select a specific IP address for use by ansible when multiple NICs are present on the VM
+    plugin: community.vmware.vmware_vm_inventory
+    strict: False
+    hostname: 10.65.223.31
+    username: administrator@vsphere.local
+    password: Esxi@123$%
+    validate_certs: False
+    compose:
+      # Set the IP address used by ansible to one that starts by 10.42. or 10.43.
+      ansible_host: >-
+        guest.net
+        | selectattr('ipAddress')
+        | map(attribute='ipAddress')
+        | flatten
+        | select('match', '^10.42.*|^10.43.*')
+        | list
+        | first
+    properties:
+      - guest.net
 '''
 
 from ansible.errors import AnsibleError, AnsibleParserError


### PR DESCRIPTION
##### SUMMARY
Add a documentation example for selecting a specific NIC when multiple NICs are attached to a VM

Fixes #1008

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
vmware_vm_inventory

