### PR TITLE
vmware_guest_sendkey: Add CTRL_X support

### DIFF
--- a/changelogs/fragments/1376-vmware_guest_sendkey-add-ctrl_x-support.yaml
+++ b/changelogs/fragments/1376-vmware_guest_sendkey-add-ctrl_x-support.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+  - vmware_guest_sendkey - Add CTRL_X binding support
+    (https://github.com/ansible-collections/community.vmware/pull/1376)

--- a/changelogs/fragments/1376-vmware_guest_sendkey-add-ctrl_x-support.yaml
+++ b/changelogs/fragments/1376-vmware_guest_sendkey-add-ctrl_x-support.yaml
@@ -1,3 +1,2 @@
 minor_changes:
   - vmware_guest_sendkey - Add CTRL_X binding support (https://github.com/ansible-collections/community.vmware/pull/1376).
-    (https://github.com/ansible-collections/community.vmware/pull/1376)

--- a/changelogs/fragments/1376-vmware_guest_sendkey-add-ctrl_x-support.yaml
+++ b/changelogs/fragments/1376-vmware_guest_sendkey-add-ctrl_x-support.yaml
@@ -1,3 +1,3 @@
 minor_changes:
-  - vmware_guest_sendkey - Add CTRL_X binding support
+  - vmware_guest_sendkey - Add CTRL_X binding support (https://github.com/ansible-collections/community.vmware/pull/1376).
     (https://github.com/ansible-collections/community.vmware/pull/1376)

--- a/plugins/modules/vmware_guest_sendkey.py
+++ b/plugins/modules/vmware_guest_sendkey.py
@@ -247,6 +247,7 @@ class PyVmomiHelper(PyVmomi):
             ('END', '0x4d', [('', [])]),
             ('CTRL_ALT_DEL', '0x4c', [('', ['CTRL', 'ALT'])]),
             ('CTRL_C', '0x06', [('', ['CTRL'])]),
+            ('CTRL_X', '0x1b', [('', ['CTRL'])]),
             ('RIGHTARROW', '0x4f', [('', [])]),
             ('LEFTARROW', '0x50', [('', [])]),
             ('DOWNARROW', '0x51', [('', [])]),

--- a/plugins/modules/vmware_guest_sendkey.py
+++ b/plugins/modules/vmware_guest_sendkey.py
@@ -79,7 +79,7 @@ options:
      description:
      - The list of the keys will be sent to the virtual machine.
      - 'Valid values are C(ENTER), C(ESC), C(BACKSPACE), C(TAB), C(SPACE), C(CAPSLOCK), C(HOME), C(DELETE), C(END), C(CTRL_ALT_DEL),
-        C(CTRL_C) and C(F1) to C(F12), C(RIGHTARROW), C(LEFTARROW), C(DOWNARROW), C(UPARROW).'
+        C(CTRL_C), C(CTRL_X) and C(F1) to C(F12), C(RIGHTARROW), C(LEFTARROW), C(DOWNARROW), C(UPARROW).'
      - If both C(keys_send) and C(string_send) are specified, keys in C(keys_send) list will be sent in front of the C(string_send).
      - Values C(HOME) and C(END) are added in version 1.17.0.
      type: list


### PR DESCRIPTION
When using sendkey module, an error message is raised.
This commit adds support for the CTRL_X binding.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Adds support for the CTRL_X key binding.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

vmware_guest_sendkey

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
When using the module sendkey with CTRL_X binding, an error is raised.
You can reproduce it with the example below: 
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
```yaml
      - name: Handle boot parameter interactively
        vmware_guest_sendkey:
          validate_certs: false
          hostname: "{{ vcenter_host }}"
          datacenter: "{{ vcenter_datacenter }}"
          username: "{{ vcenter_user }}"
          password: "{{ vcenter_password }}"
          name: "{{ vm_hostname  }}"
          keys_send:
            - CTRL_X
        delegate_to: localhost
```
<!--- Paste verbatim command output below, e.g. before and after your change -->
```json
{ 
  [...] 
  "msg": "keys_send parameter: 'CTRL_x' in ['CTRL_x'] not supported."
}
```
