### PR TITLE
fix type issue with VirtualPCIPassthrough

### DIFF
--- a/plugins/modules/vmware_guest_network.py
+++ b/plugins/modules/vmware_guest_network.py
@@ -481,9 +481,9 @@ class PyVmomiHelper(PyVmomi):
             if isinstance(nic, vim.vm.device.VirtualSriovEthernetCard):
                 d_item['allow_guest_os_mtu_change'] = nic.allowGuesOSMtuChange
                 if isinstance(nic.sriovBacking, vim.vm.device.VirtualSriovEthernetCard.SriovBackingInfo):
-                    if isinstance(nic.sriovBacking.physicalFunctionBacking, vim.vm.device.VirtualPCIPassthrough.DeviceBacking):
+                    if isinstance(nic.sriovBacking.physicalFunctionBacking, vim.vm.device.VirtualPCIPassthrough):
                         d_item['physical_function_backing'] = nic.sriovBacking.physicalFunctionBacking.id
-                    if isinstance(nic.sriovBacking.virtualFunctionBacking, vim.vm.device.VirtualPCIPassthrough.DeviceBacking):
+                    if isinstance(nic.sriovBacking.virtualFunctionBacking, vim.vm.device.VirtualPCIPassthrough):
                         d_item['virtual_function_backing'] = nic.sriovBacking.virtualFunctionBacking.id
             # If a distributed port group specified
             if isinstance(nic.backing, vim.vm.device.VirtualEthernetCard.DistributedVirtualPortBackingInfo):


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1580
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1582

##### SUMMARY
Received an error when trying to set up SRIOV: 

`AttributeError: type object 'vim.vm.device.VirtualPCIPassthrough' has no attribute 'DeviceBacking'`

According to the docs as well, there is no attribute on VirtualPCIPassthrough named DeviceBacking https://vdc-repo.vmware.com/vmwb-repository/dcr-public/3325c370-b58c-4799-99ff-58ae3baac1bd/45789cc5-aba1-48bc-a320-5e35142b50af/doc/vim.vm.device.VirtualDevice.html#backing 

I believe the intent was to compare the nic backing to the VirtualPCIPassthrough device itself. After making this change, the module seems to work correctly for me

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/vmware_guest_network.py

##### ADDITIONAL INFORMATION
