### PR TITLE
vmware_cfg_backup: Add integration tests

### DIFF
--- a/tests/integration/targets/vmware_cfg_backup/aliases
+++ b/tests/integration/targets/vmware_cfg_backup/aliases
@@ -1,0 +1,3 @@
+cloud/vcenter
+needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_cfg_backup/tasks/main.yml
+++ b/tests/integration/targets/vmware_cfg_backup/tasks/main.yml
@@ -1,0 +1,19 @@
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_attach_host: true
+
+- name: Save the ESXi configuration locally by authenticating against the vCenter and selecting the ESXi host
+  community.vmware.vmware_cfg_backup:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    esxi_hostname: "{{ esxi1 }}"
+    dest: /tmp/
+    state: saved
+  register: cfg_backup
+
+- name: Ensure config was saved
+  assert:
+    that:
+      - cfg_backup is changed


### PR DESCRIPTION
##### SUMMARY
We don't have any integration tests for `vmware_cfg_backup` yet.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_cfg_backup

##### ADDITIONAL INFORMATION
#28
