### PR TITLE
Add vmware_host_access_info and vmware_host_access_manager modules

### DIFF
--- a/plugins/modules/vmware_host_access_info.py
+++ b/plugins/modules/vmware_host_access_info.py
@@ -19,7 +19,7 @@ author:
 notes:
 - Tested on vSphere 7.0
 requirements:
-  - python >= 3.6
+- python >= 3.6
 - PyVmomi
 options:
   cluster_name:

--- a/plugins/modules/vmware_host_access_info.py
+++ b/plugins/modules/vmware_host_access_info.py
@@ -1,0 +1,140 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2022, Marius Rieder <marius.rieder@scs.ch>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = r'''
+---
+module: vmware_host_access_info
+short_description: Gathers info about an ESXi host's access configuration information
+description:
+- This module can be used to gather information about an ESXi host's access configuration information when ESXi hostname or Cluster name is given.
+author:
+  - Marius Rieder (@jiuka)
+notes:
+- Tested on vSphere 7.0
+requirements:
+  - python >= 3.6
+- PyVmomi
+options:
+  cluster_name:
+    description:
+    - Name of the cluster from which the ESXi host belong to.
+    - If C(esxi_hostname) is not given, this parameter is required.
+    type: str
+  esxi_hostname:
+    description:
+    - ESXi hostname to gather information from.
+    - If C(cluster_name) is not given, this parameter is required.
+    type: str
+extends_documentation_fragment:
+- community.vmware.vmware.documentation
+'''
+
+EXAMPLES = r'''
+- name: Gather access info about all ESXi Host in given Cluster
+  community.vmware.vmware_host_access_info:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    cluster_name: cluster_name
+  delegate_to: localhost
+
+- name: Gather access info about ESXi Host
+  community.vmware.vmware_host_access_info:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    esxi_hostname: '{{ esxi_hostname }}'
+  delegate_to: localhost
+'''
+
+RETURN = r'''
+hosts_access_info:
+    description: metadata about host's access configuration
+    returned: on success
+    type: dict
+    sample: {
+            "esxi_hostname_0001": {
+                "lockdown_mode": "disabled",
+                "lockdown_exceptions": [], 
+                "access": {
+                    "dcui": {"access": "admin", "group": false},
+                    "root": {"access": "admin", "group": false},
+                    "vpxuser": {"access": "admin", "group": false}
+                }
+            }
+        }
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.community.vmware.plugins.module_utils.vmware import vmware_argument_spec, PyVmomi
+
+
+class VmwareHostAccessInfo(PyVmomi):
+    LOCKDOWN_MODE_MAP = {
+        'lockdownDisabled': 'disabled',
+        'lockdownNormal': 'normal',
+        'lockdownStrict': 'strict'
+    }
+    ACCESS_MODE_MAP = {
+        'accessAdmin': 'admin',
+        'accessNoAccess': 'no-access',
+        'accessReadOnly': 'read-only',
+    }
+
+    def __init__(self, module):
+        super(VmwareHostAccessInfo, self).__init__(module)
+        cluster_name = self.params.get('cluster_name', None)
+        esxi_host_name = self.params.get('esxi_hostname', None)
+        self.hosts = self.get_all_host_objs(cluster_name=cluster_name, esxi_host_name=esxi_host_name)
+
+    def gather_host_access_controll_entries_info(self, access_mgr):
+        access = {}
+        for ace in access_mgr.RetrieveHostAccessControlEntries():
+            access[ace.principal] = dict(
+                access=self.ACCESS_MODE_MAP.get(ace.accessMode, ace.accessMode),
+                group=ace.group,
+            )
+        return access
+
+    def gather_host_access_info(self):
+        hosts_access_info = dict()
+        for host in self.hosts:
+            access_mgr = host.configManager.hostAccessManager
+
+            if access_mgr:
+                hosts_access_info[host.name] = dict(
+                    lockdown_mode=self.LOCKDOWN_MODE_MAP.get(access_mgr.lockdownMode, access_mgr.lockdownMode),
+                    lockdown_exceptions=[s for s in access_mgr.QueryLockdownExceptions()],
+                    access=self.gather_host_access_controll_entries_info(access_mgr)
+                )
+        return hosts_access_info
+
+
+def main():
+    argument_spec = vmware_argument_spec()
+    argument_spec.update(
+        cluster_name=dict(type='str', required=False),
+        esxi_hostname=dict(type='str', required=False),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        required_one_of=[
+            ['cluster_name', 'esxi_hostname'],
+        ],
+        supports_check_mode=True
+    )
+
+    vmware_host_access = VmwareHostAccessInfo(module)
+    module.exit_json(changed=False, hosts_access_info=vmware_host_access.gather_host_access_info())
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/vmware_host_access_info.py
+++ b/plugins/modules/vmware_host_access_info.py
@@ -62,7 +62,7 @@ hosts_access_info:
     sample: {
             "esxi_hostname_0001": {
                 "lockdown_mode": "disabled",
-                "lockdown_exceptions": [], 
+                "lockdown_exceptions": [],
                 "access": {
                     "dcui": {"access": "admin", "group": false},
                     "root": {"access": "admin", "group": false},

--- a/plugins/modules/vmware_host_access_manager.py
+++ b/plugins/modules/vmware_host_access_manager.py
@@ -1,0 +1,355 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2022, Marius Rieder <marius.rieder@scs.ch>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+module: vmware_host_access_manager
+short_description: Manage permissions and lockdown of ESXi hosts.
+author:
+  - Marius Rieder (@jiuka)
+description:
+  - This module can grant and revoke permissions on ESXi hosts.
+  - This module can add and remove users from the lockdown exception list on ESXi host.
+  - This module can set the lockdown mode on ESXi host.
+requirements:
+  - python >= 3.6
+  - PyVmomi
+version_added: '2.3.0'
+options:
+  esxi_hostname:
+    description:
+      - Name of the ESXi host that is managing the local user.
+    type: str
+    required: true
+  user_name:
+    description:
+      - Name of the local user to grant/revoke permissions of.
+    type: str
+    required: false
+  group_name:
+    description:
+      - Name of the local user to grant/revoke permissions of.
+    type: str
+    required: false
+  access:
+    description:
+      - Type of access to grant.
+      - C(admin), C(no-access) oder C(readonly) are valid options.
+    type: str
+    choices:
+      - admin
+      - no-access
+      - read-only
+    required: False
+  lockdown:
+    description:
+      - Lockdown mode to set.
+      - C(disabled), C(normal) oder C(strict) are valid options.
+    type: str
+    choices:
+      - disabled
+      - normal
+      - strict
+    required: False
+  lockdown_exceptions:
+    description:
+      - List of users to add or remove from the lockdown exception list.
+    type: list
+    elements: str
+    required: False
+    type: dict
+  state:
+    description:
+      - If set to C(present), grant permissions or add users to lockdown exceptions list.
+      - If set to C(absent), revoke permissions or remove users to lockdown exceptions list.
+    default: present
+    type: str
+    choices:
+      - present
+      - absent
+extends_documentation_fragment:
+  - community.vmware.vmware.documentation
+'''
+
+EXAMPLES = r'''
+- name: Disable lockdown mode on ESXi host
+  community.vmware.vmware_host_access_manager:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    lockdown: disabled
+
+- name: Add user to lockdown exception list on ESXi host
+  community.vmware.vmware_host_access_manager:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    lockdown_exceptions:
+      - example
+    state: present
+
+- name: Remove user to lockdown exception list on ESXi host
+  community.vmware.vmware_host_access_manager:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    lockdown_exceptions:
+      - example
+    state: absent
+
+- name: Grant ReadOnly permission on ESXi host
+  community.vmware.vmware_host_access_manager:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    user_name: example
+    access: ReadOnly
+    state: present
+
+- name: Revoke permission on ESXi host
+  community.vmware.vmware_host_access_manager:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    user_name: example
+    state: absent
+'''
+
+RETURN = r'''
+msg:
+  description: The executed result for the module.
+  returned: always
+  type: str
+  sample: >-
+    {
+        "msg": "Granted permission 'read-only' to 'root' on 'esxi_hostname_0001'"
+    }
+'''
+
+try:
+    from pyVmomi import vim
+except ImportError:
+    pass
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils._text import to_text, to_native
+from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, vmware_argument_spec
+
+
+class VmwareHostAccessManager(PyVmomi):
+    ACCESS_MODE_MAP = {
+        'admin': 'accessAdmin',
+        'no-access': 'accessNoAccess',
+        'read-only': 'accessReadOnly',
+        None: 'accessNone'
+    }
+    LOCKDOWN_MODE_MAP = {
+        'disabled': 'lockdownDisabled',
+        'normal': 'lockdownNormal',
+        'strict': 'lockdownStrict'
+    }
+
+    def __init__(self, module):
+        super(VmwareHostAccessManager, self).__init__(module)
+        self.principal = module.params["user_name"] or module.params["group_name"]
+        self.group = module.params["user_name"] == None
+        self.access_mode = module.params["access"]
+        self.lockdown_mode = module.params["lockdown_mode"]
+        self.lockdown_exceptions = module.params["lockdown_exceptions"]
+        self.state = module.params["state"]
+
+        hosts = self.params['hosts']
+        cluster = self.params['cluster_name']
+        self.hosts = self.get_all_host_objs(cluster_name=cluster, esxi_host_name=hosts)
+        if not self.hosts:
+            self.module.fail_json(msg="Failed to find host system with given configuration.")
+
+    def get_access_controll_entry(self, access_mgr):
+        """
+        Search the specified access controll entry from ESXi
+
+        Returns: searched access crontroll entry if found, else None
+        """
+        for ace in access_mgr.RetrieveHostAccessControlEntries():
+            if ace.principal == self.principal and ace.group == self.group:
+                return {v:k for k, v in self.ACCESS_MODE_MAP.items()}.get(ace.accessMode)
+        return None
+
+    def update_access_controll_entry(self, access_mgr, access_mode):
+        """
+        Update the access controll entry
+        """
+        try:
+            access_mgr.ChangeAccessMode(self.principal, self.group, self.ACCESS_MODE_MAP[access_mode])
+        except vim.fault.UserNotFound as user_not_found:
+            self.module.fail_json(msg="Failed to update permission for '%s' due to user"
+                                    " not found : %s" % (self.principal, to_native(user_not_found.msg)))
+        except Exception as generic_exc:
+            self.module.fail_json(msg="Failed to add access: %s" % (to_native(generic_exc)))
+
+    def get_lockdown_mode(self, access_mgr):
+        """
+        Get the lockdown mode from ESXi
+
+        Returns: Lockdown mode as string
+        """
+        lockdown_mode = access_mgr.lockdownMode
+        return {v:k for k, v in self.LOCKDOWN_MODE_MAP.items()}.get(lockdown_mode)
+
+    def execute_access_controll_entry(self, host, access_mgr):
+        access_mode_current = self.get_access_controll_entry(access_mgr)
+        
+        if self.state == "present":
+            if access_mode_current != self.access_mode:
+                self.result['changed'] = True
+                if self.module.check_mode:
+                    self.result['msg'].append("The permission '%s' will be granted to '%s' on '%s'." %
+                                                (self.access_mode, self.principal, host.name))
+                else:
+                    self.result['msg'].append("Granted permission '%s' to '%s' on '%s'" %
+                                                (self.access_mode, self.principal, host.name))
+                    self.update_access_controll_entry(access_mgr, self.access_mode)
+
+                self.result['result'][host.name]['access'] = {self.principal: dict(group=self.group, access=self.access_mode)}
+                if self.module._diff:
+                    self.result['diff']['before'][host.name]['access'] = [dict(principal=self.principal, group=self.group, access=access_mode_current)] if access_mode_current else []
+                    self.result['diff']['after'][host.name]['access'] = [dict(principal=self.principal, group=self.group, access=self.access_mode)]
+        elif self.state == "absent" and access_mode_current:
+            self.result['changed'] = True
+            if self.module.check_mode:
+                self.result['msg'].append("The permission '%s' will be revoked from '%s' on '%s'." %
+                                            (access_mode_current, self.principal, host.name))
+            else:
+                self.result['msg'].append("Revoked permission '%s' from '%s' on '%s'" %
+                                            (access_mode_current, self.principal, host.name))
+                self.update_access_controll_entry(access_mgr, None)
+                
+            if self.module._diff:
+                self.result['diff']['before'][host.name]['access'] =  [dict(principal=self.principal, group=self.group, access=access_mode_current)]
+                self.result['diff']['after'][host.name]['access'] = []
+    
+    def execute_lockdown_exceptions(self, host, access_mgr):
+        exceptions = [s for s in access_mgr.QueryLockdownExceptions()]
+        exceptions_current = exceptions.copy()
+
+        if self.state == "present":
+            for user in self.lockdown_exceptions:
+                if user not in exceptions:
+                    exceptions.append(user)
+                    self.result['changed'] = True
+        elif self.state == "absent":
+            for user in self.lockdown_exceptions:
+                if user in exceptions:
+                    exceptions.remove(user)
+                    self.result['changed'] = True
+
+        if self.result['changed']:
+            if self.module.check_mode:
+                self.result['msg'].append("Lockdown exceptions for '%s' would be updated" % (host.name))
+            else:
+                try:
+                    access_mgr.UpdateLockdownExceptions(exceptions)
+                except vim.fault.UserNotFound as user_not_found:
+                    self.module.fail_json(msg="Failed to update lockdown exceptions due to user"
+                                            " not found : %s" % (to_native(user_not_found.msg)))
+                except Exception as generic_exc:
+                    self.module.fail_json(msg="Failed to update lockdown exceptions due to"
+                                            " generic exception : %s" % (to_native(generic_exc)))
+                self.result['msg'].append("Updated Lockdown exceptions for '%s'" % (host.name))
+
+            self.result['result'][host.name]['lockdown_exceptions'] = exceptions
+            if self.module._diff:
+                self.result['diff']['before'][host.name]['lockdown_exceptions'] = exceptions_current
+                self.result['diff']['after'][host.name]['lockdown_exceptions'] = exceptions
+
+    def execute_lockdown_mode(self, host, access_mgr):
+        mode_current = self.get_lockdown_mode(access_mgr)
+
+        if mode_current != self.lockdown_mode:
+            self.result['changed'] = True
+            if self.module.check_mode:
+                self.result['msg'].append("Lockdown mode for '%s' would be set to '%s'" % (host.name, self.lockdown_mode))
+            else:
+                access_mgr.ChangeLockdownMode(self.LOCKDOWN_MODE_MAP(self.lockdown_mode))
+                self.result['msg'].append("Updated Lockdown mode for '%s' to '%s'" % (host.name, self.lockdown_mode))
+
+            self.result['result'][host.name]['lockdown'] = self.lockdown_mode
+            if self.module._diff:
+                self.result['diff']['before'][host.name]['lockdown_mode'] = mode_current
+                self.result['diff']['after'][host.name]['lockdown_mode'] = self.lockdown_mode
+        else:
+            self.result['result'][host.name]['lockdown']
+
+    def execute(self):
+        self.result = dict(changed=False, msg=[], result={})
+        if self.module._diff:
+            self.result['diff']=dict(before=dict(),after=dict())
+        
+        for host in self.hosts:
+            
+            self.result['result'][host.name] = {}
+            if self.module._diff:
+                self.result['diff']['before'][host.name] = {}
+                self.result['diff']['after'][host.name] = {}
+
+            host_access_mgr = host.configManager.hostAccessManager
+
+            if self.principal:
+                self.execute_access_controll_entry(host, host_access_mgr)
+
+            if self.lockdown_exceptions:
+                self.execute_lockdown_exceptions(host, host_access_mgr)
+
+            if self.lockdown_mode:
+                self.execute_lockdown_mode(host, host_access_mgr)
+
+        self.result['msg'] = ", ".join(self.result['msg'])
+        self.module.exit_json(**self.result)
+
+
+def main():
+    argument_spec = vmware_argument_spec()
+    argument_spec.update(
+        hosts=dict(type='list', aliases=['esxi_hostname'], elements='str'),
+        cluster_name=dict(type='str', aliases=['cluster']),
+        user_name=dict(type="str"),
+        group_name=dict(type="str"),
+        access=dict(type="str", aliases=["access_mode"],  choices=["admin", "no-access", "read-only"]),
+        lockdown_mode=dict(type="str", aliases=["lockdown"],  choices=["disabled", "normal", "strict"]),
+        lockdown_exceptions=dict(type="list", elements="str"),
+        state=dict(type="str", default="present", choices=["present", "absent"])
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        #required_if=[
+        #    ['state', 'present', ['access']]],
+        required_one_of=[
+            ['user_name', 'group_name', 'lockdown', 'lockdown_exceptions'],
+            ['cluster_name', 'hosts'],
+        ],
+        mutually_exclusive=[
+            ['user_name', 'group_name', 'lockdown', 'lockdown_exceptions']
+        ],
+        supports_check_mode=True,
+    )
+    vmware_host_access_manager = VmwareHostAccessManager(module)
+    vmware_host_access_manager.execute()
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/vmware_host_access_manager.py
+++ b/plugins/modules/vmware_host_access_manager.py
@@ -242,7 +242,7 @@ class VmwareHostAccessManager(PyVmomi):
             if self.module._diff:
                 self.result['diff']['before'][host.name]['access'] =  [dict(principal=self.principal, group=self.group, access=access_mode_current)]
                 self.result['diff']['after'][host.name]['access'] = []
-    
+
     def execute_lockdown_exceptions(self, host, access_mgr):
         exceptions = [s for s in access_mgr.QueryLockdownExceptions()]
         exceptions_current = exceptions.copy()
@@ -266,10 +266,10 @@ class VmwareHostAccessManager(PyVmomi):
                     access_mgr.UpdateLockdownExceptions(exceptions)
                 except vim.fault.UserNotFound as user_not_found:
                     self.module.fail_json(msg="Failed to update lockdown exceptions due to user"
-                                            " not found : %s" % (to_native(user_not_found.msg)))
+                                              " not found : %s" % (to_native(user_not_found.msg)))
                 except Exception as generic_exc:
                     self.module.fail_json(msg="Failed to update lockdown exceptions due to"
-                                            " generic exception : %s" % (to_native(generic_exc)))
+                                              " generic exception : %s" % (to_native(generic_exc)))
                 self.result['msg'].append("Updated Lockdown exceptions for '%s'" % (host.name))
 
             self.result['result'][host.name]['lockdown_exceptions'] = exceptions
@@ -298,10 +298,10 @@ class VmwareHostAccessManager(PyVmomi):
     def execute(self):
         self.result = dict(changed=False, msg=[], result={})
         if self.module._diff:
-            self.result['diff']=dict(before=dict(),after=dict())
-        
+            self.result['diff'] = dict(before=dict(), after=dict())
+
         for host in self.hosts:
-            
+
             self.result['result'][host.name] = {}
             if self.module._diff:
                 self.result['diff']['before'][host.name] = {}
@@ -329,16 +329,14 @@ def main():
         cluster_name=dict(type='str', aliases=['cluster']),
         user_name=dict(type="str"),
         group_name=dict(type="str"),
-        access=dict(type="str", aliases=["access_mode"],  choices=["admin", "no-access", "read-only"]),
-        lockdown_mode=dict(type="str", aliases=["lockdown"],  choices=["disabled", "normal", "strict"]),
+        access=dict(type="str", aliases=["access_mode"], choices=["admin", "no-access", "read-only"]),
+        lockdown_mode=dict(type="str", aliases=["lockdown"], choices=["disabled", "normal", "strict"]),
         lockdown_exceptions=dict(type="list", elements="str"),
         state=dict(type="str", default="present", choices=["present", "absent"])
     )
 
     module = AnsibleModule(
         argument_spec=argument_spec,
-        #required_if=[
-        #    ['state', 'present', ['access']]],
         required_one_of=[
             ['user_name', 'group_name', 'lockdown', 'lockdown_exceptions'],
             ['cluster_name', 'hosts'],
@@ -350,6 +348,7 @@ def main():
     )
     vmware_host_access_manager = VmwareHostAccessManager(module)
     vmware_host_access_manager.execute()
+
 
 if __name__ == "__main__":
     main()

--- a/tests/integration/targets/vmware_host_access_info/aliases
+++ b/tests/integration/targets/vmware_host_access_info/aliases
@@ -1,0 +1,3 @@
+cloud/vcenter
+needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_host_access_info/tasks/main.yml
+++ b/tests/integration/targets/vmware_host_access_info/tasks/main.yml
@@ -1,0 +1,32 @@
+# Test code for the vmware_host_access_info module.
+# Copyright: (c) 2022, Marius Rieder <marius.rieder@scs.ch>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_attach_host: true
+
+- name: Get info about access from a single host
+  vmware_host_access_info:
+    validate_certs: false
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    esxi_hostname: "{{ esxi_hosts[0] }}"
+  register: host_access_info
+
+- debug:
+    var: host_access_info
+
+- name: Get info about access from all hosts in a cluster
+  vmware_host_access_info:
+    validate_certs: false
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    cluster_name: "{{ ccr1 }}"
+  register: host_access_info
+
+- debug:
+    var: host_access_info    

--- a/tests/integration/targets/vmware_host_access_manager/aliases
+++ b/tests/integration/targets/vmware_host_access_manager/aliases
@@ -1,0 +1,4 @@
+cloud/vcenter
+needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_1esxi
+disabled

--- a/tests/integration/targets/vmware_host_access_manager/tasks/main.yml
+++ b/tests/integration/targets/vmware_host_access_manager/tasks/main.yml
@@ -1,0 +1,14 @@
+# Test code for the vmware_host_access_manager module.
+# Copyright: (c) 2022, Marius Rieder <marius.rieder@scs.ch>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- import_role:
+    name: prepare_vmware_tests
+
+- name: include tasks pre.yml
+  include_tasks: pre.yml
+
+- block:
+  - include_tasks: vmware_host_access_manager_tests.yml
+  always:
+  - include_tasks: teardown.yml

--- a/tests/integration/targets/vmware_host_access_manager/tasks/pre.yml
+++ b/tests/integration/targets/vmware_host_access_manager/tasks/pre.yml
@@ -1,0 +1,14 @@
+# Test code for the vmware_host_access_manager module.
+# Copyright: (c) 2022, Marius Rieder <marius.rieder@scs.ch>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: add local user for the test
+  vmware_local_user_manager:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    local_user_name: testuser_0001
+    local_user_password: "SamplePassword!"
+    state: present
+  ignore_errors: true

--- a/tests/integration/targets/vmware_host_access_manager/tasks/teardown.yml
+++ b/tests/integration/targets/vmware_host_access_manager/tasks/teardown.yml
@@ -1,0 +1,13 @@
+# Test code for the vmware_host_access_manager module.
+# Copyright: (c) 2022, Marius Rieder <marius.rieder@scs.ch>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: teardown local user for the test
+  vmware_local_user_manager:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    local_user_name: testuser_0001
+    state: absent
+  ignore_errors: true

--- a/tests/integration/targets/vmware_host_access_manager/tasks/vmware_host_access_manager_tests.yml
+++ b/tests/integration/targets/vmware_host_access_manager/tasks/vmware_host_access_manager_tests.yml
@@ -1,0 +1,106 @@
+# Test code for the vmware_host_tcpip_stacks module.
+# Copyright: (c) 2021, sky-joker <sky.jokerxx@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Check grant read-only permission on ESXi host
+  community.vmware.vmware_host_access_manager:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    user_name: testuser_0001
+    access: read-only
+    state: present
+  register: check_grant_read_only
+  diff: true
+  check_mode: true
+- name: Make sure if changes would occur
+  assert:
+    that:
+      - check_grant_read_only.changed is sameas true
+      - check_grant_read_only.diff is defined
+
+- name: Grant read-only permission on ESXi host
+  community.vmware.vmware_host_access_manager:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    user_name: testuser_0001
+    access: read-only
+    state: present
+  register: grant_read_only
+  diff: true
+- name: Make sure if changes will occur
+  assert:
+    that:
+      - grant_read_only.changed is sameas true
+      - grant_read_only.diff is defined
+
+- name: Grant again read-only permission on ESXi host
+  community.vmware.vmware_host_access_manager:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    user_name: testuser_0001
+    access: read-only
+    state: present
+  register: grant_again_read_only
+- name: Make sure if changes will not occur again
+  assert:
+    that:
+      - grant_again_read_only.changed is sameas false
+
+- name: Check revoke read-only permission on ESXi host
+  community.vmware.vmware_host_access_manager:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    user_name: testuser_0001
+    state: absent
+  register: check_revoke_testuser
+  diff: true
+  check_mode: true
+- name: Make sure if changes would occur
+  assert:
+    that:
+      - check_revoke_testuser.changed is sameas true
+      - check_revoke_testuser.diff is defined
+
+- name: Grant read-only permission on ESXi host
+  community.vmware.vmware_host_access_manager:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    user_name: testuser_0001
+    state: absent
+  register: revoke_testuser
+  diff: true
+- name: Make sure if changes will occur
+  assert:
+    that:
+      - revoke_testuser.changed is sameas true
+      - revoke_testuser.diff is defined
+
+- name: Grant again read-only permission on ESXi host
+  community.vmware.vmware_host_access_manager:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    user_name: testuser_0001
+    state: absent
+  register: revoke_again_testuser
+- name: Make sure if changes will not occur again
+  assert:
+    that:
+      - revoke_again_testuser.changed is sameas false


### PR DESCRIPTION


##### SUMMARY
New Modules `vmware_host_access_manager` and `vmware_host_access_info` to manage permissions, lockdown mode and exceptions in one or multiple ESXi hosts.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
vmware_host_access_manager
vmware_host_access_info

##### ADDITIONAL INFORMATION
There is already a module [vmware_host_lockdown](https://github.com/ansible-collections/community.vmware/blob/main/plugins/modules/vmware_host_lockdown.py) however it uses a deprecated API and can not manage lockdown exceptions. In addition this module can manage permissions, lockdown exceptions and all three lockdown modes the current API provides. I propose to deprecate the  `vmware_host_lockdown` module in fav our of this new module instead of changing the the old module as this would probably require braking changes. Any thoughts on this?
