### PR TITLE
Set version 2 EOL to Nov 2023

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The collection includes the VMware modules and plugins supported by Ansible VMwa
 
 | Release | Status                      | Expected end of life |
 | ------: | --------------------------: | -------------------: |
-|       2 | Maintained                  |             May 2023 |
+|       2 | Maintained                  |             Nov 2023 |
 |       1 | Maintained (bug fixes only) |             Nov 2022 |
 
 <!--start requires_ansible-->


### PR DESCRIPTION
##### SUMMARY
I think we should extend the support for version 2 of `community.vmware` to November 2023.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
README.md

##### ADDITIONAL INFORMATION
I'd like to release version 3 in time for Ansible (community package) 7.0.0. I'd also like to drop support for ansible-core below 2.14 then.

At the moment, we have a gap here. If `community.vmware` version 2 goes EOL in May and people have to, for whatever reason, stay on ansible-core 2.12or 2.13, they could only use version 2 of this collection. Which would be EOL after May 2023.

In the long run, I'd like to release a new major version of this collection for every major ansible-core / Ansible community package release dropping support for older ansible-core versions.

I think this PR makes it easier to synchronize with ansible-core / Ansible community package.