### PR TITLE
vmware_cfg_backup: Add integration test without vCenter

### DIFF
--- a/tests/integration/targets/vmware_cfg_backup/tasks/main.yml
+++ b/tests/integration/targets/vmware_cfg_backup/tasks/main.yml
@@ -11,9 +11,23 @@
     esxi_hostname: "{{ esxi1 }}"
     dest: /tmp/
     state: saved
-  register: cfg_backup
+  register: cfg_backup_vcenter
 
 - name: Ensure config was saved
   assert:
     that:
-      - cfg_backup is changed
+      - cfg_backup_vcenter is changed
+
+- name: Save the ESXi configuration locally directly from the ESXi host
+  community.vmware.vmware_cfg_backup:
+    hostname: "{{ esxi1 }}"
+    username: "{{ esxi1_username }}"
+    password: "{{ esxi1_password }}"
+    dest: /tmp/
+    state: saved
+  register: cfg_backup_esxi
+
+- name: Ensure config was saved
+  assert:
+    that:
+      - cfg_backup_esxi is changed


### PR DESCRIPTION
##### SUMMARY
Add an integration test to backup configuration directly without going through vCenter.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_cfg_backup

##### ADDITIONAL INFORMATION
#1389
