### PR TITLE
add alt+tab support

### DIFF
--- a/plugins/modules/vmware_guest_sendkey.py
+++ b/plugins/modules/vmware_guest_sendkey.py
@@ -79,7 +79,7 @@ options:
      description:
      - The list of the keys will be sent to the virtual machine.
      - 'Valid values are C(ENTER), C(ESC), C(BACKSPACE), C(TAB), C(SPACE), C(CAPSLOCK), C(HOME), C(DELETE), C(END), C(CTRL_ALT_DEL),
-        C(CTRL_C), C(CTRL_X) and C(F1) to C(F12), C(RIGHTARROW), C(LEFTARROW), C(DOWNARROW), C(UPARROW).'
+        C(CTRL_C), C(CTRL_X), C(ALT_TAB), C(F1) to C(F12), C(RIGHTARROW), C(LEFTARROW), C(DOWNARROW), and C(UPARROW).'
      - If both C(keys_send) and C(string_send) are specified, keys in C(keys_send) list will be sent in front of the C(string_send).
      - Values C(HOME) and C(END) are added in version 1.17.0.
      type: list
@@ -245,6 +245,7 @@ class PyVmomiHelper(PyVmomi):
             ('HOME', '0x4a', [('', [])]),
             ('DELETE', '0x4c', [('', [])]),
             ('END', '0x4d', [('', [])]),
+            ('ALT_TAB', '0x2b', [('', ['ALT'])]),
             ('CTRL_ALT_DEL', '0x4c', [('', ['CTRL', 'ALT'])]),
             ('CTRL_C', '0x06', [('', ['CTRL'])]),
             ('CTRL_X', '0x1b', [('', ['CTRL'])]),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adds support for the ALT_TAB key binding.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_guest_sendkey


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
would be better to update keys_send to take any key + modifiers, but that's more code than i'm willing to think about at the moment.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
