### PR TITLE
Add playbook to revert version to null

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,16 +260,22 @@ Refer [testing](testing.md) for more information.
 
 ## Publishing New Version
 
+Assuming your (local) repository has set `origin` to your GitHub fork and this repository is added as `upstream`:
+
 Prepare the release:
-- Make sure your fork is up to date; assuming your (local) repository has set `origin` to your GitHub fork and this repository is added as `upstream`: `git checkout main && git pull && git fetch upstream && git merge upstream/main`.
+- Make sure your fork is up to date: `git checkout main && git pull && git fetch upstream && git merge upstream/main`.
 - Run `ansible-playbook tools/prepare_release.yml`. The playbook tries to generate the next minor release automatically, but you can also set the version explicitly with `--extra-vars "version=$VERSION"`. You *will* have to set the version explicitly when publishing a new major release.
-- Push the created release branch `prepare_$VERSION_release` to your GitHub repo and open a PR for review.
+- Push the created release branch to your GitHub repo (`git push --set-upstream origin prepare_$VERSION_release`) and open a PR for review.
 
 Push the release:
+- After the PR has been merged, make sure your fork is up to date: `git checkout main && git pull && git fetch upstream && git merge upstream/main`.
 - Tag the release: `git tag -s $VERSION`
-- Push the tag: `git push origin $VERSION`
+- Push the tag: `git push upstream $VERSION`
 
-Create a PR to revert the version in `galaxy.yml` back to `null`.
+Revert the version in `galaxy.yml` back to `null`:
+- Make sure your fork is up to date: `git checkout main && git pull && git fetch upstream && git merge upstream/main`.
+- Run `ansible-playbook tools/unset_version.yml`.
+- Push the created branch to your GitHub repo (`git push --set-upstream origin unset_version_$VERSION`) and open a PR for review.
 
 ## Communication
 

--- a/tools/unset_version.yml
+++ b/tools/unset_version.yml
@@ -1,0 +1,26 @@
+- hosts: localhost
+  tasks:
+    - name: Get version
+      block:
+        - name: Get the current release version
+          ansible.builtin.shell: git tag --sort=-creatordate --merged|head -n1
+          register: result
+
+        - name: Set the release version
+          ansible.builtin.set_fact:
+            version: "{{ result.stdout }}"
+
+    - name: Create branch
+      ansible.builtin.shell: git checkout -b "unset_version_{{ version }}"
+
+    - name: Update galaxy.yml
+      ansible.builtin.lineinfile:
+        path: "{{ playbook_dir }}/../galaxy.yml"
+        regexp: "^version: "
+        line: "version: null"
+
+    - name: Add everything
+      ansible.builtin.shell: git add --all
+
+    - name: Commit everything
+      ansible.builtin.shell: 'git commit -m "Remove version {{ version }} from galaxy.yml"'


### PR DESCRIPTION
##### SUMMARY
This is a follow-up to #1320 adding a playbook to unset the version in `galaxy.yml` after a new release.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
galaxy.yml
README.md
tools/unset_version.yml

##### ADDITIONAL INFORMATION
