### PR TITLE
ISSUE-1290 Remove cluster host fm Pools

### DIFF
--- a/plugins/modules/vmware_content_deploy_ovf_template.py
+++ b/plugins/modules/vmware_content_deploy_ovf_template.py
@@ -260,7 +260,7 @@ class VmwareContentDeployOvfTemplate(VmwareRestClient):
             self._resourcepool_id = cluster_obj.resource_pool
 
         # Find the resourcepool by the given resourcepool name
-        if self.resourcepool and self.cluster and self.host:
+        if self.resourcepool:
             self._resourcepool_id = self.get_resource_pool_by_name(self.datacenter, self.resourcepool, self.cluster, self.host)
             if not self._resourcepool_id:
                 self._fail(msg="Failed to find the resource_pool %s" % self.resourcepool)

--- a/plugins/modules/vmware_content_deploy_template.py
+++ b/plugins/modules/vmware_content_deploy_template.py
@@ -279,7 +279,7 @@ class VmwareContentDeployTemplate(VmwareRestClient):
             self._resourcepool_id = cluster_obj.resource_pool
 
         # Find the resourcepool by the given resourcepool name
-        if self.resourcepool and self.cluster and self.host:
+        if self.resourcepool:
             self._resourcepool_id = self.get_resource_pool_by_name(self.datacenter, self.resourcepool, self.cluster, self.host)
             if not self._resourcepool_id:
                 self._fail(msg="Failed to find the resource_pool %s" % self.resourcepool)


### PR DESCRIPTION
##### SUMMARY
Fixes #1290

The two template deployment modules both require cluster and host when attempting to identify a resource pool. I have removed that constraint, as the lookup function defaults cluster and host to None if not provided.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_content_deploy_ovf_template
vmware_content_deploy_template

##### ADDITIONAL INFORMATION
