### PR TITLE
fix replace http with https when using port 443

### DIFF
--- a/changelogs/fragments/1270-vmware_cfg_backup-failed_to_write_backup_file.yaml
+++ b/changelogs/fragments/1270-vmware_cfg_backup-failed_to_write_backup_file.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_cfg_backup - Fix a bug that failed the module when port 80 is blocked (https://github.com/ansible-collections/community.vmware/issues/1270).

--- a/plugins/modules/vmware_cfg_backup.py
+++ b/plugins/modules/vmware_cfg_backup.py
@@ -172,6 +172,8 @@ class VMwareConfigurationBackup(PyVmomi):
     def save_configuration(self):
         url = self.host.configManager.firmwareSystem.BackupFirmwareConfiguration()
         url = url.replace('*', self.host.name)
+        if self.module.params["port"] == 443:
+            url = url.replace("http:", "https:")
         if os.path.isdir(self.dest):
             filename = url.rsplit('/', 1)[1]
             self.dest = os.path.join(self.dest, filename)


### PR DESCRIPTION
##### SUMMARY
It seems like the URL returned from `self.host.configManager.firmwareSystem.BackupFirmwareConfiguration()` returns the url with `http://` instead of `https://` and does not take the port into consideration. I tested it with the `save_configuration()` method and the fix works for my environment. Because of time I did not test the other methods, but the fix could be applied as well probably. Maybe this only solves the symptoms and not the cause, I do not know the **pyvmomi** and the rest of the dependencies that well...

Fixes #1270

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`vmware_cfg_backup`

##### ADDITIONAL INFORMATION
```paste below
diff --git a/plugins/modules/vmware_cfg_backup.py b/plugins/modules/vmware_cfg_backup.py
index f347c37..04388a5 100644
--- a/plugins/modules/vmware_cfg_backup.py
+++ b/plugins/modules/vmware_cfg_backup.py
@@ -172,6 +172,8 @@ class VMwareConfigurationBackup(PyVmomi):
     def save_configuration(self):
         url = self.host.configManager.firmwareSystem.BackupFirmwareConfiguration()
         url = url.replace('*', self.host.name)
+        if self.module.params["port"] == 443:
+            url = url.replace("http:", "https:")
         if os.path.isdir(self.dest):
             filename = url.rsplit('/', 1)[1]
             self.dest = os.path.join(self.dest, filename)
```