### PR TITLE
[WIP] vmware_host_passthrough: Fix the devices parameter also to specify PCI id

### DIFF
--- a/plugins/modules/vmware_host_passthrough.py
+++ b/plugins/modules/vmware_host_passthrough.py
@@ -37,13 +37,14 @@ options:
     type: str
   devices:
     description:
-      - List of PCI device name.
+      - List of PCI device name or id.
     suboptions:
-      device_name:
+      device:
         description:
           - Name of PCI device to enable passthrough.
         aliases:
           - name
+          - device_name
         type: str
     elements: dict
     required: True
@@ -82,6 +83,18 @@ EXAMPLES = r"""
     esxi_hostname: "{{ esxi1 }}"
     devices:
       - device_name: "Dual Band Wireless AC 3165"
+    state: present
+
+- name: Enable PCI device passthrough with PCI ids
+  community.vmware.vmware_host_passthrough:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi1 }}"
+    devices:
+      - device: '0000:03:00.0'
+      - device: '0000:00:02.0'
     state: present
 
 - name: Disable PCI device passthrough against the whole ESXi in a cluster
@@ -198,21 +211,27 @@ class VMwareHostPassthrough(PyVmomi):
         self.existent_devices = []
         self.non_existent_devices = []
 
+        # The keys use in checking pci devices existing.
+        keys = ['device_name', 'device_id']
+
         for host_pci_device in self.hosts_passthrough_pci_devices:
             pci_devices = []
             for esxi_hostname, value in host_pci_device.items():
                 for target_device in self.devices:
-                    device_name = target_device['device_name']
-                    if device_name in [device['device_name'] for device in value['pci_devices']]:
+                    device = target_device['device']
+                    if device in [pci_device.get(key) for key in keys for pci_device in value['pci_devices']]:
                         pci_devices.append(
-                            [device for device in value['pci_devices'] if device_name == device['device_name']]
+                            [
+                                pci_device for pci_device in value['pci_devices']
+                                if device == pci_device['device_name'] or device == pci_device['device_id']
+                            ]
                         )
                     else:
-                        self.non_existent_devices.append(device_name)
+                        self.non_existent_devices.append(device)
                 self.existent_devices.append({
                     esxi_hostname: {
                         'host_obj': value['host_obj'],
-                        'checked_pci_devices': sum(pci_devices, [])
+                        'checked_pci_devices': self.de_duplication(sum(pci_devices, []))
                     }
                 })
 
@@ -235,9 +254,9 @@ class VMwareHostPassthrough(PyVmomi):
                     'new_configs': []
                 }
                 for target_device in self.devices:
-                    device_name = target_device['device_name']
+                    device = target_device['device']
                     for checked_pci_device in value['checked_pci_devices']:
-                        if device_name == checked_pci_device['device_name']:
+                        if device == checked_pci_device['device_name'] or device == checked_pci_device['device_id']:
                             before = dict(checked_pci_device)
                             after = dict(copy.deepcopy(checked_pci_device))
 
@@ -249,6 +268,16 @@ class VMwareHostPassthrough(PyVmomi):
                             self.host_target_device_to_change_configuration[esxi_hostname]['host_obj'] = value['host_obj']
                             self.diff_config['before'][esxi_hostname].append(before)
                             self.diff_config['after'][esxi_hostname].append(after)
+
+                # De-duplicate pci device data and sort.
+                self.diff_config['before'][esxi_hostname] = sorted(
+                    self.de_duplication(self.diff_config['before'][esxi_hostname]),
+                    key=lambda d: d['device_name']
+                )
+                self.diff_config['after'][esxi_hostname] = sorted(
+                    self.de_duplication(self.diff_config['after'][esxi_hostname]),
+                    key=lambda d: d['device_name']
+                )
 
     def generate_passthrough_configurations_to_be_applied(self):
         """
@@ -268,6 +297,14 @@ class VMwareHostPassthrough(PyVmomi):
                     config.passthruEnabled = state
                     config.id = new_config['device_id']
                     self.host_passthrough_configs[esxi_hostname]['generated_new_configs'].append(config)
+
+    def de_duplication(self, data):
+        """
+        De-duplicate dictionaries in a list.
+        """
+        return [
+            dict(s) for s in set(frozenset(d.items()) for d in data)
+        ]
 
     def execute(self):
         self.collect_pci_device_ids_for_supported_passthrough()
@@ -306,7 +343,7 @@ def main():
         esxi_hostname=dict(type='str'),
         devices=dict(type='list', elements='dict', required=True,
                      options=dict(
-                         device_name=dict(type='str', aliases=['name'])
+                         device=dict(type='str', aliases=['name', 'device_name'])
                      )),
         state=dict(type='str', default='present', choices=['present', 'absent'])
     )


### PR DESCRIPTION
##### SUMMARY

If ESXi has multiple PCI devices and they are the same name, and you want to enable the passthrough, you need to specify the PCI id.  
But the module hasn't been able to specify the PCI id of the PCI device.  
This PR is to be able to specify the id in the devices parameter the module has.

fixes: https://github.com/ansible-collections/community.vmware/issues/1364

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/modules/vmware_host_passthrough.py

##### ADDITIONAL INFORMATION

tested in vCenter/ESXi 7.0.0