### PR TITLE
vmware_vm_info: Fix NoneType object has no attribute datastoreUrl for inaccessible VMs

### DIFF
--- a/changelogs/fragments/1407-vmware_vm_info-inaccessible_vm.yml
+++ b/changelogs/fragments/1407-vmware_vm_info-inaccessible_vm.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_vm_info - Fix 'NoneType' object has no attribute 'datastoreUrl' for inaccessible VMs (https://github.com/ansible-collections/community.vmware/issues/1407).

--- a/plugins/modules/vmware_vm_info.py
+++ b/plugins/modules/vmware_vm_info.py
@@ -351,8 +351,9 @@ class VmwareVmInfo(PyVmomi):
             datacenter = get_parent_datacenter(vm)
             datastore_url = list()
             datastore_attributes = ('name', 'url')
-            if vm.config.datastoreUrl:
-                for entry in vm.config.datastoreUrl:
+            vm_datastore_urls = _get_vm_prop(vm, ('config', 'datastoreUrl'))
+            if vm_datastore_urls:
+                for entry in vm_datastore_urls:
                     datastore_url.append({key: getattr(entry, key) for key in dir(entry) if key in datastore_attributes})
             virtual_machine = {
                 "guest_name": summary.config.name,


### PR DESCRIPTION
##### SUMMARY
The module fails on inaccessible VMs with `'NoneType' object has no attribute 'datastoreUrl'`.

Fixes #1407

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_vm_info

##### ADDITIONAL INFORMATION
