### PR TITLE
fixed typo related to guest MTU

### DIFF
--- a/plugins/modules/vmware_guest_network.py
+++ b/plugins/modules/vmware_guest_network.py
@@ -479,7 +479,7 @@ class PyVmomiHelper(PyVmomi):
             )
             # If NIC is a SR-IOV adapter
             if isinstance(nic, vim.vm.device.VirtualSriovEthernetCard):
-                d_item['allow_guest_os_mtu_change'] = nic.allowGuesOSMtuChange
+                d_item['allow_guest_os_mtu_change'] = nic.allowGuestOSMtuChange
                 if isinstance(nic.sriovBacking, vim.vm.device.VirtualSriovEthernetCard.SriovBackingInfo):
                     if isinstance(nic.sriovBacking.physicalFunctionBacking, vim.vm.device.VirtualPCIPassthrough.DeviceBacking):
                         d_item['physical_function_backing'] = nic.sriovBacking.physicalFunctionBacking.id


### PR DESCRIPTION
replaced one occurrence of allowGuesOSMtuChange with allowGuestOSMtuChange

##### SUMMARY
Typo in code causes error when creating SRIOV NIC

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/vmware_guest_network.py

##### ADDITIONAL INFORMATION
