### PR TITLE
1384

### DIFF
--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -1855,8 +1855,11 @@ class PyVmomiHelper(PyVmomi):
                 nic_change_detected = True
 
             net_obj = self.cache.get_network(network_name)
-            if hasattr(net_obj, 'portKeys') and \
-                not hasattr(net_obj.config, 'logicalSwitchUuid'):
+            a,b,c=hasattr(net_obj, 'portKeys'),hasattr(net_obj.config, 'logicalSwitchUuid'),isinstance(net_obj, vim.dvs.DistributedVirtualPortgroup)
+            self.module.fail_json(msg=[a,b,c])
+            if hasattr(net_obj, 'portKeys') and not \
+                hasattr(net_obj.config, 'logicalSwitchUuid') and \
+                    isinstance(net_obj, vim.dvs.DistributedVirtualPortgroup):
                 # VDS switch
                 pg_obj = None
                 if 'dvswitch_name' in network_devices[key]:

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -1908,7 +1908,6 @@ class PyVmomiHelper(PyVmomi):
                 hasattr(net_obj.config, 'logicalSwitchUuid'):
                 # cover VMWare on AWS SDDC 1.16+
                 # https://kb.vmware.com/s/article/82487
-                self.module.fail_json(msg="EUW3 only")
                 nic.device.backing = vim.vm.device.VirtualEthernetCard.OpaqueNetworkBackingInfo()
                 network_id = net_obj.config.logicalSwitchUuid
                 nic.device.backing.opaqueNetworkType = 'nsx.LogicalSwitch'

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -1855,11 +1855,9 @@ class PyVmomiHelper(PyVmomi):
                 nic_change_detected = True
 
             net_obj = self.cache.get_network(network_name)
-            a,b,c=hasattr(net_obj, 'portKeys'),hasattr(net_obj.config, 'logicalSwitchUuid'),isinstance(net_obj, vim.dvs.DistributedVirtualPortgroup)
-            self.module.fail_json(msg=[a,b,c])
-            if hasattr(net_obj, 'portKeys') and not \
+            if hasattr(net_obj, 'portKeys') and \
                 hasattr(net_obj.config, 'logicalSwitchUuid') and \
-                    isinstance(net_obj, vim.dvs.DistributedVirtualPortgroup):
+                    net_obj.config.logicalSwitchUuid is None:
                 # VDS switch
                 pg_obj = None
                 if 'dvswitch_name' in network_devices[key]:
@@ -1908,7 +1906,8 @@ class PyVmomiHelper(PyVmomi):
                 nic.device.backing.port = dvs_port_connection
 
             elif not isinstance(net_obj, vim.OpaqueNetwork) and \
-                hasattr(net_obj.config, 'logicalSwitchUuid'):
+                hasattr(net_obj.config, 'logicalSwitchUuid') and \
+                    net_obj.config.logicalSwitchUuid:
                 # cover VMWare on AWS SDDC 1.16+
                 # https://kb.vmware.com/s/article/82487
                 nic.device.backing = vim.vm.device.VirtualEthernetCard.OpaqueNetworkBackingInfo()


### PR DESCRIPTION
##### SUMMARY
Fixes 1384
VMWare Cloud on AWS (VMC) after change from NVDS to VDS
https://kb.vmware.com/s/article/82487
##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
vmware_guest.py

##### ADDITIONAL INFORMATION
VMWARE on AWS changed some return values for NSX LogicalSwitch ID on SDDC 1.16.5+
https://kb.vmware.com/s/article/82487
This is tested with SDDC 1.16.4, SDDC 1.16.5 and vSphere7

TODO: 
ON SDDC 1.16.4 It only works when deploying from template, if you try without template, the VM does not get a network adapter!


<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
