### PR TITLE
vmware_guest_disk: Avoid using in maintenance DS

### DIFF
--- a/changelogs/fragments/1321-vmware_vm_info-allocaded_storag_cpu_memory_output.yaml
+++ b/changelogs/fragments/1321-vmware_vm_info-allocaded_storag_cpu_memory_output.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - vmware_guest_disk - Ignore datastores in maintenance mode
+    (https://github.com/ansible-collections/community.vmware/pull/1321).

--- a/plugins/modules/vmware_guest_disk.py
+++ b/plugins/modules/vmware_guest_disk.py
@@ -1044,6 +1044,8 @@ class PyVmomiHelper(PyVmomi):
         datastore = None
         datastore_freespace = 0
         for ds in datastore_cluster_obj.childEntity:
+            if ds.summary.maintenanceMode == "inMaintenance":
+                continue
             if ds.summary.freeSpace > datastore_freespace:
                 # If datastore field is provided, filter destination datastores
                 datastore = ds


### PR DESCRIPTION
The get_recommended_datastore from the vmware_guest_disk filters out
datastores using the one with the greater amount of free space.
However, it doesn't check the datastore status (eg. inMaintenance).

When running the task on an SDRS cluster, which have a datastore in
maintenance, and that datastore is the one with the greater amount of
free space, the module fails with a pyvmomi error like:
"This operation is not allowed in the current state of the datastore".

This commit ensure to skip the selection of in-maintenance datastores by
not even checking their size, and exclude them immediately.

##### SUMMARY

Avoid recommending in-maintenance datastores when trying to create
a disk with vmware_guest_disk.

(Not able to find issues reported for this error, but IIRC I've seen at least one
in the previous days...)

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

vmware_guest_disk

##### ADDITIONAL INFORMATION

The get_recommended_datastore from the vmware_guest_disk filters out
datastores using the one with the greater amount of free space.
However, it doesn't check the datastore status (eg. inMaintenance).

When running the task on an SDRS cluster, which have a datastore in
maintenance, and that datastore is the one with the greater amount of
free space, the module fails with a pyvmomi error like:
"This operation is not allowed in the current state of the datastore".

This is because the recommended datastore is in-maintenance, and VMware
refuses to operate on a datastore with this state.

This commit ensure to skip the selection of in-maintenance datastores by
not even checking their size, and exclude them immediately.

Note that it may be required in other contexts such as : 
- <https://github.com/ansible-collections/community.vmware/blob/main/plugins/module_utils/vmware.py#L1669>
  Used by <https://github.com/ansible-collections/community.vmware/blob/main/plugins/modules/vmware_recommended_datastore.py#L90>