### PR TITLE
Add version to galaxy.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,8 @@ Push the release:
 - Tag the release: `git tag -s $VERSION`
 - Push the tag: `git push origin $VERSION`
 
+Create a PR to revert the version in `galaxy.yml` back to `null`.
+
 ## Communication
 
 We have a dedicated Working Group for VMware.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,7 @@
 ---
 namespace: community
 name: vmware
+version: null
 # the version key is generated during the release by Zuul
 # https://github.com/ansible-network/releases/tree/master/ansible_releases/cmd
 # A script based on https://pypi.org/project/pbr/ will generate the version

--- a/tools/prepare_release.yml
+++ b/tools/prepare_release.yml
@@ -14,6 +14,12 @@
     - name: Create release branch
       ansible.builtin.shell: git checkout -b "prepare_{{ version }}_release"
 
+    - name: Update galaxy.yml
+      ansible.builtin.lineinfile:
+        path: "{{ playbook_dir }}/../galaxy.yml"
+        regexp: "^version: "
+        line: "version: {{ version }}"
+
     - name: Update documentation
       import_tasks: create_documentation_tasks.yml
 


### PR DESCRIPTION
##### SUMMARY
Some people want to install this collection directly from GitHub, but this fails because `version` is missing in `galaxy.yml`.

This PR tries to fix this by:

- adding `version: null` to `galaxy.yml` (I would have preferred `version: devel` but got an error about semantic versioning)
- set the correct version in the `prepare_release.yml` playbook
- document that after releasing the version should be reverted back to `null`

Unfortunately, the last is an additional manual step. But I think it important to distinguish between "real" releases and soomething that's been created directly from the main branch and might include additional commits.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
galaxy.yml

##### ADDITIONAL INFORMATION

- #666 
- #758 
- #1232 