### PR TITLE
galaxy.yml: Mover version below comment

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,11 +1,11 @@
 ---
 namespace: community
 name: vmware
-version: null
 # the version key is generated during the release by Zuul
 # https://github.com/ansible-network/releases/tree/master/ansible_releases/cmd
 # A script based on https://pypi.org/project/pbr/ will generate the version
 # key. The version value depends on the tag or the last git tag.
+version: null
 readme: README.md
 authors:
   - Ansible (https://github.com/ansible)


### PR DESCRIPTION
##### SUMMARY
This is a follow-up tp #1320 moving `version` to a better place in `galaxy.yml`.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
galaxy.yml

##### ADDITIONAL INFORMATION
I've just added `version: null` somewhere to make it work, but it's probably better placed _after_ this comment:

```
# the version key is generated during the release by Zuul
# https://github.com/ansible-network/releases/tree/master/ansible_releases/cmd
# A script based on https://pypi.org/project/pbr/ will generate the version
# key. The version value depends on the tag or the last git tag.
```