### PR TITLE
Backport vmware_guest_disk: Avoid using in maintenance DS

### DIFF
--- a/changelogs/fragments/1321-vmware_vm_info-allocaded_storag_cpu_memory_output.yaml
+++ b/changelogs/fragments/1321-vmware_vm_info-allocaded_storag_cpu_memory_output.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+  - vmware_guest_disk - Ignore datastores in maintenance mode
+    (https://github.com/ansible-collections/community.vmware/pull/1321).

--- a/plugins/modules/vmware_guest_disk.py
+++ b/plugins/modules/vmware_guest_disk.py
@@ -1044,6 +1044,8 @@ class PyVmomiHelper(PyVmomi):
         datastore = None
         datastore_freespace = 0
         for ds in datastore_cluster_obj.childEntity:
+            if ds.summary.maintenanceMode == "inMaintenance":
+                continue
             if ds.summary.freeSpace > datastore_freespace:
                 # If datastore field is provided, filter destination datastores
                 datastore = ds


### PR DESCRIPTION
Backport #1321

##### SUMMARY
Avoid recommending in-maintenance datastores when trying to create a disk with vmware_guest_disk.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_guest_disk

##### ADDITIONAL INFORMATION
