### PR TITLE
vmware_guest_instant_clone: Support FQPN of folder path

### DIFF
--- a/changelogs/fragments/1354-vmware_guest_instant_clone.yml
+++ b/changelogs/fragments/1354-vmware_guest_instant_clone.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_guest_instant_clone - Support FQPN in the folder parameter.

--- a/plugins/modules/vmware_guest_instant_clone.py
+++ b/plugins/modules/vmware_guest_instant_clone.py
@@ -479,7 +479,7 @@ class VmwareGuestInstantClone(PyVmomi):
             self.module.fail_json(msg="Datastore not found.")
 
         if self.params['folder']:
-            self.folder = self.find_folder_by_name(folder_name=self.params['folder'])
+            self.folder = self.find_folder_by_fqpn(folder_name=self.params['folder'], datacenter_name=self.params['datacenter'], folder_type='vm')
             if self.folder is None:
                 self.module.fail_json(msg="Folder not found.")
         else:


### PR DESCRIPTION
##### SUMMARY

This PR will support FQPN in the folder parameter the vmware_guest_instant_clone module has.

fixes: https://github.com/ansible-collections/community.vmware/issues/1353

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

plugins/modules/vmware_guest_instant_clone.py

##### ADDITIONAL INFORMATION

I tested the below 3 patterns of folder path based on the base-playbook.  
I confirmed the patterns worked well.

```
1. folder: "/{{ datacenter }}/vm/"
2. folder: vm
3. folder: vm/sample
```

**base-playbook**

```yaml
---
- hosts: localhost
  gather_facts: false
  connection: local
  tasks:
    - name: Instant Clone a VM
      community.vmware.vmware_guest_instant_clone:
        hostname: "{{ vcenter_hostname }}"
        username: "{{ vcenter_username }}"
        password: "{{ vcenter_password }}"
        validate_certs: false
        folder: "/{{ datacenter }}/vm/"
        datastore: "{{ rw_datastore }}"
        datacenter: "{{ datacenter }}"
        host: "{{ esxi_hostname }}"
        name: "{{ clone_vm }}"
        parent_vm: "{{ parent_vm  }}"
        resource_pool: "{{ resource_pool }}"
      register: vm_clone
      delegate_to: localhost
```