### PR TITLE
vmware_local_role_manager: don't require a specific version of python

### DIFF
--- a/plugins/modules/vmware_local_role_manager.py
+++ b/plugins/modules/vmware_local_role_manager.py
@@ -22,9 +22,6 @@ author:
 notes:
     - Tested on ESXi 6.5
     - Be sure that the ESXi user used for login, has the appropriate rights to create / delete / edit roles
-requirements:
-    - "python >= 2.6"
-    - PyVmomi
 options:
   local_role_name:
     description:


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1603
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1600
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1605
Depends-On: https://github.com/ansible-collections/community.vmware/pull/1413

The Python and pyVmomi requirements are defined at the collection level.
