### PR TITLE
Improve module documentation

### DIFF
--- a/docs/community.vmware.vcenter_domain_user_group_info_module.rst
+++ b/docs/community.vmware.vcenter_domain_user_group_info_module.rst
@@ -21,13 +21,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.7
-- PyVmomi
-
 
 Parameters
 ----------

--- a/docs/community.vmware.vcenter_extension_info_module.rst
+++ b/docs/community.vmware.vcenter_extension_info_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -174,7 +167,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vcenter_extension_module.rst
+++ b/docs/community.vmware.vcenter_extension_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -366,7 +359,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vcenter_folder_module.rst
+++ b/docs/community.vmware.vcenter_folder_module.rst
@@ -21,13 +21,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -277,7 +270,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vcenter_license_module.rst
+++ b/docs/community.vmware.vcenter_license_module.rst
@@ -20,12 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- pyVmomi
-
 
 Parameters
 ----------

--- a/docs/community.vmware.vcenter_standard_key_provider_module.rst
+++ b/docs/community.vmware.vcenter_standard_key_provider_module.rst
@@ -21,13 +21,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 3.6
-- PyVmomi
-
 
 Parameters
 ----------

--- a/docs/community.vmware.vmware_about_info_module.rst
+++ b/docs/community.vmware.vmware_about_info_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -174,7 +167,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_category_info_module.rst
+++ b/docs/community.vmware.vmware_category_info_module.rst
@@ -26,8 +26,6 @@ Requirements
 ------------
 The below requirements are needed on the host that executes this module.
 
-- python >= 2.6
-- PyVmomi
 - vSphere Automation SDK
 
 
@@ -187,12 +185,6 @@ Parameters
     </table>
     <br/>
 
-
-Notes
------
-
-.. note::
-   - Tested on vSphere 6.5
 
 
 

--- a/docs/community.vmware.vmware_category_module.rst
+++ b/docs/community.vmware.vmware_category_module.rst
@@ -26,8 +26,6 @@ Requirements
 ------------
 The below requirements are needed on the host that executes this module.
 
-- python >= 2.6
-- PyVmomi
 - vSphere Automation SDK
 
 
@@ -316,12 +314,6 @@ Parameters
     </table>
     <br/>
 
-
-Notes
------
-
-.. note::
-   - Tested on vSphere 6.5
 
 
 

--- a/docs/community.vmware.vmware_cfg_backup_module.rst
+++ b/docs/community.vmware.vmware_cfg_backup_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi installed
-
 
 Parameters
 ----------
@@ -244,7 +237,6 @@ Notes
 -----
 
 .. note::
-   - Tested on ESXi 6.0
    - Works only for ESXi hosts
    - For configuration load or reset, the host will be switched automatically to maintenance mode.
    - All modules requires API write access and hence is not supported on a free ESXi license.

--- a/docs/community.vmware.vmware_cluster_dpm_module.rst
+++ b/docs/community.vmware.vmware_cluster_dpm_module.rst
@@ -21,13 +21,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- Tested on ESXi 6.7 and 7.0.
-- PyVmomi installed.
-
 
 Parameters
 ----------

--- a/docs/community.vmware.vmware_cluster_drs_module.rst
+++ b/docs/community.vmware.vmware_cluster_drs_module.rst
@@ -21,13 +21,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- Tested on ESXi 5.5 and 6.5.
-- PyVmomi installed.
-
 
 Parameters
 ----------

--- a/docs/community.vmware.vmware_cluster_ha_module.rst
+++ b/docs/community.vmware.vmware_cluster_ha_module.rst
@@ -21,13 +21,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- Tested on ESXi 5.5 and 6.5.
-- PyVmomi installed.
-
 
 Parameters
 ----------

--- a/docs/community.vmware.vmware_cluster_info_module.rst
+++ b/docs/community.vmware.vmware_cluster_info_module.rst
@@ -21,13 +21,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -273,7 +266,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5, 6.7
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_cluster_module.rst
+++ b/docs/community.vmware.vmware_cluster_module.rst
@@ -22,13 +22,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- Tested on ESXi 5.5 and 6.5.
-- PyVmomi installed.
-
 
 Parameters
 ----------

--- a/docs/community.vmware.vmware_cluster_vcls_module.rst
+++ b/docs/community.vmware.vmware_cluster_vcls_module.rst
@@ -22,13 +22,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- Tested on ESXi 7.0
-- PyVmomi installed.
-
 
 Parameters
 ----------

--- a/docs/community.vmware.vmware_cluster_vsan_module.rst
+++ b/docs/community.vmware.vmware_cluster_vsan_module.rst
@@ -25,8 +25,6 @@ Requirements
 ------------
 The below requirements are needed on the host that executes this module.
 
-- Tested on ESXi 6.7.
-- PyVmomi installed.
 - vSAN Management SDK, which needs to be downloaded from VMware and installed manually.
 
 

--- a/docs/community.vmware.vmware_content_deploy_ovf_template_module.rst
+++ b/docs/community.vmware.vmware_content_deploy_ovf_template_module.rst
@@ -25,8 +25,6 @@ Requirements
 ------------
 The below requirements are needed on the host that executes this module.
 
-- python >= 2.6
-- PyVmomi
 - vSphere Automation SDK
 
 
@@ -388,12 +386,6 @@ Parameters
     </table>
     <br/>
 
-
-Notes
------
-
-.. note::
-   - Tested on vSphere 6.7
 
 
 

--- a/docs/community.vmware.vmware_content_deploy_template_module.rst
+++ b/docs/community.vmware.vmware_content_deploy_template_module.rst
@@ -28,8 +28,6 @@ Requirements
 ------------
 The below requirements are needed on the host that executes this module.
 
-- python >= 2.6
-- PyVmomi
 - vSphere Automation SDK
 
 
@@ -401,12 +399,6 @@ Parameters
     </table>
     <br/>
 
-
-Notes
------
-
-.. note::
-   - Tested on vSphere 6.7 U3
 
 
 

--- a/docs/community.vmware.vmware_content_library_info_module.rst
+++ b/docs/community.vmware.vmware_content_library_info_module.rst
@@ -27,8 +27,6 @@ Requirements
 ------------
 The below requirements are needed on the host that executes this module.
 
-- python >= 2.6
-- PyVmomi
 - vSphere Automation SDK
 
 
@@ -203,12 +201,6 @@ Parameters
     </table>
     <br/>
 
-
-Notes
------
-
-.. note::
-   - Tested on vSphere 6.5, 6.7
 
 
 

--- a/docs/community.vmware.vmware_content_library_manager_module.rst
+++ b/docs/community.vmware.vmware_content_library_manager_module.rst
@@ -26,8 +26,6 @@ Requirements
 ------------
 The below requirements are needed on the host that executes this module.
 
-- python >= 2.6
-- PyVmomi
 - vSphere Automation SDK
 
 
@@ -346,12 +344,6 @@ Parameters
     </table>
     <br/>
 
-
-Notes
------
-
-.. note::
-   - Tested on vSphere 6.5, 6.7, and 7.0
 
 
 

--- a/docs/community.vmware.vmware_datacenter_info_module.rst
+++ b/docs/community.vmware.vmware_datacenter_info_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.7
-- PyVmomi
-
 
 Parameters
 ----------
@@ -254,7 +247,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_datacenter_module.rst
+++ b/docs/community.vmware.vmware_datacenter_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -209,7 +202,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.0, 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_datastore_cluster_manager_module.rst
+++ b/docs/community.vmware.vmware_datastore_cluster_manager_module.rst
@@ -21,13 +21,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.7
-- PyVmomi
-
 
 Parameters
 ----------
@@ -245,7 +238,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.0, 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_datastore_cluster_module.rst
+++ b/docs/community.vmware.vmware_datastore_cluster_module.rst
@@ -21,13 +21,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -346,7 +339,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.0, 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_datastore_info_module.rst
+++ b/docs/community.vmware.vmware_datastore_info_module.rst
@@ -21,13 +21,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -334,7 +327,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 5.5, 6.0 and 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_datastore_maintenancemode_module.rst
+++ b/docs/community.vmware.vmware_datastore_maintenancemode_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -245,7 +238,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 5.5, 6.0 and 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_deploy_ovf_module.rst
+++ b/docs/community.vmware.vmware_deploy_ovf_module.rst
@@ -20,12 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- pyvmomi
-
 
 Parameters
 ----------

--- a/docs/community.vmware.vmware_dns_config_module.rst
+++ b/docs/community.vmware.vmware_dns_config_module.rst
@@ -27,13 +27,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -230,7 +223,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 5.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_drs_group_info_module.rst
+++ b/docs/community.vmware.vmware_drs_group_info_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -207,7 +200,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5 and 6.7
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_drs_group_manager_module.rst
+++ b/docs/community.vmware.vmware_drs_group_manager_module.rst
@@ -21,13 +21,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.7
-- PyVmomi
-
 
 Parameters
 ----------
@@ -278,7 +271,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5, and 6.7.
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_drs_group_module.rst
+++ b/docs/community.vmware.vmware_drs_group_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.7
-- PyVmomi
-
 
 Parameters
 ----------
@@ -276,7 +269,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5, and 6.7
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_drs_rule_info_module.rst
+++ b/docs/community.vmware.vmware_drs_rule_info_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -208,7 +201,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_dvs_host_module.rst
+++ b/docs/community.vmware.vmware_dvs_host_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.7
-- PyVmomi
-
 
 Parameters
 ----------
@@ -344,7 +337,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 5.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_dvs_portgroup_find_module.rst
+++ b/docs/community.vmware.vmware_dvs_portgroup_find_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.7
-- PyVmomi
-
 
 Parameters
 ----------
@@ -241,7 +234,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_dvs_portgroup_info_module.rst
+++ b/docs/community.vmware.vmware_dvs_portgroup_info_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -321,7 +314,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 7.0
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_dvs_portgroup_module.rst
+++ b/docs/community.vmware.vmware_dvs_portgroup_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -1081,7 +1074,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 7.0
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_dvswitch_info_module.rst
+++ b/docs/community.vmware.vmware_dvswitch_info_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.7
-- PyVmomi
-
 
 Parameters
 ----------

--- a/docs/community.vmware.vmware_dvswitch_lacp_module.rst
+++ b/docs/community.vmware.vmware_dvswitch_lacp_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -321,7 +314,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.7
    - You need to run the task two times if you want to remove all LAGs and change the support mode to 'basic'
    - All modules requires API write access and hence is not supported on a free ESXi license.
 

--- a/docs/community.vmware.vmware_dvswitch_module.rst
+++ b/docs/community.vmware.vmware_dvswitch_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -774,7 +767,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5, 6.7 and 7.0
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_dvswitch_nioc_module.rst
+++ b/docs/community.vmware.vmware_dvswitch_nioc_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -356,7 +349,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.7
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_dvswitch_pvlans_module.rst
+++ b/docs/community.vmware.vmware_dvswitch_pvlans_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -235,7 +228,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5 and 6.7
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_dvswitch_uplink_pg_module.rst
+++ b/docs/community.vmware.vmware_dvswitch_uplink_pg_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -474,7 +467,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5 and 6.7
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_evc_mode_module.rst
+++ b/docs/community.vmware.vmware_evc_mode_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -243,7 +236,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.7
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_export_ovf_module.rst
+++ b/docs/community.vmware.vmware_export_ovf_module.rst
@@ -21,13 +21,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------

--- a/docs/community.vmware.vmware_first_class_disk_module.rst
+++ b/docs/community.vmware.vmware_first_class_disk_module.rst
@@ -21,13 +21,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -262,7 +255,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 7.0
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_folder_info_module.rst
+++ b/docs/community.vmware.vmware_folder_info_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -191,7 +184,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5
    - ``flat_folder_info`` added in VMware collection 1.4.0.
    - All modules requires API write access and hence is not supported on a free ESXi license.
 

--- a/docs/community.vmware.vmware_guest_boot_info_module.rst
+++ b/docs/community.vmware.vmware_guest_boot_info_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -260,7 +253,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_guest_boot_manager_module.rst
+++ b/docs/community.vmware.vmware_guest_boot_manager_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -388,7 +381,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_guest_controller_module.rst
+++ b/docs/community.vmware.vmware_guest_controller_module.rst
@@ -21,13 +21,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.7
-- PyVmomi
-
 
 Parameters
 ----------
@@ -440,7 +433,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.0, 6.5 and 6.7
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_guest_custom_attribute_defs_module.rst
+++ b/docs/community.vmware.vmware_guest_custom_attribute_defs_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -213,7 +206,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_guest_custom_attributes_module.rst
+++ b/docs/community.vmware.vmware_guest_custom_attributes_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -346,7 +339,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_guest_customization_info_module.rst
+++ b/docs/community.vmware.vmware_guest_customization_info_module.rst
@@ -21,13 +21,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -190,7 +183,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.0 and 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_guest_disk_info_module.rst
+++ b/docs/community.vmware.vmware_guest_disk_info_module.rst
@@ -21,13 +21,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -285,9 +278,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.0 and 6.5.
-   - Disk UUID information is added in version 2.8.
-   - Additional information about guest disk backings added in version 2.8.
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_guest_disk_module.rst
+++ b/docs/community.vmware.vmware_guest_disk_module.rst
@@ -23,13 +23,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -910,7 +903,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.0 and 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_guest_file_operation_module.rst
+++ b/docs/community.vmware.vmware_guest_file_operation_module.rst
@@ -20,14 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-- requests
-
 
 Parameters
 ----------
@@ -539,7 +531,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6
    - Only the first match against vm_id is used, even if there are multiple matches
    - All modules requires API write access and hence is not supported on a free ESXi license.
 

--- a/docs/community.vmware.vmware_guest_find_module.rst
+++ b/docs/community.vmware.vmware_guest_find_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -225,7 +218,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_guest_info_module.rst
+++ b/docs/community.vmware.vmware_guest_info_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -395,7 +388,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 5.5, 6.7
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_guest_module.rst
+++ b/docs/community.vmware.vmware_guest_module.rst
@@ -21,13 +21,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -2299,7 +2292,6 @@ Notes
    -    Network > Assign Network
    -    Resource > Assign Virtual Machine to Resource Pool
    - Module may require additional privileges as well, which may be required for gathering facts - e.g. ESXi configurations.
-   - Tested on vSphere 5.5, 6.0, 6.5 and 6.7.
    - Use SCSI disks instead of IDE when you want to expand online disks by specifying a SCSI controller.
    - Uses SysPrep for Windows VM (depends on 'guest_id' parameter match 'win') with PyVmomi.
    - In order to change the VM's parameters (e.g. number of CPUs), the VM must be powered off unless the hot-add support is enabled and the ``state=present`` must be used to apply the changes.

--- a/docs/community.vmware.vmware_guest_move_module.rst
+++ b/docs/community.vmware.vmware_guest_move_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -304,7 +297,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 5.5 and vSphere 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_guest_network_module.rst
+++ b/docs/community.vmware.vmware_guest_network_module.rst
@@ -21,13 +21,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.7
-- PyVmomi
-
 
 Parameters
 ----------
@@ -885,7 +878,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.0, 6.5 and 6.7
    - For backwards compatibility network_data is returned when using the gather_network_info and networks parameters
    - All modules requires API write access and hence is not supported on a free ESXi license.
 

--- a/docs/community.vmware.vmware_guest_powerstate_module.rst
+++ b/docs/community.vmware.vmware_guest_powerstate_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------

--- a/docs/community.vmware.vmware_guest_register_operation_module.rst
+++ b/docs/community.vmware.vmware_guest_register_operation_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.7
-- PyVmomi
-
 
 Parameters
 ----------

--- a/docs/community.vmware.vmware_guest_screenshot_module.rst
+++ b/docs/community.vmware.vmware_guest_screenshot_module.rst
@@ -21,13 +21,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -315,7 +308,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5 and 6.7
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_guest_sendkey_module.rst
+++ b/docs/community.vmware.vmware_guest_sendkey_module.rst
@@ -21,13 +21,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -147,7 +140,7 @@ Parameters
                 </td>
                 <td>
                         <div>The list of the keys will be sent to the virtual machine.</div>
-                        <div>Valid values are <code>ENTER</code>, <code>ESC</code>, <code>BACKSPACE</code>, <code>TAB</code>, <code>SPACE</code>, <code>CAPSLOCK</code>, <code>HOME</code>, <code>DELETE</code>, <code>END</code>, <code>CTRL_ALT_DEL</code>, <code>CTRL_C</code> and <code>F1</code> to <code>F12</code>, <code>RIGHTARROW</code>, <code>LEFTARROW</code>, <code>DOWNARROW</code>, <code>UPARROW</code>.</div>
+                        <div>Valid values are <code>ENTER</code>, <code>ESC</code>, <code>BACKSPACE</code>, <code>TAB</code>, <code>SPACE</code>, <code>CAPSLOCK</code>, <code>HOME</code>, <code>DELETE</code>, <code>END</code>, <code>CTRL_ALT_DEL</code>, <code>CTRL_C</code>, <code>CTRL_X</code> and <code>F1</code> to <code>F12</code>, <code>RIGHTARROW</code>, <code>LEFTARROW</code>, <code>DOWNARROW</code>, <code>UPARROW</code>.</div>
                         <div>If both <code>keys_send</code> and <code>string_send</code> are specified, keys in <code>keys_send</code> list will be sent in front of the <code>string_send</code>.</div>
                         <div>Values <code>HOME</code> and <code>END</code> are added in version 1.17.0.</div>
                 </td>
@@ -352,7 +345,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5 and 6.7
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_guest_snapshot_info_module.rst
+++ b/docs/community.vmware.vmware_guest_snapshot_info_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -285,7 +278,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.0 and 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_guest_snapshot_module.rst
+++ b/docs/community.vmware.vmware_guest_snapshot_module.rst
@@ -21,13 +21,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -457,7 +450,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 5.5, 6.0 and 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_guest_storage_policy_module.rst
+++ b/docs/community.vmware.vmware_guest_storage_policy_module.rst
@@ -21,12 +21,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- pyVmomi
-
 
 Parameters
 ----------
@@ -338,7 +332,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.0 and 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_guest_tools_info_module.rst
+++ b/docs/community.vmware.vmware_guest_tools_info_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.7
-- PyVmomi
-
 
 Parameters
 ----------
@@ -302,7 +295,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.0, 6.5, 6.7
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_guest_tools_upgrade_module.rst
+++ b/docs/community.vmware.vmware_guest_tools_upgrade_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------

--- a/docs/community.vmware.vmware_guest_tools_wait_module.rst
+++ b/docs/community.vmware.vmware_guest_tools_wait_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -320,7 +313,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_guest_tpm_module.rst
+++ b/docs/community.vmware.vmware_guest_tpm_module.rst
@@ -22,13 +22,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -289,8 +282,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.7
-   - Tested on vSphere 7.0
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_guest_vgpu_module.rst
+++ b/docs/community.vmware.vmware_guest_vgpu_module.rst
@@ -23,13 +23,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 3.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -373,7 +366,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.7
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_guest_video_module.rst
+++ b/docs/community.vmware.vmware_guest_video_module.rst
@@ -21,13 +21,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -394,7 +387,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.0, 6.5 and 6.7
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_guest_vnc_module.rst
+++ b/docs/community.vmware.vmware_guest_vnc_module.rst
@@ -27,13 +27,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------

--- a/docs/community.vmware.vmware_host_acceptance_module.rst
+++ b/docs/community.vmware.vmware_host_acceptance_module.rst
@@ -21,13 +21,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -255,7 +248,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_host_active_directory_module.rst
+++ b/docs/community.vmware.vmware_host_active_directory_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -272,7 +265,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_host_auto_start_module.rst
+++ b/docs/community.vmware.vmware_host_auto_start_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.7
-- PyVmomi
-
 
 Parameters
 ----------

--- a/docs/community.vmware.vmware_host_capability_info_module.rst
+++ b/docs/community.vmware.vmware_host_capability_info_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -206,7 +199,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_host_config_info_module.rst
+++ b/docs/community.vmware.vmware_host_config_info_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -206,7 +199,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_host_config_manager_module.rst
+++ b/docs/community.vmware.vmware_host_config_manager_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -226,7 +219,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_host_custom_attributes_module.rst
+++ b/docs/community.vmware.vmware_host_custom_attributes_module.rst
@@ -21,12 +21,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- PyVmomi
-
 
 Parameters
 ----------
@@ -265,7 +259,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.7
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_host_datastore_module.rst
+++ b/docs/community.vmware.vmware_host_datastore_module.rst
@@ -23,13 +23,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -356,8 +349,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.0, 6.5 and ESXi 6.7
-   - NFS v4.1 tested on vSphere 6.5
    - Kerberos authentication with NFS v4.1 isn't implemented
    - All modules requires API write access and hence is not supported on a free ESXi license.
 

--- a/docs/community.vmware.vmware_host_disk_info_module.rst
+++ b/docs/community.vmware.vmware_host_disk_info_module.rst
@@ -22,13 +22,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -208,7 +201,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.7 and 7.0
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_host_dns_info_module.rst
+++ b/docs/community.vmware.vmware_host_dns_info_module.rst
@@ -21,13 +21,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -207,7 +200,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_host_dns_module.rst
+++ b/docs/community.vmware.vmware_host_dns_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -331,7 +324,6 @@ Notes
 
 .. note::
    - This module is a replacement for the module ``vmware_dns_config``
-   - Tested on vSphere 6.7
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_host_facts_module.rst
+++ b/docs/community.vmware.vmware_host_facts_module.rst
@@ -26,13 +26,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------

--- a/docs/community.vmware.vmware_host_feature_info_module.rst
+++ b/docs/community.vmware.vmware_host_feature_info_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -206,7 +199,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_host_firewall_info_module.rst
+++ b/docs/community.vmware.vmware_host_firewall_info_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -206,7 +199,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_host_firewall_manager_module.rst
+++ b/docs/community.vmware.vmware_host_firewall_manager_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -229,7 +222,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.0, vSphere 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_host_hyperthreading_module.rst
+++ b/docs/community.vmware.vmware_host_hyperthreading_module.rst
@@ -22,13 +22,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -229,7 +222,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_host_inventory_inventory.rst
+++ b/docs/community.vmware.vmware_host_inventory_inventory.rst
@@ -26,9 +26,6 @@ Requirements
 ------------
 The below requirements are needed on the local Ansible controller node that executes this inventory.
 
-- Python >= 2.7
-- PyVmomi
-- requests >= 2.3
 - vSphere Automation SDK - For tag feature
 
 

--- a/docs/community.vmware.vmware_host_ipv6_module.rst
+++ b/docs/community.vmware.vmware_host_ipv6_module.rst
@@ -21,13 +21,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -227,7 +220,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_host_iscsi_info_module.rst
+++ b/docs/community.vmware.vmware_host_iscsi_info_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.7
-- PyVmomi
-
 
 Parameters
 ----------

--- a/docs/community.vmware.vmware_host_iscsi_module.rst
+++ b/docs/community.vmware.vmware_host_iscsi_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.7
-- PyVmomi
-
 
 Parameters
 ----------

--- a/docs/community.vmware.vmware_host_kernel_manager_module.rst
+++ b/docs/community.vmware.vmware_host_kernel_manager_module.rst
@@ -24,13 +24,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.7
-- PyVmomi
-
 
 Parameters
 ----------
@@ -244,7 +237,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.0
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_host_lockdown_module.rst
+++ b/docs/community.vmware.vmware_host_lockdown_module.rst
@@ -23,13 +23,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -235,7 +228,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_host_logbundle_info_module.rst
+++ b/docs/community.vmware.vmware_host_logbundle_info_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.7
-- PyVmomi
-
 
 Parameters
 ----------

--- a/docs/community.vmware.vmware_host_logbundle_module.rst
+++ b/docs/community.vmware.vmware_host_logbundle_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.7
-- PyVmomi
-
 
 Parameters
 ----------

--- a/docs/community.vmware.vmware_host_module.rst
+++ b/docs/community.vmware.vmware_host_module.rst
@@ -25,8 +25,6 @@ Requirements
 ------------
 The below requirements are needed on the host that executes this module.
 
-- python >= 2.6
-- PyVmomi
 - ssl
 - socket
 - hashlib
@@ -421,7 +419,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 5.5, 6.0, 6.5 and 6.7
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_host_ntp_info_module.rst
+++ b/docs/community.vmware.vmware_host_ntp_info_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -208,7 +201,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_host_ntp_module.rst
+++ b/docs/community.vmware.vmware_host_ntp_module.rst
@@ -22,13 +22,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -267,7 +260,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_host_package_info_module.rst
+++ b/docs/community.vmware.vmware_host_package_info_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -208,7 +201,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_host_passthrough_module.rst
+++ b/docs/community.vmware.vmware_host_passthrough_module.rst
@@ -21,13 +21,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 3.6
-- PyVmomi
-
 
 Parameters
 ----------

--- a/docs/community.vmware.vmware_host_powermgmt_policy_module.rst
+++ b/docs/community.vmware.vmware_host_powermgmt_policy_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -227,7 +220,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_host_powerstate_module.rst
+++ b/docs/community.vmware.vmware_host_powerstate_module.rst
@@ -22,13 +22,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------

--- a/docs/community.vmware.vmware_host_scanhba_module.rst
+++ b/docs/community.vmware.vmware_host_scanhba_module.rst
@@ -24,13 +24,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -267,7 +260,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.0
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_host_scsidisk_info_module.rst
+++ b/docs/community.vmware.vmware_host_scsidisk_info_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- Python >= 2.7
-- PyVmomi
-
 
 Parameters
 ----------

--- a/docs/community.vmware.vmware_host_service_info_module.rst
+++ b/docs/community.vmware.vmware_host_service_info_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -208,7 +201,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5
    - If source package name is not available then fact is populated as null.
    - All modules requires API write access and hence is not supported on a free ESXi license.
 

--- a/docs/community.vmware.vmware_host_service_manager_module.rst
+++ b/docs/community.vmware.vmware_host_service_manager_module.rst
@@ -22,13 +22,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -276,7 +269,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_host_snmp_module.rst
+++ b/docs/community.vmware.vmware_host_snmp_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -353,7 +346,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5
    - You need to reset the agent (to factory defaults) if you want to clear all community strings, trap targets, or filters
    - SNMP v3 configuration isn't implemented yet
    - All modules requires API write access and hence is not supported on a free ESXi license.

--- a/docs/community.vmware.vmware_host_sriov_module.rst
+++ b/docs/community.vmware.vmware_host_sriov_module.rst
@@ -23,13 +23,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.7
-- PyVmomi
-
 
 Parameters
 ----------
@@ -264,7 +257,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.0
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_host_ssl_info_module.rst
+++ b/docs/community.vmware.vmware_host_ssl_info_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -208,7 +201,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_host_tcpip_stacks_module.rst
+++ b/docs/community.vmware.vmware_host_tcpip_stacks_module.rst
@@ -21,13 +21,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.7
-- PyVmomi
-
 
 Parameters
 ----------

--- a/docs/community.vmware.vmware_host_user_manager_module.rst
+++ b/docs/community.vmware.vmware_host_user_manager_module.rst
@@ -21,13 +21,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 3.6
-- PyVmomi
-
 
 Parameters
 ----------

--- a/docs/community.vmware.vmware_host_vmhba_info_module.rst
+++ b/docs/community.vmware.vmware_host_vmhba_info_module.rst
@@ -22,13 +22,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -210,7 +203,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_host_vmnic_info_module.rst
+++ b/docs/community.vmware.vmware_host_vmnic_info_module.rst
@@ -24,13 +24,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -269,7 +262,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_local_role_info_module.rst
+++ b/docs/community.vmware.vmware_local_role_info_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -174,7 +167,6 @@ Notes
 -----
 
 .. note::
-   - Tested on ESXi 6.5
    - Be sure that the ESXi user used for login, has the appropriate rights to view roles
    - The module returns a list of dict in version 2.8 and above.
    - All modules requires API write access and hence is not supported on a free ESXi license.

--- a/docs/community.vmware.vmware_local_role_manager_module.rst
+++ b/docs/community.vmware.vmware_local_role_manager_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -270,7 +263,6 @@ Notes
 -----
 
 .. note::
-   - Tested on ESXi 6.5
    - Be sure that the ESXi user used for login, has the appropriate rights to create / delete / edit roles
    - All modules requires API write access and hence is not supported on a free ESXi license.
 

--- a/docs/community.vmware.vmware_local_user_info_module.rst
+++ b/docs/community.vmware.vmware_local_user_info_module.rst
@@ -22,13 +22,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -176,7 +169,6 @@ Notes
 -----
 
 .. note::
-   - Tested on ESXi 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_local_user_manager_module.rst
+++ b/docs/community.vmware.vmware_local_user_manager_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi installed
-
 
 Parameters
 ----------
@@ -239,7 +232,6 @@ Notes
 -----
 
 .. note::
-   - Tested on ESXi 6.0
    - Be sure that the ESXi user used for login, has the appropriate rights to create / delete / edit users
    - All modules requires API write access and hence is not supported on a free ESXi license.
 

--- a/docs/community.vmware.vmware_maintenancemode_module.rst
+++ b/docs/community.vmware.vmware_maintenancemode_module.rst
@@ -21,13 +21,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -266,7 +259,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 5.5, 6.0 and 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_migrate_vmk_module.rst
+++ b/docs/community.vmware.vmware_migrate_vmk_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -287,7 +280,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.7
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_object_custom_attributes_info_module.rst
+++ b/docs/community.vmware.vmware_object_custom_attributes_info_module.rst
@@ -21,13 +21,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 3.6
-- PyVmomi
-
 
 Parameters
 ----------

--- a/docs/community.vmware.vmware_object_rename_module.rst
+++ b/docs/community.vmware.vmware_object_rename_module.rst
@@ -26,8 +26,6 @@ Requirements
 ------------
 The below requirements are needed on the host that executes this module.
 
-- python >= 2.7
-- PyVmomi
 - vSphere Automation SDK
 
 
@@ -264,12 +262,6 @@ Parameters
     </table>
     <br/>
 
-
-Notes
------
-
-.. note::
-   - Tested on vSphere 6.5
 
 
 

--- a/docs/community.vmware.vmware_object_role_permission_info_module.rst
+++ b/docs/community.vmware.vmware_object_role_permission_info_module.rst
@@ -21,13 +21,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 3
-- PyVmomi
-
 
 Parameters
 ----------
@@ -254,7 +247,6 @@ Notes
 -----
 
 .. note::
-   - Tested on ESXi 6.5, vSphere 6.7
    - The ESXi login user must have the appropriate rights to administer permissions.
    - Supports check mode.
    - All modules requires API write access and hence is not supported on a free ESXi license.

--- a/docs/community.vmware.vmware_object_role_permission_module.rst
+++ b/docs/community.vmware.vmware_object_role_permission_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.7
-- PyVmomi
-
 
 Parameters
 ----------
@@ -309,7 +302,6 @@ Notes
 -----
 
 .. note::
-   - Tested on ESXi 6.5, vSphere 6.7
    - The ESXi login user must have the appropriate rights to administer permissions.
    - Permissions for a distributed switch must be defined and managed on either the datacenter or a folder containing the switch.
    - All modules requires API write access and hence is not supported on a free ESXi license.

--- a/docs/community.vmware.vmware_portgroup_info_module.rst
+++ b/docs/community.vmware.vmware_portgroup_info_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -227,7 +220,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_portgroup_module.rst
+++ b/docs/community.vmware.vmware_portgroup_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -580,10 +573,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 5.5 and 6.5
-   - Complete configuration only tested on vSphere 6.5
-   - ``inbound_policy`` and ``rolling_order`` are removed in 2.11.
-   - Those two options are only used during portgroup creation. Updating is not supported with those options.
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_recommended_datastore_module.rst
+++ b/docs/community.vmware.vmware_recommended_datastore_module.rst
@@ -21,13 +21,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 3
-- PyVmomi
-
 
 Parameters
 ----------
@@ -207,7 +200,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.7 and 7.0.2
    - Supports Check mode.
    - All modules requires API write access and hence is not supported on a free ESXi license.
 

--- a/docs/community.vmware.vmware_resource_pool_info_module.rst
+++ b/docs/community.vmware.vmware_resource_pool_info_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -174,7 +167,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_resource_pool_module.rst
+++ b/docs/community.vmware.vmware_resource_pool_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -461,7 +454,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_tag_info_module.rst
+++ b/docs/community.vmware.vmware_tag_info_module.rst
@@ -26,8 +26,6 @@ Requirements
 ------------
 The below requirements are needed on the host that executes this module.
 
-- python >= 2.6
-- PyVmomi
 - vSphere Automation SDK
 
 
@@ -187,12 +185,6 @@ Parameters
     </table>
     <br/>
 
-
-Notes
------
-
-.. note::
-   - Tested on vSphere 6.5
 
 
 

--- a/docs/community.vmware.vmware_tag_manager_module.rst
+++ b/docs/community.vmware.vmware_tag_manager_module.rst
@@ -26,8 +26,6 @@ Requirements
 ------------
 The below requirements are needed on the host that executes this module.
 
-- python >= 2.6
-- PyVmomi
 - vSphere Automation SDK
 
 
@@ -293,12 +291,6 @@ Parameters
     </table>
     <br/>
 
-
-Notes
------
-
-.. note::
-   - Tested on vSphere 6.5
 
 
 

--- a/docs/community.vmware.vmware_tag_module.rst
+++ b/docs/community.vmware.vmware_tag_module.rst
@@ -26,8 +26,6 @@ Requirements
 ------------
 The below requirements are needed on the host that executes this module.
 
-- python >= 2.6
-- PyVmomi
 - vSphere Automation SDK
 
 
@@ -262,12 +260,6 @@ Parameters
     </table>
     <br/>
 
-
-Notes
------
-
-.. note::
-   - Tested on vSphere 6.5
 
 
 

--- a/docs/community.vmware.vmware_target_canonical_info_module.rst
+++ b/docs/community.vmware.vmware_target_canonical_info_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- Tested on vSphere 5.5 and 6.5
-- PyVmomi installed
-
 
 Parameters
 ----------

--- a/docs/community.vmware.vmware_tools_connection.rst
+++ b/docs/community.vmware.vmware_tools_connection.rst
@@ -26,7 +26,6 @@ Requirements
 ------------
 The below requirements are needed on the local Ansible controller node that executes this connection.
 
-- pyvmomi (Python library)
 - requests (Python library)
 
 

--- a/docs/community.vmware.vmware_vc_infraprofile_info_module.rst
+++ b/docs/community.vmware.vmware_vc_infraprofile_info_module.rst
@@ -27,8 +27,6 @@ Requirements
 ------------
 The below requirements are needed on the host that executes this module.
 
-- python >= 2.7
-- PyVmomi
 - vSphere Automation SDK
 
 
@@ -286,12 +284,6 @@ Parameters
     </table>
     <br/>
 
-
-Notes
------
-
-.. note::
-   - Tested on vSphere 7.0
 
 
 

--- a/docs/community.vmware.vmware_vcenter_settings_info_module.rst
+++ b/docs/community.vmware.vmware_vcenter_settings_info_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.7
-- PyVmomi
-
 
 Parameters
 ----------

--- a/docs/community.vmware.vmware_vcenter_settings_module.rst
+++ b/docs/community.vmware.vmware_vcenter_settings_module.rst
@@ -21,13 +21,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -896,7 +889,6 @@ Notes
 -----
 
 .. note::
-   - Tested with vCenter Server Appliance (vCSA) 6.5 and 6.7
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_vcenter_statistics_module.rst
+++ b/docs/community.vmware.vmware_vcenter_statistics_module.rst
@@ -21,13 +21,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -571,7 +564,6 @@ Notes
 -----
 
 .. note::
-   - Tested with vCenter Server Appliance (vCSA) 6.5 and 6.7
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_vm_config_option_module.rst
+++ b/docs/community.vmware.vmware_vm_config_option_module.rst
@@ -22,14 +22,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-- System.View privilege
-
 
 Parameters
 ----------
@@ -317,8 +309,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5
-   - Tested on vSphere 6.7
    - Known issue on vSphere 7.0 (https://github.com/vmware/pyvmomi/issues/915)
    - All modules requires API write access and hence is not supported on a free ESXi license.
 

--- a/docs/community.vmware.vmware_vm_host_drs_rule_module.rst
+++ b/docs/community.vmware.vmware_vm_host_drs_rule_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -335,7 +328,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5 and 6.7
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_vm_info_module.rst
+++ b/docs/community.vmware.vmware_vm_info_module.rst
@@ -21,13 +21,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -295,8 +288,6 @@ Notes
 -----
 
 .. note::
-   - Tested on ESXi 6.7, vSphere 5.5 and vSphere 6.5
-   - From 2.8 and onwards, information are returned as list of dict instead of dict.
    - Fact about ``moid`` added in VMware collection 1.4.0.
    - Fact about ``datastore_url`` is added in VMware collection 1.18.0.
    - All modules requires API write access and hence is not supported on a free ESXi license.

--- a/docs/community.vmware.vmware_vm_inventory_inventory.rst
+++ b/docs/community.vmware.vmware_vm_inventory_inventory.rst
@@ -25,8 +25,6 @@ Requirements
 ------------
 The below requirements are needed on the local Ansible controller node that executes this inventory.
 
-- Python >= 2.7
-- PyVmomi
 - requests >= 2.3
 - vSphere Automation SDK - For tag feature
 

--- a/docs/community.vmware.vmware_vm_shell_module.rst
+++ b/docs/community.vmware.vmware_vm_shell_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -403,7 +396,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 5.5, 6.0 and 6.5.
    - Only the first match against vm_id is used, even if there are multiple matches.
    - All modules requires API write access and hence is not supported on a free ESXi license.
 

--- a/docs/community.vmware.vmware_vm_storage_policy_info_module.rst
+++ b/docs/community.vmware.vmware_vm_storage_policy_info_module.rst
@@ -21,13 +21,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -175,7 +168,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_vm_storage_policy_module.rst
+++ b/docs/community.vmware.vmware_vm_storage_policy_module.rst
@@ -22,13 +22,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.7
-- PyVmomi
-
 
 Parameters
 ----------
@@ -284,7 +277,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_vm_vm_drs_rule_module.rst
+++ b/docs/community.vmware.vmware_vm_vm_drs_rule_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -305,7 +298,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_vm_vss_dvs_migrate_module.rst
+++ b/docs/community.vmware.vmware_vm_vss_dvs_migrate_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -206,7 +199,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 5.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_vmkernel_info_module.rst
+++ b/docs/community.vmware.vmware_vmkernel_info_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -208,7 +201,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_vmkernel_module.rst
+++ b/docs/community.vmware.vmware_vmkernel_module.rst
@@ -23,13 +23,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -554,7 +547,6 @@ Notes
    - The option ``device`` need to be used with DHCP because otherwise it's not possible to check if a VMkernel device is already present
    - You can only change from DHCP to static, and vSS to vDS, or vice versa, in one step, without creating a new device, with ``device`` specified.
    - You can only create the VMKernel adapter on a vDS if authenticated to vCenter and not if authenticated to ESXi.
-   - Tested on vSphere 5.5 and 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_vmotion_module.rst
+++ b/docs/community.vmware.vmware_vmotion_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- pyVmomi
-
 
 Parameters
 ----------
@@ -346,7 +339,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.0
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_vsan_cluster_module.rst
+++ b/docs/community.vmware.vmware_vsan_cluster_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -189,7 +182,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 5.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_vsan_health_info_module.rst
+++ b/docs/community.vmware.vmware_vsan_health_info_module.rst
@@ -24,7 +24,6 @@ Requirements
 ------------
 The below requirements are needed on the host that executes this module.
 
-- PyVmomi
 - VMware vSAN Python's SDK
 
 

--- a/docs/community.vmware.vmware_vspan_session_module.rst
+++ b/docs/community.vmware.vmware_vspan_session_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python > =  2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -567,7 +560,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.7
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_vswitch_info_module.rst
+++ b/docs/community.vmware.vmware_vswitch_info_module.rst
@@ -23,13 +23,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -231,7 +224,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vmware_vswitch_module.rst
+++ b/docs/community.vmware.vmware_vswitch_module.rst
@@ -20,13 +20,6 @@ Synopsis
 
 
 
-Requirements
-------------
-The below requirements are needed on the host that executes this module.
-
-- python >= 2.6
-- PyVmomi
-
 
 Parameters
 ----------
@@ -580,7 +573,6 @@ Notes
 -----
 
 .. note::
-   - Tested on vSphere 5.5 and 6.5
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/docs/community.vmware.vsphere_copy_module.rst
+++ b/docs/community.vmware.vsphere_copy_module.rst
@@ -250,7 +250,6 @@ Notes
 
 .. note::
    - This module ought to be run from a system that can access the vCenter or the ESXi directly and has the file to transfer. It can be the normal remote target or you can change it either by using ``transport: local`` or using ``delegate_to``.
-   - Tested on vSphere 5.5 and ESXi 6.7
    - All modules requires API write access and hence is not supported on a free ESXi license.
 
 

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,5 +1,5 @@
 ---
-requires_ansible: '>=2.11.0'
+requires_ansible: '>=2.12.0'
 
 action_groups:
   vmware:

--- a/plugins/connection/vmware_tools.py
+++ b/plugins/connection/vmware_tools.py
@@ -16,7 +16,6 @@ DOCUMENTATION = r'''
       - In case of Windows VMs, set C(ansible_shell_type) to C(powershell).
       - Does not work with 'become'.
     requirements:
-      - pyvmomi (Python library)
       - requests (Python library)
     options:
       vmware_host:

--- a/plugins/inventory/vmware_host_inventory.py
+++ b/plugins/inventory/vmware_host_inventory.py
@@ -20,9 +20,6 @@ DOCUMENTATION = r"""
       - inventory_cache
       - constructed
     requirements:
-      - "Python >= 2.7"
-      - "PyVmomi"
-      - "requests >= 2.3"
       - "vSphere Automation SDK - For tag feature"
     version_added: "1.11.0"
     options:

--- a/plugins/inventory/vmware_vm_inventory.py
+++ b/plugins/inventory/vmware_vm_inventory.py
@@ -19,8 +19,6 @@ DOCUMENTATION = r'''
       - inventory_cache
       - constructed
     requirements:
-      - "Python >= 2.7"
-      - "PyVmomi"
       - "requests >= 2.3"
       - "vSphere Automation SDK - For tag feature"
     options:

--- a/plugins/modules/vcenter_domain_user_group_info.py
+++ b/plugins/modules/vcenter_domain_user_group_info.py
@@ -15,9 +15,6 @@ author:
   - sky-joker (@sky-joker)
 description:
   - This module can be used to gather information about user or group of a domain.
-requirements:
-  - python >= 2.7
-  - PyVmomi
 options:
   domain:
     description:

--- a/plugins/modules/vcenter_extension.py
+++ b/plugins/modules/vcenter_extension.py
@@ -17,8 +17,6 @@ description:
     - This module can be used to register/deregister vCenter Extensions.
 author:
     - Michael Tipton (@castawayegr)
-notes:
-    - Tested on vSphere 6.5
 options:
   extension_key:
     description:

--- a/plugins/modules/vcenter_extension.py
+++ b/plugins/modules/vcenter_extension.py
@@ -19,9 +19,6 @@ author:
     - Michael Tipton (@castawayegr)
 notes:
     - Tested on vSphere 6.5
-requirements:
-    - "python >= 2.6"
-    - PyVmomi
 options:
   extension_key:
     description:

--- a/plugins/modules/vcenter_extension_info.py
+++ b/plugins/modules/vcenter_extension_info.py
@@ -17,8 +17,6 @@ description:
 - This module can be used to gather information about vCenter extension.
 author:
 - Abhijeet Kasurde (@Akasurde)
-notes:
-- Tested on vSphere 6.5
 extends_documentation_fragment:
 - community.vmware.vmware.documentation
 

--- a/plugins/modules/vcenter_extension_info.py
+++ b/plugins/modules/vcenter_extension_info.py
@@ -19,9 +19,6 @@ author:
 - Abhijeet Kasurde (@Akasurde)
 notes:
 - Tested on vSphere 6.5
-requirements:
-- python >= 2.6
-- PyVmomi
 extends_documentation_fragment:
 - community.vmware.vmware.documentation
 

--- a/plugins/modules/vcenter_folder.py
+++ b/plugins/modules/vcenter_folder.py
@@ -22,9 +22,6 @@ author:
 - Jan Meerkamp (@meerkampdvv)
 notes:
 - Tested on vSphere 6.5
-requirements:
-- python >= 2.6
-- PyVmomi
 options:
   datacenter:
     description:

--- a/plugins/modules/vcenter_folder.py
+++ b/plugins/modules/vcenter_folder.py
@@ -20,8 +20,6 @@ author:
 - Abhijeet Kasurde (@Akasurde)
 - Christian Kotte (@ckotte) <christian.kotte@gmx.de>
 - Jan Meerkamp (@meerkampdvv)
-notes:
-- Tested on vSphere 6.5
 options:
   datacenter:
     description:

--- a/plugins/modules/vcenter_license.py
+++ b/plugins/modules/vcenter_license.py
@@ -15,8 +15,6 @@ description:
 - Add and delete vCenter, ESXi server license keys.
 author:
 - Dag Wieers (@dagwieers)
-requirements:
-- pyVmomi
 options:
   labels:
     description:

--- a/plugins/modules/vcenter_standard_key_provider.py
+++ b/plugins/modules/vcenter_standard_key_provider.py
@@ -20,9 +20,6 @@ description: >
   https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.security.doc/GUID-6DB1E745-9624-43EA-847C-DD2F767CB94B.html)
 author:
   - Diane Wang (@Tomorrow9) <dianew@vmware.com>
-requirements:
-  - python >= 3.6
-  - PyVmomi
 options:
   name:
     description: Name of the Key Provider to be added, reconfigured or removed from vCenter.

--- a/plugins/modules/vmware_about_info.py
+++ b/plugins/modules/vmware_about_info.py
@@ -19,9 +19,6 @@ author:
 - Abhijeet Kasurde (@Akasurde)
 notes:
 - Tested on vSphere 6.5
-requirements:
-- python >= 2.6
-- PyVmomi
 extends_documentation_fragment:
 - community.vmware.vmware.documentation
 

--- a/plugins/modules/vmware_about_info.py
+++ b/plugins/modules/vmware_about_info.py
@@ -17,8 +17,6 @@ description:
 - This module can be used to gather information about VMware server to which user is trying to connect.
 author:
 - Abhijeet Kasurde (@Akasurde)
-notes:
-- Tested on vSphere 6.5
 extends_documentation_fragment:
 - community.vmware.vmware.documentation
 

--- a/plugins/modules/vmware_category.py
+++ b/plugins/modules/vmware_category.py
@@ -23,8 +23,6 @@ author:
 notes:
 - Tested on vSphere 6.5
 requirements:
-- python >= 2.6
-- PyVmomi
 - vSphere Automation SDK
 options:
     category_name:

--- a/plugins/modules/vmware_category.py
+++ b/plugins/modules/vmware_category.py
@@ -20,8 +20,6 @@ description:
 - All variables and VMware object names are case sensitive.
 author:
 - Abhijeet Kasurde (@Akasurde)
-notes:
-- Tested on vSphere 6.5
 requirements:
 - vSphere Automation SDK
 options:

--- a/plugins/modules/vmware_category_info.py
+++ b/plugins/modules/vmware_category_info.py
@@ -23,8 +23,6 @@ author:
 notes:
 - Tested on vSphere 6.5
 requirements:
-- python >= 2.6
-- PyVmomi
 - vSphere Automation SDK
 extends_documentation_fragment:
 - community.vmware.vmware_rest_client.documentation

--- a/plugins/modules/vmware_category_info.py
+++ b/plugins/modules/vmware_category_info.py
@@ -20,8 +20,6 @@ description:
 - All variables and VMware object names are case sensitive.
 author:
 - Abhijeet Kasurde (@Akasurde)
-notes:
-- Tested on vSphere 6.5
 requirements:
 - vSphere Automation SDK
 extends_documentation_fragment:

--- a/plugins/modules/vmware_cfg_backup.py
+++ b/plugins/modules/vmware_cfg_backup.py
@@ -22,9 +22,6 @@ notes:
     - Tested on ESXi 6.0
     - Works only for ESXi hosts
     - For configuration load or reset, the host will be switched automatically to maintenance mode.
-requirements:
-    - "python >= 2.6"
-    - PyVmomi installed
 options:
     esxi_hostname:
         description:

--- a/plugins/modules/vmware_cfg_backup.py
+++ b/plugins/modules/vmware_cfg_backup.py
@@ -19,7 +19,6 @@ description:
 author:
     - Andreas Nafpliotis (@nafpliot-ibm)
 notes:
-    - Tested on ESXi 6.0
     - Works only for ESXi hosts
     - For configuration load or reset, the host will be switched automatically to maintenance mode.
 options:

--- a/plugins/modules/vmware_cluster.py
+++ b/plugins/modules/vmware_cluster.py
@@ -21,9 +21,6 @@ description:
 author:
 - Joseph Callen (@jcpowermac)
 - Abhijeet Kasurde (@Akasurde)
-requirements:
-    - Tested on ESXi 5.5 and 6.5.
-    - PyVmomi installed.
 options:
     cluster_name:
       description:

--- a/plugins/modules/vmware_cluster_dpm.py
+++ b/plugins/modules/vmware_cluster_dpm.py
@@ -20,9 +20,6 @@ description:
     - All values and VMware object names are case sensitive.
 author:
 - Olivia Luetolf (@olilu)
-requirements:
-    - Tested on ESXi 6.7 and 7.0.
-    - PyVmomi installed.
 options:
     cluster_name:
       description:

--- a/plugins/modules/vmware_cluster_drs.py
+++ b/plugins/modules/vmware_cluster_drs.py
@@ -20,9 +20,6 @@ description:
 author:
 - Joseph Callen (@jcpowermac)
 - Abhijeet Kasurde (@Akasurde)
-requirements:
-    - Tested on ESXi 5.5 and 6.5.
-    - PyVmomi installed.
 options:
     cluster_name:
       description:

--- a/plugins/modules/vmware_cluster_ha.py
+++ b/plugins/modules/vmware_cluster_ha.py
@@ -21,9 +21,6 @@ description:
 author:
 - Joseph Callen (@jcpowermac)
 - Abhijeet Kasurde (@Akasurde)
-requirements:
-    - Tested on ESXi 5.5 and 6.5.
-    - PyVmomi installed.
 options:
     cluster_name:
       description:

--- a/plugins/modules/vmware_cluster_info.py
+++ b/plugins/modules/vmware_cluster_info.py
@@ -20,8 +20,6 @@ description:
 author:
     - Abhijeet Kasurde (@Akasurde)
     - Christian Neugum (@digifuchsi)
-notes:
-    - Tested on vSphere 6.5, 6.7
 options:
    datacenter:
      description:

--- a/plugins/modules/vmware_cluster_info.py
+++ b/plugins/modules/vmware_cluster_info.py
@@ -22,9 +22,6 @@ author:
     - Christian Neugum (@digifuchsi)
 notes:
     - Tested on vSphere 6.5, 6.7
-requirements:
-    - "python >= 2.6"
-    - PyVmomi
 options:
    datacenter:
      description:

--- a/plugins/modules/vmware_cluster_vcls.py
+++ b/plugins/modules/vmware_cluster_vcls.py
@@ -21,9 +21,6 @@ description:
 author:
 - Joseph Callen (@jcpowermac)
 - Nina Loser (@Nina2244)
-requirements:
-    - Tested on ESXi 7.0
-    - PyVmomi installed.
 options:
     cluster_name:
       description:

--- a/plugins/modules/vmware_cluster_vsan.py
+++ b/plugins/modules/vmware_cluster_vsan.py
@@ -22,8 +22,6 @@ author:
 - Abhijeet Kasurde (@Akasurde)
 - Mario Lenz (@mariolenz)
 requirements:
-    - Tested on ESXi 6.7.
-    - PyVmomi installed.
     - vSAN Management SDK, which needs to be downloaded from VMware and installed manually.
 options:
     cluster_name:

--- a/plugins/modules/vmware_content_deploy_ovf_template.py
+++ b/plugins/modules/vmware_content_deploy_ovf_template.py
@@ -18,8 +18,6 @@ description:
 - All variables and VMware object names are case sensitive.
 author:
 - Lev Goncharv (@ultral)
-notes:
-- Tested on vSphere 6.7
 requirements:
 - vSphere Automation SDK
 options:

--- a/plugins/modules/vmware_content_deploy_ovf_template.py
+++ b/plugins/modules/vmware_content_deploy_ovf_template.py
@@ -21,8 +21,6 @@ author:
 notes:
 - Tested on vSphere 6.7
 requirements:
-- python >= 2.6
-- PyVmomi
 - vSphere Automation SDK
 options:
     log_level:

--- a/plugins/modules/vmware_content_deploy_template.py
+++ b/plugins/modules/vmware_content_deploy_template.py
@@ -25,8 +25,6 @@ author:
 notes:
 - Tested on vSphere 6.7 U3
 requirements:
-- python >= 2.6
-- PyVmomi
 - vSphere Automation SDK
 options:
     log_level:

--- a/plugins/modules/vmware_content_deploy_template.py
+++ b/plugins/modules/vmware_content_deploy_template.py
@@ -22,8 +22,6 @@ description:
 - All variables and VMware object names are case sensitive.
 author:
 - Pavan Bidkar (@pgbidkar)
-notes:
-- Tested on vSphere 6.7 U3
 requirements:
 - vSphere Automation SDK
 options:

--- a/plugins/modules/vmware_content_library_info.py
+++ b/plugins/modules/vmware_content_library_info.py
@@ -21,8 +21,6 @@ description:
 - All variables and VMware object names are case sensitive.
 author:
 - Pavan Bidkar (@pgbidkar)
-notes:
-- Tested on vSphere 6.5, 6.7
 requirements:
 - vSphere Automation SDK
 options:

--- a/plugins/modules/vmware_content_library_info.py
+++ b/plugins/modules/vmware_content_library_info.py
@@ -24,8 +24,6 @@ author:
 notes:
 - Tested on vSphere 6.5, 6.7
 requirements:
-- python >= 2.6
-- PyVmomi
 - vSphere Automation SDK
 options:
     library_id:

--- a/plugins/modules/vmware_content_library_manager.py
+++ b/plugins/modules/vmware_content_library_manager.py
@@ -20,8 +20,6 @@ description:
 - All variables and VMware object names are case sensitive.
 author:
 - Pavan Bidkar (@pgbidkar)
-notes:
-- Tested on vSphere 6.5, 6.7, and 7.0
 requirements:
 - vSphere Automation SDK
 options:

--- a/plugins/modules/vmware_content_library_manager.py
+++ b/plugins/modules/vmware_content_library_manager.py
@@ -23,8 +23,6 @@ author:
 notes:
 - Tested on vSphere 6.5, 6.7, and 7.0
 requirements:
-- python >= 2.6
-- PyVmomi
 - vSphere Automation SDK
 options:
     library_name:

--- a/plugins/modules/vmware_datacenter.py
+++ b/plugins/modules/vmware_datacenter.py
@@ -19,8 +19,6 @@ description:
 author:
 - Joseph Callen (@jcpowermac)
 - Kamil Szczygiel (@kamsz)
-notes:
-    - Tested on vSphere 6.0, 6.5
 options:
     datacenter_name:
       description:

--- a/plugins/modules/vmware_datacenter.py
+++ b/plugins/modules/vmware_datacenter.py
@@ -21,9 +21,6 @@ author:
 - Kamil Szczygiel (@kamsz)
 notes:
     - Tested on vSphere 6.0, 6.5
-requirements:
-    - "python >= 2.6"
-    - PyVmomi
 options:
     datacenter_name:
       description:

--- a/plugins/modules/vmware_datacenter_info.py
+++ b/plugins/modules/vmware_datacenter_info.py
@@ -20,9 +20,6 @@ author:
 - Abhijeet Kasurde (@Akasurde)
 notes:
     - Tested on vSphere 6.5
-requirements:
-    - "python >= 2.7"
-    - PyVmomi
 options:
     datacenter:
       description:

--- a/plugins/modules/vmware_datacenter_info.py
+++ b/plugins/modules/vmware_datacenter_info.py
@@ -18,8 +18,6 @@ description:
     - This module can be used to gather information VMware vSphere Datacenters.
 author:
 - Abhijeet Kasurde (@Akasurde)
-notes:
-    - Tested on vSphere 6.5
 options:
     datacenter:
       description:

--- a/plugins/modules/vmware_datastore_cluster.py
+++ b/plugins/modules/vmware_datastore_cluster.py
@@ -19,8 +19,6 @@ description:
     - All parameters and VMware object values are case sensitive.
 author:
 -  Abhijeet Kasurde (@Akasurde)
-notes:
-    - Tested on vSphere 6.0, 6.5
 options:
     datacenter_name:
       description:

--- a/plugins/modules/vmware_datastore_cluster.py
+++ b/plugins/modules/vmware_datastore_cluster.py
@@ -21,9 +21,6 @@ author:
 -  Abhijeet Kasurde (@Akasurde)
 notes:
     - Tested on vSphere 6.0, 6.5
-requirements:
-    - "python >= 2.6"
-    - PyVmomi
 options:
     datacenter_name:
       description:

--- a/plugins/modules/vmware_datastore_cluster_manager.py
+++ b/plugins/modules/vmware_datastore_cluster_manager.py
@@ -21,9 +21,6 @@ author:
 -  Abhijeet Kasurde (@Akasurde)
 notes:
     - Tested on vSphere 6.0, 6.5
-requirements:
-    - "python >= 2.7"
-    - PyVmomi
 options:
     datacenter_name:
       description:

--- a/plugins/modules/vmware_datastore_cluster_manager.py
+++ b/plugins/modules/vmware_datastore_cluster_manager.py
@@ -19,8 +19,6 @@ description:
     - All parameters and VMware object values are case sensitive.
 author:
 -  Abhijeet Kasurde (@Akasurde)
-notes:
-    - Tested on vSphere 6.0, 6.5
 options:
     datacenter_name:
       description:

--- a/plugins/modules/vmware_datastore_info.py
+++ b/plugins/modules/vmware_datastore_info.py
@@ -21,9 +21,6 @@ author:
     - Tim Rightnour (@garbled1)
 notes:
     - Tested on vSphere 5.5, 6.0 and 6.5
-requirements:
-    - "python >= 2.6"
-    - PyVmomi
 options:
    name:
      description:

--- a/plugins/modules/vmware_datastore_info.py
+++ b/plugins/modules/vmware_datastore_info.py
@@ -19,8 +19,6 @@ description:
     - All values and VMware object names are case sensitive.
 author:
     - Tim Rightnour (@garbled1)
-notes:
-    - Tested on vSphere 5.5, 6.0 and 6.5
 options:
    name:
      description:

--- a/plugins/modules/vmware_datastore_maintenancemode.py
+++ b/plugins/modules/vmware_datastore_maintenancemode.py
@@ -18,8 +18,6 @@ description:
     - This module can be used to manage maintenance mode of a datastore.
 author:
 - "Abhijeet Kasurde (@Akasurde)"
-notes:
-    - Tested on vSphere 5.5, 6.0 and 6.5
 options:
     datastore:
       description:

--- a/plugins/modules/vmware_datastore_maintenancemode.py
+++ b/plugins/modules/vmware_datastore_maintenancemode.py
@@ -20,9 +20,6 @@ author:
 - "Abhijeet Kasurde (@Akasurde)"
 notes:
     - Tested on vSphere 5.5, 6.0 and 6.5
-requirements:
-    - "python >= 2.6"
-    - PyVmomi
 options:
     datastore:
       description:

--- a/plugins/modules/vmware_deploy_ovf.py
+++ b/plugins/modules/vmware_deploy_ovf.py
@@ -134,8 +134,6 @@ options:
         - Wait until vCenter detects an IP address for the VM.
         - This requires vmware-tools (vmtoolsd) to properly work after creation.
         type: bool
-requirements:
-    - pyvmomi
 extends_documentation_fragment:
 - community.vmware.vmware.documentation
 

--- a/plugins/modules/vmware_dns_config.py
+++ b/plugins/modules/vmware_dns_config.py
@@ -17,8 +17,6 @@ description:
     - Manage VMware ESXi DNS Configuration
 author:
 - Joseph Callen (@jcpowermac)
-notes:
-    - Tested on vSphere 5.5
 deprecated:
     removed_at_date: '2022-06-01'
     why: Will be replaced with new module M(community.vmware.vmware_host_dns).

--- a/plugins/modules/vmware_dns_config.py
+++ b/plugins/modules/vmware_dns_config.py
@@ -19,9 +19,6 @@ author:
 - Joseph Callen (@jcpowermac)
 notes:
     - Tested on vSphere 5.5
-requirements:
-    - "python >= 2.6"
-    - PyVmomi
 deprecated:
     removed_at_date: '2022-06-01'
     why: Will be replaced with new module M(community.vmware.vmware_host_dns).

--- a/plugins/modules/vmware_drs_group.py
+++ b/plugins/modules/vmware_drs_group.py
@@ -63,9 +63,6 @@ options:
     required: false
     type: list
     elements: str
-requirements:
-  - "python >= 2.7"
-  - PyVmomi
 short_description: "Creates vm/host group in a given cluster."
 '''
 

--- a/plugins/modules/vmware_drs_group.py
+++ b/plugins/modules/vmware_drs_group.py
@@ -20,8 +20,6 @@ extends_documentation_fragment:
 - community.vmware.vmware.documentation
 
 module: vmware_drs_group
-notes:
-  - Tested on vSphere 6.5, and 6.7
 options:
   cluster_name:
     description:

--- a/plugins/modules/vmware_drs_group_info.py
+++ b/plugins/modules/vmware_drs_group_info.py
@@ -20,8 +20,6 @@ extends_documentation_fragment:
 - community.vmware.vmware.documentation
 
 module: vmware_drs_group_info
-notes:
-  - "Tested on vSphere 6.5 and 6.7"
 options:
   cluster_name:
     description:

--- a/plugins/modules/vmware_drs_group_info.py
+++ b/plugins/modules/vmware_drs_group_info.py
@@ -37,9 +37,6 @@ options:
       - "Datacenter to search for DRS VM/Host groups."
     required: false
     type: str
-requirements:
-  - "python >= 2.6"
-  - PyVmomi
 short_description: "Gathers info about DRS VM/Host groups on the given cluster"
 '''
 

--- a/plugins/modules/vmware_drs_group_manager.py
+++ b/plugins/modules/vmware_drs_group_manager.py
@@ -64,9 +64,6 @@ options:
       - If set to C(present), VMs/hosts will be added to the given DRS group.
       - If set to C(absent), VMs/hosts will be removed from the given DRS group.
     type: str
-requirements:
-  - "python >= 2.7"
-  - PyVmomi
 version_added: '1.7.0'
 '''
 

--- a/plugins/modules/vmware_drs_group_manager.py
+++ b/plugins/modules/vmware_drs_group_manager.py
@@ -21,8 +21,6 @@ description:
   - The module can be used to add VMs / Hosts to or remove them from a DRS group.
 extends_documentation_fragment:
 - community.vmware.vmware.documentation
-notes:
-  - Tested on vSphere 6.5, and 6.7.
 options:
   cluster:
     description:

--- a/plugins/modules/vmware_drs_rule_info.py
+++ b/plugins/modules/vmware_drs_rule_info.py
@@ -18,8 +18,6 @@ description:
 - 'This module can be used to gather information about DRS VM-VM and VM-HOST rules from the given cluster.'
 author:
 - Abhijeet Kasurde (@Akasurde)
-notes:
-- Tested on vSphere 6.5
 options:
   cluster_name:
     description:

--- a/plugins/modules/vmware_drs_rule_info.py
+++ b/plugins/modules/vmware_drs_rule_info.py
@@ -20,9 +20,6 @@ author:
 - Abhijeet Kasurde (@Akasurde)
 notes:
 - Tested on vSphere 6.5
-requirements:
-- python >= 2.6
-- PyVmomi
 options:
   cluster_name:
     description:

--- a/plugins/modules/vmware_dvs_host.py
+++ b/plugins/modules/vmware_dvs_host.py
@@ -24,9 +24,6 @@ author:
 - Joseph Andreatta (@vmwjoseph)
 notes:
     - Tested on vSphere 5.5
-requirements:
-    - "python >= 2.7"
-    - PyVmomi
 options:
     esxi_hostname:
         description:

--- a/plugins/modules/vmware_dvs_host.py
+++ b/plugins/modules/vmware_dvs_host.py
@@ -22,8 +22,6 @@ author:
 - Joseph Callen (@jcpowermac)
 - Abhijeet Kasurde (@Akasurde)
 - Joseph Andreatta (@vmwjoseph)
-notes:
-    - Tested on vSphere 5.5
 options:
     esxi_hostname:
         description:

--- a/plugins/modules/vmware_dvs_portgroup.py
+++ b/plugins/modules/vmware_dvs_portgroup.py
@@ -19,8 +19,6 @@ description:
 author:
     - Joseph Callen (@jcpowermac)
     - Philippe Dellaert (@pdellaert) <philippe@dellaert.org>
-notes:
-    - Tested on vSphere 7.0
 options:
     portgroup_name:
         description:

--- a/plugins/modules/vmware_dvs_portgroup.py
+++ b/plugins/modules/vmware_dvs_portgroup.py
@@ -21,9 +21,6 @@ author:
     - Philippe Dellaert (@pdellaert) <philippe@dellaert.org>
 notes:
     - Tested on vSphere 7.0
-requirements:
-    - "python >= 2.6"
-    - PyVmomi
 options:
     portgroup_name:
         description:

--- a/plugins/modules/vmware_dvs_portgroup_find.py
+++ b/plugins/modules/vmware_dvs_portgroup_find.py
@@ -19,9 +19,6 @@ author:
 - David Martinez (@dx0xm)
 notes:
 - Tested on vSphere 6.5
-requirements:
-- python >= 2.7
-- PyVmomi
 options:
   dvswitch:
     description:

--- a/plugins/modules/vmware_dvs_portgroup_find.py
+++ b/plugins/modules/vmware_dvs_portgroup_find.py
@@ -17,8 +17,6 @@ description:
 - Find portgroup(s) based on different criteria such as distributed vSwitch, VLAN id or a string in the name.
 author:
 - David Martinez (@dx0xm)
-notes:
-- Tested on vSphere 6.5
 options:
   dvswitch:
     description:

--- a/plugins/modules/vmware_dvs_portgroup_info.py
+++ b/plugins/modules/vmware_dvs_portgroup_info.py
@@ -20,9 +20,6 @@ author:
 - Abhijeet Kasurde (@Akasurde)
 notes:
 - Tested on vSphere 7.0
-requirements:
-- python >= 2.6
-- PyVmomi
 options:
   datacenter:
     description:

--- a/plugins/modules/vmware_dvs_portgroup_info.py
+++ b/plugins/modules/vmware_dvs_portgroup_info.py
@@ -18,8 +18,6 @@ description:
 - This module can be used to gather information about DVS portgroup configurations.
 author:
 - Abhijeet Kasurde (@Akasurde)
-notes:
-- Tested on vSphere 7.0
 options:
   datacenter:
     description:

--- a/plugins/modules/vmware_dvswitch.py
+++ b/plugins/modules/vmware_dvswitch.py
@@ -24,9 +24,6 @@ author:
 - Christian Kotte (@ckotte)
 notes:
     - Tested on vSphere 6.5, 6.7 and 7.0
-requirements:
-    - "python >= 2.6"
-    - PyVmomi
 options:
     datacenter_name:
         description:

--- a/plugins/modules/vmware_dvswitch.py
+++ b/plugins/modules/vmware_dvswitch.py
@@ -22,8 +22,6 @@ author:
 - Joseph Callen (@jcpowermac)
 - Abhijeet Kasurde (@Akasurde)
 - Christian Kotte (@ckotte)
-notes:
-    - Tested on vSphere 6.5, 6.7 and 7.0
 options:
     datacenter_name:
         description:

--- a/plugins/modules/vmware_dvswitch_info.py
+++ b/plugins/modules/vmware_dvswitch_info.py
@@ -17,9 +17,6 @@ description:
     - This module can be used to gather information about dvswitch configurations.
 author:
     - sky-joker (@sky-joker)
-requirements:
-    - "python >= 2.7"
-    - PyVmomi
 options:
     folder:
       description:

--- a/plugins/modules/vmware_dvswitch_lacp.py
+++ b/plugins/modules/vmware_dvswitch_lacp.py
@@ -20,9 +20,6 @@ author:
 notes:
     - Tested on vSphere 6.7
     - You need to run the task two times if you want to remove all LAGs and change the support mode to 'basic'
-requirements:
-    - "python >= 2.6"
-    - PyVmomi
 options:
     switch:
         description:

--- a/plugins/modules/vmware_dvswitch_lacp.py
+++ b/plugins/modules/vmware_dvswitch_lacp.py
@@ -18,7 +18,6 @@ description:
 author:
 - Christian Kotte (@ckotte)
 notes:
-    - Tested on vSphere 6.7
     - You need to run the task two times if you want to remove all LAGs and change the support mode to 'basic'
 options:
     switch:

--- a/plugins/modules/vmware_dvswitch_nioc.py
+++ b/plugins/modules/vmware_dvswitch_nioc.py
@@ -18,8 +18,6 @@ description:
     - This module can be used to manage distributed switch Network IO Control configurations.
 author:
     - Joseph Andreatta (@vmwjoseph)
-notes:
-    - Tested on vSphere 6.7
 options:
     switch:
         description:

--- a/plugins/modules/vmware_dvswitch_nioc.py
+++ b/plugins/modules/vmware_dvswitch_nioc.py
@@ -20,9 +20,6 @@ author:
     - Joseph Andreatta (@vmwjoseph)
 notes:
     - Tested on vSphere 6.7
-requirements:
-    - "python >= 2.6"
-    - PyVmomi
 options:
     switch:
         description:

--- a/plugins/modules/vmware_dvswitch_pvlans.py
+++ b/plugins/modules/vmware_dvswitch_pvlans.py
@@ -19,9 +19,6 @@ author:
 - Christian Kotte (@ckotte)
 notes:
     - Tested on vSphere 6.5 and 6.7
-requirements:
-    - "python >= 2.6"
-    - PyVmomi
 options:
     switch:
         description:

--- a/plugins/modules/vmware_dvswitch_pvlans.py
+++ b/plugins/modules/vmware_dvswitch_pvlans.py
@@ -17,8 +17,6 @@ description:
     - This module can be used to configure Private VLANs (PVLANs) on a Distributed Switch.
 author:
 - Christian Kotte (@ckotte)
-notes:
-    - Tested on vSphere 6.5 and 6.7
 options:
     switch:
         description:

--- a/plugins/modules/vmware_dvswitch_uplink_pg.py
+++ b/plugins/modules/vmware_dvswitch_uplink_pg.py
@@ -19,9 +19,6 @@ author:
 - Christian Kotte (@ckotte)
 notes:
     - Tested on vSphere 6.5 and 6.7
-requirements:
-    - "python >= 2.6"
-    - PyVmomi
 options:
     switch:
         description:

--- a/plugins/modules/vmware_dvswitch_uplink_pg.py
+++ b/plugins/modules/vmware_dvswitch_uplink_pg.py
@@ -17,8 +17,6 @@ description:
     - This module can be used to configure the uplink portgroup of a Distributed Switch.
 author:
 - Christian Kotte (@ckotte)
-notes:
-    - Tested on vSphere 6.5 and 6.7
 options:
     switch:
         description:

--- a/plugins/modules/vmware_evc_mode.py
+++ b/plugins/modules/vmware_evc_mode.py
@@ -19,9 +19,6 @@ author:
     - Michael Tipton (@castawayegr)
 notes:
     - Tested on vSphere 6.7
-requirements:
-    - "python >= 2.6"
-    - PyVmomi
 options:
   datacenter_name:
     description:

--- a/plugins/modules/vmware_evc_mode.py
+++ b/plugins/modules/vmware_evc_mode.py
@@ -17,8 +17,6 @@ description:
     - This module can be used to enable/disable EVC mode on vCenter.
 author:
     - Michael Tipton (@castawayegr)
-notes:
-    - Tested on vSphere 6.7
 options:
   datacenter_name:
     description:

--- a/plugins/modules/vmware_export_ovf.py
+++ b/plugins/modules/vmware_export_ovf.py
@@ -18,9 +18,6 @@ description: >
    This module can be used to export a VMware virtual machine to OVF template from vCenter server or ESXi host.
 author:
 - Diane Wang (@Tomorrow9) <dianew@vmware.com>
-requirements:
-- python >= 2.6
-- PyVmomi
 notes: []
 options:
   name:

--- a/plugins/modules/vmware_first_class_disk.py
+++ b/plugins/modules/vmware_first_class_disk.py
@@ -18,8 +18,6 @@ description:
     - This module can be used to manage (create, delete, resize) VMware vSphere First Class Disks.
 author:
 - Mario Lenz (@mariolenz)
-notes:
-    - Tested on vSphere 7.0
 options:
     datacenter_name:
       description: The name of the datacenter.

--- a/plugins/modules/vmware_first_class_disk.py
+++ b/plugins/modules/vmware_first_class_disk.py
@@ -20,9 +20,6 @@ author:
 - Mario Lenz (@mariolenz)
 notes:
     - Tested on vSphere 7.0
-requirements:
-    - "python >= 2.6"
-    - PyVmomi
 options:
     datacenter_name:
       description: The name of the datacenter.

--- a/plugins/modules/vmware_folder_info.py
+++ b/plugins/modules/vmware_folder_info.py
@@ -18,7 +18,6 @@ description:
 author:
 - David Hewitt (@davidmhewitt)
 notes:
-- Tested on vSphere 6.5
 - C(flat_folder_info) added in VMware collection 1.4.0.
 options:
   datacenter:

--- a/plugins/modules/vmware_folder_info.py
+++ b/plugins/modules/vmware_folder_info.py
@@ -20,9 +20,6 @@ author:
 notes:
 - Tested on vSphere 6.5
 - C(flat_folder_info) added in VMware collection 1.4.0.
-requirements:
-- python >= 2.6
-- PyVmomi
 options:
   datacenter:
     description:

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -22,9 +22,6 @@ author:
 - Loic Blot (@nerzhul) <loic.blot@unix-experience.fr>
 - Philippe Dellaert (@pdellaert) <philippe@dellaert.org>
 - Abhijeet Kasurde (@Akasurde) <akasurde@redhat.com>
-requirements:
-- python >= 2.6
-- PyVmomi
 notes:
     - Please make sure that the user used for M(community.vmware.vmware_guest) has the correct level of privileges.
     - For example, following is the list of minimum privileges required by users to create virtual machines.

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -32,7 +32,6 @@ notes:
     - "   Network > Assign Network"
     - "   Resource > Assign Virtual Machine to Resource Pool"
     - "Module may require additional privileges as well, which may be required for gathering facts - e.g. ESXi configurations."
-    - Tested on vSphere 5.5, 6.0, 6.5 and 6.7.
     - Use SCSI disks instead of IDE when you want to expand online disks by specifying a SCSI controller.
     - Uses SysPrep for Windows VM (depends on 'guest_id' parameter match 'win') with PyVmomi.
     - In order to change the VM's parameters (e.g. number of CPUs), the VM must be powered off unless the hot-add

--- a/plugins/modules/vmware_guest_boot_info.py
+++ b/plugins/modules/vmware_guest_boot_info.py
@@ -18,8 +18,6 @@ description:
     - Gather information about boot options for the given virtual machine.
 author:
     - Abhijeet Kasurde (@Akasurde)
-notes:
-    - Tested on vSphere 6.5
 options:
    name:
      description:

--- a/plugins/modules/vmware_guest_boot_info.py
+++ b/plugins/modules/vmware_guest_boot_info.py
@@ -20,9 +20,6 @@ author:
     - Abhijeet Kasurde (@Akasurde)
 notes:
     - Tested on vSphere 6.5
-requirements:
-    - "python >= 2.6"
-    - PyVmomi
 options:
    name:
      description:

--- a/plugins/modules/vmware_guest_boot_manager.py
+++ b/plugins/modules/vmware_guest_boot_manager.py
@@ -18,8 +18,6 @@ description:
     - This module can be used to manage boot options for the given virtual machine.
 author:
     - Abhijeet Kasurde (@Akasurde) <akasurde@redhat.com>
-notes:
-    - Tested on vSphere 6.5
 options:
    name:
      description:

--- a/plugins/modules/vmware_guest_boot_manager.py
+++ b/plugins/modules/vmware_guest_boot_manager.py
@@ -20,9 +20,6 @@ author:
     - Abhijeet Kasurde (@Akasurde) <akasurde@redhat.com>
 notes:
     - Tested on vSphere 6.5
-requirements:
-    - "python >= 2.6"
-    - PyVmomi
 options:
    name:
      description:

--- a/plugins/modules/vmware_guest_controller.py
+++ b/plugins/modules/vmware_guest_controller.py
@@ -21,9 +21,6 @@ author:
     - Diane Wang (@Tomorrow9) <dianew@vmware.com>
 notes:
     - Tested on vSphere 6.0, 6.5 and 6.7
-requirements:
-    - "python >= 2.7"
-    - PyVmomi
 options:
    name:
      description:

--- a/plugins/modules/vmware_guest_controller.py
+++ b/plugins/modules/vmware_guest_controller.py
@@ -19,8 +19,6 @@ description:
     - All parameters and VMware object names are case sensitive.
 author:
     - Diane Wang (@Tomorrow9) <dianew@vmware.com>
-notes:
-    - Tested on vSphere 6.0, 6.5 and 6.7
 options:
    name:
      description:

--- a/plugins/modules/vmware_guest_custom_attribute_defs.py
+++ b/plugins/modules/vmware_guest_custom_attribute_defs.py
@@ -18,8 +18,6 @@ description:
 author:
     - Jimmy Conner (@cigamit)
     - Abhijeet Kasurde (@Akasurde)
-notes:
-    - Tested on vSphere 6.5
 options:
    attribute_key:
      description:

--- a/plugins/modules/vmware_guest_custom_attribute_defs.py
+++ b/plugins/modules/vmware_guest_custom_attribute_defs.py
@@ -20,9 +20,6 @@ author:
     - Abhijeet Kasurde (@Akasurde)
 notes:
     - Tested on vSphere 6.5
-requirements:
-    - "python >= 2.6"
-    - PyVmomi
 options:
    attribute_key:
      description:

--- a/plugins/modules/vmware_guest_custom_attributes.py
+++ b/plugins/modules/vmware_guest_custom_attributes.py
@@ -21,9 +21,6 @@ author:
     - Abhijeet Kasurde (@Akasurde)
 notes:
     - Tested on vSphere 6.5
-requirements:
-    - "python >= 2.6"
-    - PyVmomi
 options:
    name:
      description:

--- a/plugins/modules/vmware_guest_custom_attributes.py
+++ b/plugins/modules/vmware_guest_custom_attributes.py
@@ -19,8 +19,6 @@ description:
 author:
     - Jimmy Conner (@cigamit)
     - Abhijeet Kasurde (@Akasurde)
-notes:
-    - Tested on vSphere 6.5
 options:
    name:
      description:

--- a/plugins/modules/vmware_guest_customization_info.py
+++ b/plugins/modules/vmware_guest_customization_info.py
@@ -19,8 +19,6 @@ description:
     - All parameters and VMware object names are case sensitive.
 author:
     - Abhijeet Kasurde (@Akasurde)
-notes:
-    - Tested on vSphere 6.0 and 6.5
 options:
    spec_name:
      description:

--- a/plugins/modules/vmware_guest_customization_info.py
+++ b/plugins/modules/vmware_guest_customization_info.py
@@ -21,9 +21,6 @@ author:
     - Abhijeet Kasurde (@Akasurde)
 notes:
     - Tested on vSphere 6.0 and 6.5
-requirements:
-    - "python >= 2.6"
-    - PyVmomi
 options:
    spec_name:
      description:

--- a/plugins/modules/vmware_guest_disk.py
+++ b/plugins/modules/vmware_guest_disk.py
@@ -23,9 +23,6 @@ author:
     - Abhijeet Kasurde (@Akasurde) <akasurde@redhat.com>
 notes:
     - Tested on vSphere 6.0 and 6.5
-requirements:
-    - "python >= 2.6"
-    - PyVmomi
 options:
    name:
      description:

--- a/plugins/modules/vmware_guest_disk.py
+++ b/plugins/modules/vmware_guest_disk.py
@@ -21,8 +21,6 @@ description:
     - Be careful while removing disk specified as this may lead to data loss.
 author:
     - Abhijeet Kasurde (@Akasurde) <akasurde@redhat.com>
-notes:
-    - Tested on vSphere 6.0 and 6.5
 options:
    name:
      description:

--- a/plugins/modules/vmware_guest_disk_info.py
+++ b/plugins/modules/vmware_guest_disk_info.py
@@ -24,9 +24,6 @@ notes:
     - Tested on vSphere 6.0 and 6.5.
     - Disk UUID information is added in version 2.8.
     - Additional information about guest disk backings added in version 2.8.
-requirements:
-    - "python >= 2.6"
-    - PyVmomi
 options:
    name:
      description:

--- a/plugins/modules/vmware_guest_disk_info.py
+++ b/plugins/modules/vmware_guest_disk_info.py
@@ -20,10 +20,6 @@ description:
     - All parameters and VMware object names are case sensitive.
 author:
     - Abhijeet Kasurde (@Akasurde) <akasurde@redhat.com>
-notes:
-    - Tested on vSphere 6.0 and 6.5.
-    - Disk UUID information is added in version 2.8.
-    - Additional information about guest disk backings added in version 2.8.
 options:
    name:
      description:

--- a/plugins/modules/vmware_guest_file_operation.py
+++ b/plugins/modules/vmware_guest_file_operation.py
@@ -18,7 +18,6 @@ description:
 author:
   - Stéphane Travassac (@stravassac)
 notes:
-    - Tested on vSphere 6
     - Only the first match against vm_id is used, even if there are multiple matches
 options:
     datacenter:

--- a/plugins/modules/vmware_guest_file_operation.py
+++ b/plugins/modules/vmware_guest_file_operation.py
@@ -20,10 +20,6 @@ author:
 notes:
     - Tested on vSphere 6
     - Only the first match against vm_id is used, even if there are multiple matches
-requirements:
-    - "python >= 2.6"
-    - PyVmomi
-    - requests
 options:
     datacenter:
         description:

--- a/plugins/modules/vmware_guest_find.py
+++ b/plugins/modules/vmware_guest_find.py
@@ -17,8 +17,6 @@ description:
     - Find the folder path(s) for a virtual machine by name or UUID
 author:
     - Abhijeet Kasurde (@Akasurde) <akasurde@redhat.com>
-notes:
-    - Tested on vSphere 6.5
 options:
    name:
      description:

--- a/plugins/modules/vmware_guest_find.py
+++ b/plugins/modules/vmware_guest_find.py
@@ -19,9 +19,6 @@ author:
     - Abhijeet Kasurde (@Akasurde) <akasurde@redhat.com>
 notes:
     - Tested on vSphere 6.5
-requirements:
-    - "python >= 2.6"
-    - PyVmomi
 options:
    name:
      description:

--- a/plugins/modules/vmware_guest_info.py
+++ b/plugins/modules/vmware_guest_info.py
@@ -18,8 +18,6 @@ description:
     - Gather information about a single VM on a VMware ESX cluster.
 author:
     - Loic Blot (@nerzhul) <loic.blot@unix-experience.fr>
-notes:
-    - Tested on vSphere 5.5, 6.7
 options:
    name:
      description:

--- a/plugins/modules/vmware_guest_info.py
+++ b/plugins/modules/vmware_guest_info.py
@@ -20,9 +20,6 @@ author:
     - Loic Blot (@nerzhul) <loic.blot@unix-experience.fr>
 notes:
     - Tested on vSphere 5.5, 6.7
-requirements:
-    - "python >= 2.6"
-    - PyVmomi
 options:
    name:
      description:

--- a/plugins/modules/vmware_guest_move.py
+++ b/plugins/modules/vmware_guest_move.py
@@ -20,9 +20,6 @@ author:
     - Jose Angel Munoz (@imjoseangel)
 notes:
     - Tested on vSphere 5.5 and vSphere 6.5
-requirements:
-    - python >= 2.6
-    - PyVmomi
 options:
    name:
         description:

--- a/plugins/modules/vmware_guest_move.py
+++ b/plugins/modules/vmware_guest_move.py
@@ -18,8 +18,6 @@ description:
     - This module can be used to move virtual machines between folders.
 author:
     - Jose Angel Munoz (@imjoseangel)
-notes:
-    - Tested on vSphere 5.5 and vSphere 6.5
 options:
    name:
         description:

--- a/plugins/modules/vmware_guest_network.py
+++ b/plugins/modules/vmware_guest_network.py
@@ -19,7 +19,6 @@ version_added: '1.0.0'
 author:
   - Diane Wang (@Tomorrow9) <dianew@vmware.com>
 notes:
-  - Tested on vSphere 6.0, 6.5 and 6.7
   - For backwards compatibility network_data is returned when using the gather_network_info and networks parameters
 options:
   name:

--- a/plugins/modules/vmware_guest_network.py
+++ b/plugins/modules/vmware_guest_network.py
@@ -16,9 +16,6 @@ short_description: Manage network adapters of specified virtual machine in given
 description:
   - This module is used to add, reconfigure, remove network adapter of given virtual machine.
 version_added: '1.0.0'
-requirements:
-  - "python >= 2.7"
-  - "PyVmomi"
 author:
   - Diane Wang (@Tomorrow9) <dianew@vmware.com>
 notes:

--- a/plugins/modules/vmware_guest_powerstate.py
+++ b/plugins/modules/vmware_guest_powerstate.py
@@ -17,9 +17,6 @@ description:
 - Power on / Power off / Restart a virtual machine.
 author:
 - Abhijeet Kasurde (@Akasurde) <akasurde@redhat.com>
-requirements:
-- python >= 2.6
-- PyVmomi
 options:
   datacenter:
     description:

--- a/plugins/modules/vmware_guest_register_operation.py
+++ b/plugins/modules/vmware_guest_register_operation.py
@@ -16,9 +16,6 @@ author:
   - sky-joker (@sky-joker)
 description:
   - This module can register or unregister VMs to the inventory.
-requirements:
-  - python >= 2.7
-  - PyVmomi
 options:
   datacenter:
     description:

--- a/plugins/modules/vmware_guest_screenshot.py
+++ b/plugins/modules/vmware_guest_screenshot.py
@@ -21,9 +21,6 @@ author:
     - Diane Wang (@Tomorrow9) <dianew@vmware.com>
 notes:
     - Tested on vSphere 6.5 and 6.7
-requirements:
-    - "python >= 2.6"
-    - PyVmomi
 options:
    name:
      description:

--- a/plugins/modules/vmware_guest_screenshot.py
+++ b/plugins/modules/vmware_guest_screenshot.py
@@ -19,8 +19,6 @@ description:
     - All parameters and VMware object names are case sensitive.
 author:
     - Diane Wang (@Tomorrow9) <dianew@vmware.com>
-notes:
-    - Tested on vSphere 6.5 and 6.7
 options:
    name:
      description:

--- a/plugins/modules/vmware_guest_sendkey.py
+++ b/plugins/modules/vmware_guest_sendkey.py
@@ -21,9 +21,6 @@ author:
     - Diane Wang (@Tomorrow9) <dianew@vmware.com>
 notes:
     - Tested on vSphere 6.5 and 6.7
-requirements:
-    - "python >= 2.6"
-    - PyVmomi
 options:
    name:
      description:

--- a/plugins/modules/vmware_guest_sendkey.py
+++ b/plugins/modules/vmware_guest_sendkey.py
@@ -19,8 +19,6 @@ description:
     - All parameters and VMware object names are case sensitive.
 author:
     - Diane Wang (@Tomorrow9) <dianew@vmware.com>
-notes:
-    - Tested on vSphere 6.5 and 6.7
 options:
    name:
      description:

--- a/plugins/modules/vmware_guest_snapshot.py
+++ b/plugins/modules/vmware_guest_snapshot.py
@@ -21,9 +21,6 @@ author:
     - Loic Blot (@nerzhul) <loic.blot@unix-experience.fr>
 notes:
     - Tested on vSphere 5.5, 6.0 and 6.5
-requirements:
-    - "python >= 2.6"
-    - PyVmomi
 options:
    state:
      description:

--- a/plugins/modules/vmware_guest_snapshot.py
+++ b/plugins/modules/vmware_guest_snapshot.py
@@ -19,8 +19,6 @@ description:
     - All parameters and VMware object names are case sensitive.
 author:
     - Loic Blot (@nerzhul) <loic.blot@unix-experience.fr>
-notes:
-    - Tested on vSphere 5.5, 6.0 and 6.5
 options:
    state:
      description:

--- a/plugins/modules/vmware_guest_snapshot_info.py
+++ b/plugins/modules/vmware_guest_snapshot_info.py
@@ -18,8 +18,6 @@ description:
     - This module can be used to gather information about virtual machine's snapshots.
 author:
     - Abhijeet Kasurde (@Akasurde)
-notes:
-    - Tested on vSphere 6.0 and 6.5
 options:
    name:
      description:

--- a/plugins/modules/vmware_guest_snapshot_info.py
+++ b/plugins/modules/vmware_guest_snapshot_info.py
@@ -20,9 +20,6 @@ author:
     - Abhijeet Kasurde (@Akasurde)
 notes:
     - Tested on vSphere 6.0 and 6.5
-requirements:
-    - "python >= 2.6"
-    - PyVmomi
 options:
    name:
      description:

--- a/plugins/modules/vmware_guest_storage_policy.py
+++ b/plugins/modules/vmware_guest_storage_policy.py
@@ -31,8 +31,6 @@ description:
 version_added: 1.9.0
 author:
     - Tyler Gates (@tgates81)
-notes:
-    - Tested on vSphere 6.0 and 6.5
 options:
    name:
      description:

--- a/plugins/modules/vmware_guest_storage_policy.py
+++ b/plugins/modules/vmware_guest_storage_policy.py
@@ -33,8 +33,6 @@ author:
     - Tyler Gates (@tgates81)
 notes:
     - Tested on vSphere 6.0 and 6.5
-requirements:
-    - pyVmomi
 options:
    name:
      description:

--- a/plugins/modules/vmware_guest_tools_info.py
+++ b/plugins/modules/vmware_guest_tools_info.py
@@ -20,9 +20,6 @@ author:
     - Diane Wang (@Tomorrow9) <dianew@vmware.com>
 notes:
     - Tested on vSphere 6.0, 6.5, 6.7
-requirements:
-    - "python >= 2.7"
-    - PyVmomi
 options:
    name:
      description:

--- a/plugins/modules/vmware_guest_tools_info.py
+++ b/plugins/modules/vmware_guest_tools_info.py
@@ -18,8 +18,6 @@ description:
     - Gather information about the VMware tools installed in virtual machine.
 author:
     - Diane Wang (@Tomorrow9) <dianew@vmware.com>
-notes:
-    - Tested on vSphere 6.0, 6.5, 6.7
 options:
    name:
      description:

--- a/plugins/modules/vmware_guest_tools_upgrade.py
+++ b/plugins/modules/vmware_guest_tools_upgrade.py
@@ -15,9 +15,6 @@ module: vmware_guest_tools_upgrade
 short_description: Module to upgrade VMTools
 description:
     - This module upgrades the VMware Tools on Windows and Linux guests and reboots them.
-requirements:
-    - "python >= 2.6"
-    - PyVmomi
 notes:
     - "In order to upgrade VMTools, please power on virtual machine before hand - either 'manually' or
       using module M(community.vmware.vmware_guest_powerstate)."

--- a/plugins/modules/vmware_guest_tools_wait.py
+++ b/plugins/modules/vmware_guest_tools_wait.py
@@ -19,9 +19,6 @@ author:
     - Philippe Dellaert (@pdellaert) <philippe@dellaert.org>
 notes:
     - Tested on vSphere 6.5
-requirements:
-    - python >= 2.6
-    - PyVmomi
 options:
    name:
      description:

--- a/plugins/modules/vmware_guest_tools_wait.py
+++ b/plugins/modules/vmware_guest_tools_wait.py
@@ -17,8 +17,6 @@ description:
     - This module can be used to wait for VMware tools to become available on the given VM and return facts.
 author:
     - Philippe Dellaert (@pdellaert) <philippe@dellaert.org>
-notes:
-    - Tested on vSphere 6.5
 options:
    name:
      description:

--- a/plugins/modules/vmware_guest_tpm.py
+++ b/plugins/modules/vmware_guest_tpm.py
@@ -20,9 +20,6 @@ description: >
 author:
 - Diane Wang (@Tomorrow9) <dianew@vmware.com>
 version_added: '1.16.0'
-notes:
-- Tested on vSphere 6.7
-- Tested on vSphere 7.0
 options:
   name:
     description:

--- a/plugins/modules/vmware_guest_tpm.py
+++ b/plugins/modules/vmware_guest_tpm.py
@@ -23,9 +23,6 @@ version_added: '1.16.0'
 notes:
 - Tested on vSphere 6.7
 - Tested on vSphere 7.0
-requirements:
-- python >= 2.6
-- PyVmomi
 options:
   name:
     description:

--- a/plugins/modules/vmware_guest_vgpu.py
+++ b/plugins/modules/vmware_guest_vgpu.py
@@ -21,8 +21,6 @@ description:
 author:
     - Mohamed Alibi (@Medalibi)
     - Unknown (@matancarmeli7)
-notes:
-    - Tested on vSphere 6.7
 options:
    name:
      description:

--- a/plugins/modules/vmware_guest_vgpu.py
+++ b/plugins/modules/vmware_guest_vgpu.py
@@ -23,9 +23,6 @@ author:
     - Unknown (@matancarmeli7)
 notes:
     - Tested on vSphere 6.7
-requirements:
-    - "python >= 3.6"
-    - PyVmomi
 options:
    name:
      description:

--- a/plugins/modules/vmware_guest_video.py
+++ b/plugins/modules/vmware_guest_video.py
@@ -21,9 +21,6 @@ author:
     - Diane Wang (@Tomorrow9) <dianew@vmware.com>
 notes:
     - Tested on vSphere 6.0, 6.5 and 6.7
-requirements:
-    - "python >= 2.6"
-    - PyVmomi
 options:
    name:
      description:

--- a/plugins/modules/vmware_guest_video.py
+++ b/plugins/modules/vmware_guest_video.py
@@ -19,8 +19,6 @@ description:
     - All parameters and VMware object names are case sensitive.
 author:
     - Diane Wang (@Tomorrow9) <dianew@vmware.com>
-notes:
-    - Tested on vSphere 6.0, 6.5 and 6.7
 options:
    name:
      description:

--- a/plugins/modules/vmware_guest_vnc.py
+++ b/plugins/modules/vmware_guest_vnc.py
@@ -22,9 +22,6 @@ description:
   - This module can be used to enable and disable VNC remote display on virtual machine.
 author:
   - Armin Ranjbar Daemi (@rmin)
-requirements:
-  - python >= 2.6
-  - PyVmomi
 options:
   datacenter:
     description:

--- a/plugins/modules/vmware_host.py
+++ b/plugins/modules/vmware_host.py
@@ -23,8 +23,6 @@ author:
 - Russell Teague (@mtnbikenc)
 - Maxime de Roucy (@tchernomax)
 - Christian Kotte (@ckotte)
-notes:
-- Tested on vSphere 5.5, 6.0, 6.5 and 6.7
 requirements:
 - ssl
 - socket

--- a/plugins/modules/vmware_host.py
+++ b/plugins/modules/vmware_host.py
@@ -26,8 +26,6 @@ author:
 notes:
 - Tested on vSphere 5.5, 6.0, 6.5 and 6.7
 requirements:
-- python >= 2.6
-- PyVmomi
 - ssl
 - socket
 - hashlib

--- a/plugins/modules/vmware_host_acceptance.py
+++ b/plugins/modules/vmware_host_acceptance.py
@@ -18,8 +18,6 @@ description:
 - The host acceptance level controls the acceptance level of each VIB on a ESXi host.
 author:
 - Abhijeet Kasurde (@Akasurde)
-notes:
-- Tested on vSphere 6.5
 options:
   cluster_name:
     description:

--- a/plugins/modules/vmware_host_acceptance.py
+++ b/plugins/modules/vmware_host_acceptance.py
@@ -20,9 +20,6 @@ author:
 - Abhijeet Kasurde (@Akasurde)
 notes:
 - Tested on vSphere 6.5
-requirements:
-- python >= 2.6
-- PyVmomi
 options:
   cluster_name:
     description:

--- a/plugins/modules/vmware_host_active_directory.py
+++ b/plugins/modules/vmware_host_active_directory.py
@@ -17,8 +17,6 @@ description:
 - This module can be used to join or leave an ESXi host to or from an Active Directory domain.
 author:
 - Christian Kotte (@ckotte)
-notes:
-- Tested on vSphere 6.5
 options:
   ad_domain:
     description:

--- a/plugins/modules/vmware_host_active_directory.py
+++ b/plugins/modules/vmware_host_active_directory.py
@@ -19,9 +19,6 @@ author:
 - Christian Kotte (@ckotte)
 notes:
 - Tested on vSphere 6.5
-requirements:
-- python >= 2.6
-- PyVmomi
 options:
   ad_domain:
     description:

--- a/plugins/modules/vmware_host_auto_start.py
+++ b/plugins/modules/vmware_host_auto_start.py
@@ -16,9 +16,6 @@ author:
   - sky-joker (@sky-joker)
 description:
   - In this module, can set up automatic startup and shutdown of virtual machines according to host startup or shutdown.
-requirements:
-  - python >= 2.7
-  - PyVmomi
 options:
   esxi_hostname:
     description:

--- a/plugins/modules/vmware_host_capability_info.py
+++ b/plugins/modules/vmware_host_capability_info.py
@@ -19,9 +19,6 @@ author:
 - Abhijeet Kasurde (@Akasurde)
 notes:
 - Tested on vSphere 6.5
-requirements:
-- python >= 2.6
-- PyVmomi
 options:
   cluster_name:
     description:

--- a/plugins/modules/vmware_host_capability_info.py
+++ b/plugins/modules/vmware_host_capability_info.py
@@ -17,8 +17,6 @@ description:
 - This module can be used to gather information about an ESXi host's capability information when ESXi hostname or Cluster name is given.
 author:
 - Abhijeet Kasurde (@Akasurde)
-notes:
-- Tested on vSphere 6.5
 options:
   cluster_name:
     description:

--- a/plugins/modules/vmware_host_config_info.py
+++ b/plugins/modules/vmware_host_config_info.py
@@ -17,8 +17,6 @@ description:
 - This module can be used to gather information about an ESXi host's advance configuration information when ESXi hostname or Cluster name is given.
 author:
 - Abhijeet Kasurde (@Akasurde)
-notes:
-- Tested on vSphere 6.5
 options:
   cluster_name:
     description:

--- a/plugins/modules/vmware_host_config_info.py
+++ b/plugins/modules/vmware_host_config_info.py
@@ -19,9 +19,6 @@ author:
 - Abhijeet Kasurde (@Akasurde)
 notes:
 - Tested on vSphere 6.5
-requirements:
-- python >= 2.6
-- PyVmomi
 options:
   cluster_name:
     description:

--- a/plugins/modules/vmware_host_config_manager.py
+++ b/plugins/modules/vmware_host_config_manager.py
@@ -19,9 +19,6 @@ author:
 - Abhijeet Kasurde (@Akasurde)
 notes:
 - Tested on vSphere 6.5
-requirements:
-- python >= 2.6
-- PyVmomi
 options:
   cluster_name:
     description:

--- a/plugins/modules/vmware_host_config_manager.py
+++ b/plugins/modules/vmware_host_config_manager.py
@@ -17,8 +17,6 @@ description:
 - This module can be used to manage advanced system settings of an ESXi host when ESXi hostname or Cluster name is given.
 author:
 - Abhijeet Kasurde (@Akasurde)
-notes:
-- Tested on vSphere 6.5
 options:
   cluster_name:
     description:

--- a/plugins/modules/vmware_host_custom_attributes.py
+++ b/plugins/modules/vmware_host_custom_attributes.py
@@ -17,8 +17,6 @@ description:
 author:
     - Hunter Christain (@exp-hc)
 version_added: '1.11.0'
-notes:
-    - Tested on vSphere 6.7
 options:
    esxi_hostname:
      description:

--- a/plugins/modules/vmware_host_custom_attributes.py
+++ b/plugins/modules/vmware_host_custom_attributes.py
@@ -19,8 +19,6 @@ author:
 version_added: '1.11.0'
 notes:
     - Tested on vSphere 6.7
-requirements:
-    - PyVmomi
 options:
    esxi_hostname:
      description:

--- a/plugins/modules/vmware_host_datastore.py
+++ b/plugins/modules/vmware_host_datastore.py
@@ -25,9 +25,6 @@ notes:
 - Tested on vSphere 6.0, 6.5 and ESXi 6.7
 - NFS v4.1 tested on vSphere 6.5
 - Kerberos authentication with NFS v4.1 isn't implemented
-requirements:
-- python >= 2.6
-- PyVmomi
 options:
   datastore_name:
     description:

--- a/plugins/modules/vmware_host_datastore.py
+++ b/plugins/modules/vmware_host_datastore.py
@@ -22,8 +22,6 @@ author:
 - Ludovic Rivallain (@lrivallain) <ludovic.rivallain@gmail.com>
 - Christian Kotte (@ckotte) <christian.kotte@gmx.de>
 notes:
-- Tested on vSphere 6.0, 6.5 and ESXi 6.7
-- NFS v4.1 tested on vSphere 6.5
 - Kerberos authentication with NFS v4.1 isn't implemented
 options:
   datastore_name:

--- a/plugins/modules/vmware_host_disk_info.py
+++ b/plugins/modules/vmware_host_disk_info.py
@@ -18,8 +18,6 @@ description:
 - If I(esxi_hostname) is provided, then disk information about the given host system will be returned.
 author:
 - Matt Proud (@laidbackware)
-notes:
-- Tested on vSphere 6.7 and 7.0
 options:
   cluster_name:
     description:

--- a/plugins/modules/vmware_host_disk_info.py
+++ b/plugins/modules/vmware_host_disk_info.py
@@ -20,9 +20,6 @@ author:
 - Matt Proud (@laidbackware)
 notes:
 - Tested on vSphere 6.7 and 7.0
-requirements:
-- python >= 2.6
-- PyVmomi
 options:
   cluster_name:
     description:

--- a/plugins/modules/vmware_host_dns.py
+++ b/plugins/modules/vmware_host_dns.py
@@ -21,9 +21,6 @@ author:
 notes:
 - This module is a replacement for the module C(vmware_dns_config)
 - Tested on vSphere 6.7
-requirements:
-- python >= 2.6
-- PyVmomi
 options:
   type:
     description:

--- a/plugins/modules/vmware_host_dns.py
+++ b/plugins/modules/vmware_host_dns.py
@@ -20,7 +20,6 @@ author:
 - Mario Lenz (@mariolenz)
 notes:
 - This module is a replacement for the module C(vmware_dns_config)
-- Tested on vSphere 6.7
 options:
   type:
     description:

--- a/plugins/modules/vmware_host_dns_info.py
+++ b/plugins/modules/vmware_host_dns_info.py
@@ -18,8 +18,6 @@ description:
 - All parameters and VMware object names are case sensitive.
 author:
 - Abhijeet Kasurde (@Akasurde)
-notes:
-- Tested on vSphere 6.5
 options:
   cluster_name:
     description:

--- a/plugins/modules/vmware_host_dns_info.py
+++ b/plugins/modules/vmware_host_dns_info.py
@@ -20,9 +20,6 @@ author:
 - Abhijeet Kasurde (@Akasurde)
 notes:
 - Tested on vSphere 6.5
-requirements:
-- python >= 2.6
-- PyVmomi
 options:
   cluster_name:
     description:

--- a/plugins/modules/vmware_host_facts.py
+++ b/plugins/modules/vmware_host_facts.py
@@ -25,9 +25,6 @@ description:
       Users are recommended to check connection state value and take appropriate decision in the playbook.
 author:
     - Wei Gao (@woshihaoren)
-requirements:
-    - python >= 2.6
-    - PyVmomi
 options:
   esxi_hostname:
     description:

--- a/plugins/modules/vmware_host_feature_info.py
+++ b/plugins/modules/vmware_host_feature_info.py
@@ -17,8 +17,6 @@ description:
 - This module can be used to gather information about an ESXi host's feature capability information when ESXi hostname or Cluster name is given.
 author:
 - Abhijeet Kasurde (@Akasurde)
-notes:
-- Tested on vSphere 6.5
 options:
   cluster_name:
     description:

--- a/plugins/modules/vmware_host_feature_info.py
+++ b/plugins/modules/vmware_host_feature_info.py
@@ -19,9 +19,6 @@ author:
 - Abhijeet Kasurde (@Akasurde)
 notes:
 - Tested on vSphere 6.5
-requirements:
-- python >= 2.6
-- PyVmomi
 options:
   cluster_name:
     description:

--- a/plugins/modules/vmware_host_firewall_info.py
+++ b/plugins/modules/vmware_host_firewall_info.py
@@ -17,8 +17,6 @@ description:
 - This module can be used to gather information about an ESXi host's firewall configuration information when ESXi hostname or Cluster name is given.
 author:
 - Abhijeet Kasurde (@Akasurde)
-notes:
-- Tested on vSphere 6.5
 options:
   cluster_name:
     description:

--- a/plugins/modules/vmware_host_firewall_info.py
+++ b/plugins/modules/vmware_host_firewall_info.py
@@ -19,9 +19,6 @@ author:
 - Abhijeet Kasurde (@Akasurde)
 notes:
 - Tested on vSphere 6.5
-requirements:
-- python >= 2.6
-- PyVmomi
 options:
   cluster_name:
     description:

--- a/plugins/modules/vmware_host_firewall_manager.py
+++ b/plugins/modules/vmware_host_firewall_manager.py
@@ -20,9 +20,6 @@ author:
 - Aaron Longchamps (@alongchamps)
 notes:
 - Tested on vSphere 6.0, vSphere 6.5
-requirements:
-- python >= 2.6
-- PyVmomi
 options:
   cluster_name:
     description:

--- a/plugins/modules/vmware_host_firewall_manager.py
+++ b/plugins/modules/vmware_host_firewall_manager.py
@@ -18,8 +18,6 @@ description:
 author:
 - Abhijeet Kasurde (@Akasurde)
 - Aaron Longchamps (@alongchamps)
-notes:
-- Tested on vSphere 6.0, vSphere 6.5
 options:
   cluster_name:
     description:

--- a/plugins/modules/vmware_host_hyperthreading.py
+++ b/plugins/modules/vmware_host_hyperthreading.py
@@ -21,9 +21,6 @@ author:
 - Christian Kotte (@ckotte)
 notes:
 - Tested on vSphere 6.5
-requirements:
-- python >= 2.6
-- PyVmomi
 options:
   state:
      description:

--- a/plugins/modules/vmware_host_hyperthreading.py
+++ b/plugins/modules/vmware_host_hyperthreading.py
@@ -19,8 +19,6 @@ description:
 - The module informs the user if Hyperthreading is enabled but inactive because the processor is vulnerable to L1 Terminal Fault (L1TF).
 author:
 - Christian Kotte (@ckotte)
-notes:
-- Tested on vSphere 6.5
 options:
   state:
      description:

--- a/plugins/modules/vmware_host_ipv6.py
+++ b/plugins/modules/vmware_host_ipv6.py
@@ -18,8 +18,6 @@ description:
 - It also checks if the host needs to be restarted.
 author:
 - Christian Kotte (@ckotte) <christian.kotte@gmx.de>
-notes:
-- Tested on vSphere 6.5
 options:
   state:
      description:

--- a/plugins/modules/vmware_host_ipv6.py
+++ b/plugins/modules/vmware_host_ipv6.py
@@ -20,9 +20,6 @@ author:
 - Christian Kotte (@ckotte) <christian.kotte@gmx.de>
 notes:
 - Tested on vSphere 6.5
-requirements:
-- python >= 2.6
-- PyVmomi
 options:
   state:
      description:

--- a/plugins/modules/vmware_host_iscsi.py
+++ b/plugins/modules/vmware_host_iscsi.py
@@ -15,9 +15,6 @@ author:
   - sky-joker (@sky-joker)
 description:
   - In this module, can manage the iSCSI configuration of ESXi host
-requirements:
-  - python >= 2.7
-  - PyVmomi
 options:
   esxi_hostname:
     description:

--- a/plugins/modules/vmware_host_iscsi_info.py
+++ b/plugins/modules/vmware_host_iscsi_info.py
@@ -15,9 +15,6 @@ author:
   - sky-joker (@sky-joker)
 description:
   - This module can be used to gather information about the iSCSI configuration of the ESXi host.
-requirements:
-  - python >= 2.7
-  - PyVmomi
 options:
   esxi_hostname:
     description:

--- a/plugins/modules/vmware_host_kernel_manager.py
+++ b/plugins/modules/vmware_host_kernel_manager.py
@@ -22,9 +22,6 @@ author:
 - Aaron Longchamps (@alongchamps)
 notes:
 - Tested on vSphere 6.0
-requirements:
-- python >= 2.7
-- PyVmomi
 options:
   esxi_hostname:
     description:

--- a/plugins/modules/vmware_host_kernel_manager.py
+++ b/plugins/modules/vmware_host_kernel_manager.py
@@ -20,8 +20,6 @@ description:
 - You can use M(ansible.builtin.reboot) or M(community.vmware.vmware_host_powerstate) module to reboot all ESXi host systems.
 author:
 - Aaron Longchamps (@alongchamps)
-notes:
-- Tested on vSphere 6.0
 options:
   esxi_hostname:
     description:

--- a/plugins/modules/vmware_host_lockdown.py
+++ b/plugins/modules/vmware_host_lockdown.py
@@ -20,8 +20,6 @@ description:
 - Please specify C(hostname) as vCenter IP or hostname only, as lockdown operations are not possible from standalone ESXi server.
 author:
 - Abhijeet Kasurde (@Akasurde)
-notes:
-- Tested on vSphere 6.5
 options:
   cluster_name:
     description:

--- a/plugins/modules/vmware_host_lockdown.py
+++ b/plugins/modules/vmware_host_lockdown.py
@@ -22,9 +22,6 @@ author:
 - Abhijeet Kasurde (@Akasurde)
 notes:
 - Tested on vSphere 6.5
-requirements:
-- python >= 2.6
-- PyVmomi
 options:
   cluster_name:
     description:

--- a/plugins/modules/vmware_host_logbundle.py
+++ b/plugins/modules/vmware_host_logbundle.py
@@ -17,9 +17,6 @@ description:
     - This module can be used to fetch logbundle file from ESXi.
 author:
     - sky-joker (@sky-joker)
-requirements:
-    - "python >= 2.7"
-    - PyVmomi
 options:
     esxi_hostname:
       description:

--- a/plugins/modules/vmware_host_logbundle_info.py
+++ b/plugins/modules/vmware_host_logbundle_info.py
@@ -17,9 +17,6 @@ description:
     - This module can be used to gather manifest information for logbundle from ESXi.
 author:
     - sky-joker (@sky-joker)
-requirements:
-    - "python >= 2.7"
-    - PyVmomi
 options:
     esxi_hostname:
       description:

--- a/plugins/modules/vmware_host_ntp.py
+++ b/plugins/modules/vmware_host_ntp.py
@@ -21,8 +21,6 @@ description:
 author:
 - Abhijeet Kasurde (@Akasurde)
 - Christian Kotte (@ckotte)
-notes:
-- Tested on vSphere 6.5
 options:
   esxi_hostname:
     description:

--- a/plugins/modules/vmware_host_ntp.py
+++ b/plugins/modules/vmware_host_ntp.py
@@ -23,9 +23,6 @@ author:
 - Christian Kotte (@ckotte)
 notes:
 - Tested on vSphere 6.5
-requirements:
-- python >= 2.6
-- PyVmomi
 options:
   esxi_hostname:
     description:

--- a/plugins/modules/vmware_host_ntp_info.py
+++ b/plugins/modules/vmware_host_ntp_info.py
@@ -19,9 +19,6 @@ author:
 - Abhijeet Kasurde (@Akasurde)
 notes:
 - Tested on vSphere 6.5
-requirements:
-- python >= 2.6
-- PyVmomi
 options:
   cluster_name:
     description:

--- a/plugins/modules/vmware_host_ntp_info.py
+++ b/plugins/modules/vmware_host_ntp_info.py
@@ -17,8 +17,6 @@ description:
 - This module can be used to gather information about NTP configurations on an ESXi host.
 author:
 - Abhijeet Kasurde (@Akasurde)
-notes:
-- Tested on vSphere 6.5
 options:
   cluster_name:
     description:

--- a/plugins/modules/vmware_host_package_info.py
+++ b/plugins/modules/vmware_host_package_info.py
@@ -19,9 +19,6 @@ author:
 - Abhijeet Kasurde (@Akasurde)
 notes:
 - Tested on vSphere 6.5
-requirements:
-- python >= 2.6
-- PyVmomi
 options:
   cluster_name:
     description:

--- a/plugins/modules/vmware_host_package_info.py
+++ b/plugins/modules/vmware_host_package_info.py
@@ -17,8 +17,6 @@ description:
 - This module can be used to gather information about available packages and their status on an ESXi host.
 author:
 - Abhijeet Kasurde (@Akasurde)
-notes:
-- Tested on vSphere 6.5
 options:
   cluster_name:
     description:

--- a/plugins/modules/vmware_host_passthrough.py
+++ b/plugins/modules/vmware_host_passthrough.py
@@ -18,9 +18,6 @@ description:
   - This module can be managed PCI device passthrough settings on host.
 notes:
   - Supports C(check_mode).
-requirements:
-  - python >= 3.6
-  - PyVmomi
 version_added: '1.11.0'
 options:
   cluster:

--- a/plugins/modules/vmware_host_powermgmt_policy.py
+++ b/plugins/modules/vmware_host_powermgmt_policy.py
@@ -19,9 +19,6 @@ author:
 - Christian Kotte (@ckotte) <christian.kotte@gmx.de>
 notes:
 - Tested on vSphere 6.5
-requirements:
-- python >= 2.6
-- PyVmomi
 options:
   policy:
     description:

--- a/plugins/modules/vmware_host_powermgmt_policy.py
+++ b/plugins/modules/vmware_host_powermgmt_policy.py
@@ -17,8 +17,6 @@ description:
 - This module can be used to manage the Power Management Policy of ESXi host systems in given vCenter infrastructure.
 author:
 - Christian Kotte (@ckotte) <christian.kotte@gmx.de>
-notes:
-- Tested on vSphere 6.5
 options:
   policy:
     description:

--- a/plugins/modules/vmware_host_powerstate.py
+++ b/plugins/modules/vmware_host_powerstate.py
@@ -20,9 +20,6 @@ description:
 - State 'reboot-host', 'shutdown-host' and 'power-down-to-standby' are not supported by all the host systems.
 author:
 - Abhijeet Kasurde (@Akasurde)
-requirements:
-- python >= 2.6
-- PyVmomi
 options:
   state:
     description:

--- a/plugins/modules/vmware_host_scanhba.py
+++ b/plugins/modules/vmware_host_scanhba.py
@@ -24,9 +24,6 @@ author:
 - Michael Eaton (@michaeldeaton)
 notes:
 - Tested on vSphere 6.0
-requirements:
-- python >= 2.6
-- PyVmomi
 options:
   esxi_hostname:
     description:

--- a/plugins/modules/vmware_host_scanhba.py
+++ b/plugins/modules/vmware_host_scanhba.py
@@ -22,8 +22,6 @@ description:
 - You can supply an esxi_hostname or a cluster_name
 author:
 - Michael Eaton (@michaeldeaton)
-notes:
-- Tested on vSphere 6.0
 options:
   esxi_hostname:
     description:

--- a/plugins/modules/vmware_host_scsidisk_info.py
+++ b/plugins/modules/vmware_host_scsidisk_info.py
@@ -18,9 +18,6 @@ description:
 - This module can be used to gather information about SCSI disk attached to the given ESXi.
 author:
 - Abhijeet Kasurde (@Akasurde)
-requirements:
-- Python >= 2.7
-- PyVmomi
 options:
   esxi_hostname:
     description:

--- a/plugins/modules/vmware_host_service_info.py
+++ b/plugins/modules/vmware_host_service_info.py
@@ -18,7 +18,6 @@ description:
 author:
 - Abhijeet Kasurde (@Akasurde)
 notes:
-- Tested on vSphere 6.5
 - If source package name is not available then fact is populated as null.
 options:
   cluster_name:

--- a/plugins/modules/vmware_host_service_info.py
+++ b/plugins/modules/vmware_host_service_info.py
@@ -20,9 +20,6 @@ author:
 notes:
 - Tested on vSphere 6.5
 - If source package name is not available then fact is populated as null.
-requirements:
-- python >= 2.6
-- PyVmomi
 options:
   cluster_name:
     description:

--- a/plugins/modules/vmware_host_service_manager.py
+++ b/plugins/modules/vmware_host_service_manager.py
@@ -19,8 +19,6 @@ description:
 - If specific esxi_hostname is provided, then specified service will be managed on given ESXi host only.
 author:
 - Abhijeet Kasurde (@Akasurde)
-notes:
-- Tested on vSphere 6.5
 options:
   cluster_name:
     description:

--- a/plugins/modules/vmware_host_service_manager.py
+++ b/plugins/modules/vmware_host_service_manager.py
@@ -21,9 +21,6 @@ author:
 - Abhijeet Kasurde (@Akasurde)
 notes:
 - Tested on vSphere 6.5
-requirements:
-- python >= 2.6
-- PyVmomi
 options:
   cluster_name:
     description:

--- a/plugins/modules/vmware_host_snmp.py
+++ b/plugins/modules/vmware_host_snmp.py
@@ -18,7 +18,6 @@ description:
 author:
 - Christian Kotte (@ckotte)
 notes:
-- Tested on vSphere 6.5
 - You need to reset the agent (to factory defaults) if you want to clear all community strings, trap targets, or filters
 - SNMP v3 configuration isn't implemented yet
 options:

--- a/plugins/modules/vmware_host_snmp.py
+++ b/plugins/modules/vmware_host_snmp.py
@@ -21,9 +21,6 @@ notes:
 - Tested on vSphere 6.5
 - You need to reset the agent (to factory defaults) if you want to clear all community strings, trap targets, or filters
 - SNMP v3 configuration isn't implemented yet
-requirements:
-- python >= 2.6
-- PyVmomi
 options:
   state:
     description:

--- a/plugins/modules/vmware_host_sriov.py
+++ b/plugins/modules/vmware_host_sriov.py
@@ -21,8 +21,6 @@ description:
 version_added: '1.0.0'
 author:
 - Viktor Tsymbalyuk (@victron)
-notes:
-- Tested on vSphere 6.0
 options:
   esxi_hostname:
     description:

--- a/plugins/modules/vmware_host_sriov.py
+++ b/plugins/modules/vmware_host_sriov.py
@@ -23,9 +23,6 @@ author:
 - Viktor Tsymbalyuk (@victron)
 notes:
 - Tested on vSphere 6.0
-requirements:
-- python >= 2.7
-- PyVmomi
 options:
   esxi_hostname:
     description:

--- a/plugins/modules/vmware_host_ssl_info.py
+++ b/plugins/modules/vmware_host_ssl_info.py
@@ -17,8 +17,6 @@ description:
 - This module can be used to gather information of the SSL thumbprint information for a host.
 author:
 - Abhijeet Kasurde (@Akasurde)
-notes:
-- Tested on vSphere 6.5
 options:
   cluster_name:
     description:

--- a/plugins/modules/vmware_host_ssl_info.py
+++ b/plugins/modules/vmware_host_ssl_info.py
@@ -19,9 +19,6 @@ author:
 - Abhijeet Kasurde (@Akasurde)
 notes:
 - Tested on vSphere 6.5
-requirements:
-- python >= 2.6
-- PyVmomi
 options:
   cluster_name:
     description:

--- a/plugins/modules/vmware_host_tcpip_stacks.py
+++ b/plugins/modules/vmware_host_tcpip_stacks.py
@@ -16,9 +16,6 @@ author:
   - sky-joker (@sky-joker)
 description:
   - This module can be used to modify the TCP/IP stacks configuration.
-requirements:
-  - python >= 2.7
-  - PyVmomi
 version_added: '1.10.0'
 options:
   esxi_hostname:

--- a/plugins/modules/vmware_host_user_manager.py
+++ b/plugins/modules/vmware_host_user_manager.py
@@ -15,9 +15,6 @@ author:
   - sky-joker (@sky-joker)
 description:
   - This module can add, update or delete local users on ESXi host.
-requirements:
-  - python >= 3.6
-  - PyVmomi
 version_added: '2.1.0'
 options:
   esxi_hostname:

--- a/plugins/modules/vmware_host_vmhba_info.py
+++ b/plugins/modules/vmware_host_vmhba_info.py
@@ -21,9 +21,6 @@ author:
 - Christian Kotte (@ckotte)
 notes:
 - Tested on vSphere 6.5
-requirements:
-- python >= 2.6
-- PyVmomi
 options:
   esxi_hostname:
     description:

--- a/plugins/modules/vmware_host_vmhba_info.py
+++ b/plugins/modules/vmware_host_vmhba_info.py
@@ -19,8 +19,6 @@ description:
 - If C(esxi_hostname) is provided, then vmhba information about given host system will be returned.
 author:
 - Christian Kotte (@ckotte)
-notes:
-- Tested on vSphere 6.5
 options:
   esxi_hostname:
     description:

--- a/plugins/modules/vmware_host_vmnic_info.py
+++ b/plugins/modules/vmware_host_vmnic_info.py
@@ -25,9 +25,6 @@ author:
 - Christian Kotte (@ckotte)
 notes:
 - Tested on vSphere 6.5
-requirements:
-- python >= 2.6
-- PyVmomi
 options:
   capabilities:
     description:

--- a/plugins/modules/vmware_host_vmnic_info.py
+++ b/plugins/modules/vmware_host_vmnic_info.py
@@ -23,8 +23,6 @@ description:
 author:
 - Abhijeet Kasurde (@Akasurde)
 - Christian Kotte (@ckotte)
-notes:
-- Tested on vSphere 6.5
 options:
   capabilities:
     description:

--- a/plugins/modules/vmware_local_role_info.py
+++ b/plugins/modules/vmware_local_role_info.py
@@ -21,9 +21,6 @@ notes:
     - Tested on ESXi 6.5
     - Be sure that the ESXi user used for login, has the appropriate rights to view roles
     - The module returns a list of dict in version 2.8 and above.
-requirements:
-    - "python >= 2.6"
-    - PyVmomi
 extends_documentation_fragment:
 - community.vmware.vmware.documentation
 

--- a/plugins/modules/vmware_local_role_info.py
+++ b/plugins/modules/vmware_local_role_info.py
@@ -18,7 +18,6 @@ description:
 author:
 - Abhijeet Kasurde (@Akasurde)
 notes:
-    - Tested on ESXi 6.5
     - Be sure that the ESXi user used for login, has the appropriate rights to view roles
     - The module returns a list of dict in version 2.8 and above.
 extends_documentation_fragment:

--- a/plugins/modules/vmware_local_role_manager.py
+++ b/plugins/modules/vmware_local_role_manager.py
@@ -20,7 +20,6 @@ author:
 - Abhijeet Kasurde (@Akasurde)
 - Christian Kotte (@ckotte)
 notes:
-    - Tested on ESXi 6.5
     - Be sure that the ESXi user used for login, has the appropriate rights to create / delete / edit roles
 options:
   local_role_name:

--- a/plugins/modules/vmware_local_role_manager.py
+++ b/plugins/modules/vmware_local_role_manager.py
@@ -22,9 +22,6 @@ author:
 notes:
     - Tested on ESXi 6.5
     - Be sure that the ESXi user used for login, has the appropriate rights to create / delete / edit roles
-requirements:
-    - "python >= 2.6"
-    - PyVmomi
 options:
   local_role_name:
     description:

--- a/plugins/modules/vmware_local_user_info.py
+++ b/plugins/modules/vmware_local_user_info.py
@@ -23,9 +23,6 @@ author:
 - Christian Kotte (@ckotte)
 notes:
     - Tested on ESXi 6.5
-requirements:
-    - "python >= 2.6"
-    - PyVmomi
 extends_documentation_fragment:
 - community.vmware.vmware.documentation
 

--- a/plugins/modules/vmware_local_user_info.py
+++ b/plugins/modules/vmware_local_user_info.py
@@ -21,8 +21,6 @@ description:
 author:
 - Abhijeet Kasurde (@Akasurde)
 - Christian Kotte (@ckotte)
-notes:
-    - Tested on ESXi 6.5
 extends_documentation_fragment:
 - community.vmware.vmware.documentation
 

--- a/plugins/modules/vmware_local_user_manager.py
+++ b/plugins/modules/vmware_local_user_manager.py
@@ -19,7 +19,6 @@ description:
 author:
 - Andreas Nafpliotis (@nafpliot-ibm)
 notes:
-    - Tested on ESXi 6.0
     - Be sure that the ESXi user used for login, has the appropriate rights to create / delete / edit users
 options:
     local_user_name:

--- a/plugins/modules/vmware_local_user_manager.py
+++ b/plugins/modules/vmware_local_user_manager.py
@@ -21,9 +21,6 @@ author:
 notes:
     - Tested on ESXi 6.0
     - Be sure that the ESXi user used for login, has the appropriate rights to create / delete / edit users
-requirements:
-    - "python >= 2.6"
-    - PyVmomi installed
 options:
     local_user_name:
         description:

--- a/plugins/modules/vmware_maintenancemode.py
+++ b/plugins/modules/vmware_maintenancemode.py
@@ -20,8 +20,6 @@ description:
 author:
 - Jay Jahns (@jjahns) <jjahns@vmware.com>
 - Abhijeet Kasurde (@Akasurde)
-notes:
-    - Tested on vSphere 5.5, 6.0 and 6.5
 options:
     esxi_hostname:
         description:

--- a/plugins/modules/vmware_maintenancemode.py
+++ b/plugins/modules/vmware_maintenancemode.py
@@ -22,9 +22,6 @@ author:
 - Abhijeet Kasurde (@Akasurde)
 notes:
     - Tested on vSphere 5.5, 6.0 and 6.5
-requirements:
-    - "python >= 2.6"
-    - PyVmomi
 options:
     esxi_hostname:
         description:

--- a/plugins/modules/vmware_migrate_vmk.py
+++ b/plugins/modules/vmware_migrate_vmk.py
@@ -18,8 +18,6 @@ description:
 author:
 - Joseph Callen (@jcpowermac)
 - Russell Teague (@mtnbikenc)
-notes:
-    - Tested on vSphere 6.7
 options:
     esxi_hostname:
         description:

--- a/plugins/modules/vmware_migrate_vmk.py
+++ b/plugins/modules/vmware_migrate_vmk.py
@@ -20,9 +20,6 @@ author:
 - Russell Teague (@mtnbikenc)
 notes:
     - Tested on vSphere 6.7
-requirements:
-    - "python >= 2.6"
-    - PyVmomi
 options:
     esxi_hostname:
         description:

--- a/plugins/modules/vmware_object_custom_attributes_info.py
+++ b/plugins/modules/vmware_object_custom_attributes_info.py
@@ -18,9 +18,6 @@ description:
   - This module can be gathered custom attributes of an object.
 notes:
   - Supports C(check_mode).
-requirements:
-  - python >= 3.6
-  - PyVmomi
 version_added: '1.11.0'
 options:
   object_type:

--- a/plugins/modules/vmware_object_rename.py
+++ b/plugins/modules/vmware_object_rename.py
@@ -22,8 +22,6 @@ author:
 notes:
 - Tested on vSphere 6.5
 requirements:
-- python >= 2.7
-- PyVmomi
 - vSphere Automation SDK
 options:
     object_type:

--- a/plugins/modules/vmware_object_rename.py
+++ b/plugins/modules/vmware_object_rename.py
@@ -19,8 +19,6 @@ description:
 - Renaming Host and Network is not supported by VMware APIs.
 author:
 - Abhijeet Kasurde (@Akasurde)
-notes:
-- Tested on vSphere 6.5
 requirements:
 - vSphere Automation SDK
 options:

--- a/plugins/modules/vmware_object_role_permission.py
+++ b/plugins/modules/vmware_object_role_permission.py
@@ -20,7 +20,6 @@ author:
 - Derek Rushing (@kryptsi)
 - Joseph Andreatta (@vmwjoseph)
 notes:
-    - Tested on ESXi 6.5, vSphere 6.7
     - The ESXi login user must have the appropriate rights to administer permissions.
     - Permissions for a distributed switch must be defined and managed on either the datacenter or a folder containing the switch.
 options:

--- a/plugins/modules/vmware_object_role_permission.py
+++ b/plugins/modules/vmware_object_role_permission.py
@@ -23,9 +23,6 @@ notes:
     - Tested on ESXi 6.5, vSphere 6.7
     - The ESXi login user must have the appropriate rights to administer permissions.
     - Permissions for a distributed switch must be defined and managed on either the datacenter or a folder containing the switch.
-requirements:
-    - "python >= 2.7"
-    - PyVmomi
 options:
   role:
     description:

--- a/plugins/modules/vmware_object_role_permission_info.py
+++ b/plugins/modules/vmware_object_role_permission_info.py
@@ -24,9 +24,6 @@ notes:
     - Tested on ESXi 6.5, vSphere 6.7
     - The ESXi login user must have the appropriate rights to administer permissions.
     - Supports check mode.
-requirements:
-    - "python >= 3"
-    - PyVmomi
 options:
   principal:
     description:

--- a/plugins/modules/vmware_object_role_permission_info.py
+++ b/plugins/modules/vmware_object_role_permission_info.py
@@ -21,7 +21,6 @@ description: This module can be used to gather object permissions on the given V
 author:
 - Abhijeet Kasurde (@Akasurde)
 notes:
-    - Tested on ESXi 6.5, vSphere 6.7
     - The ESXi login user must have the appropriate rights to administer permissions.
     - Supports check mode.
 options:

--- a/plugins/modules/vmware_portgroup.py
+++ b/plugins/modules/vmware_portgroup.py
@@ -28,9 +28,6 @@ notes:
     - Complete configuration only tested on vSphere 6.5
     - 'C(inbound_policy) and C(rolling_order) are removed in 2.11.'
     - Those two options are only used during portgroup creation. Updating is not supported with those options.
-requirements:
-    - "python >= 2.6"
-    - PyVmomi
 options:
     switch:
         description:

--- a/plugins/modules/vmware_portgroup.py
+++ b/plugins/modules/vmware_portgroup.py
@@ -23,11 +23,6 @@ author:
 - Russell Teague (@mtnbikenc)
 - Abhijeet Kasurde (@Akasurde)
 - Christian Kotte (@ckotte)
-notes:
-    - Tested on vSphere 5.5 and 6.5
-    - Complete configuration only tested on vSphere 6.5
-    - 'C(inbound_policy) and C(rolling_order) are removed in 2.11.'
-    - Those two options are only used during portgroup creation. Updating is not supported with those options.
 options:
     switch:
         description:

--- a/plugins/modules/vmware_portgroup_info.py
+++ b/plugins/modules/vmware_portgroup_info.py
@@ -19,8 +19,6 @@ description:
 author:
 - Abhijeet Kasurde (@Akasurde)
 - Christian Kotte (@ckotte)
-notes:
-- Tested on vSphere 6.5
 options:
   policies:
     description:

--- a/plugins/modules/vmware_portgroup_info.py
+++ b/plugins/modules/vmware_portgroup_info.py
@@ -21,9 +21,6 @@ author:
 - Christian Kotte (@ckotte)
 notes:
 - Tested on vSphere 6.5
-requirements:
-- python >= 2.6
-- PyVmomi
 options:
   policies:
     description:

--- a/plugins/modules/vmware_recommended_datastore.py
+++ b/plugins/modules/vmware_recommended_datastore.py
@@ -23,9 +23,6 @@ author:
 notes:
 - Tested on vSphere 6.7 and 7.0.2
 - Supports Check mode.
-requirements:
-- python >= 3
-- PyVmomi
 options:
   datacenter:
     description:

--- a/plugins/modules/vmware_recommended_datastore.py
+++ b/plugins/modules/vmware_recommended_datastore.py
@@ -21,7 +21,6 @@ author:
 - Alina Buzachis (@alinabuzachis)
 - Abhijeet Kasurde (@Akasurde)
 notes:
-- Tested on vSphere 6.7 and 7.0.2
 - Supports Check mode.
 options:
   datacenter:

--- a/plugins/modules/vmware_resource_pool.py
+++ b/plugins/modules/vmware_resource_pool.py
@@ -17,8 +17,6 @@ description:
     - This module can be used to add/remove a resource pool to/from vCenter
 author:
 - Davis Phillips (@dav1x)
-notes:
-    - Tested on vSphere 6.5
 options:
     datacenter:
         description:

--- a/plugins/modules/vmware_resource_pool.py
+++ b/plugins/modules/vmware_resource_pool.py
@@ -19,9 +19,6 @@ author:
 - Davis Phillips (@dav1x)
 notes:
     - Tested on vSphere 6.5
-requirements:
-    - "python >= 2.6"
-    - PyVmomi
 options:
     datacenter:
         description:

--- a/plugins/modules/vmware_resource_pool_info.py
+++ b/plugins/modules/vmware_resource_pool_info.py
@@ -19,9 +19,6 @@ author:
 - Abhijeet Kasurde (@Akasurde)
 notes:
 - Tested on vSphere 6.5
-requirements:
-- python >= 2.6
-- PyVmomi
 extends_documentation_fragment:
 - community.vmware.vmware.documentation
 

--- a/plugins/modules/vmware_resource_pool_info.py
+++ b/plugins/modules/vmware_resource_pool_info.py
@@ -17,8 +17,6 @@ description:
 - This module can be used to gather information about all resource configuration information.
 author:
 - Abhijeet Kasurde (@Akasurde)
-notes:
-- Tested on vSphere 6.5
 extends_documentation_fragment:
 - community.vmware.vmware.documentation
 

--- a/plugins/modules/vmware_tag.py
+++ b/plugins/modules/vmware_tag.py
@@ -23,8 +23,6 @@ author:
 notes:
 - Tested on vSphere 6.5
 requirements:
-- python >= 2.6
-- PyVmomi
 - vSphere Automation SDK
 options:
     tag_name:

--- a/plugins/modules/vmware_tag.py
+++ b/plugins/modules/vmware_tag.py
@@ -20,8 +20,6 @@ description:
 - All variables and VMware object names are case sensitive.
 author:
 - Abhijeet Kasurde (@Akasurde)
-notes:
-- Tested on vSphere 6.5
 requirements:
 - vSphere Automation SDK
 options:

--- a/plugins/modules/vmware_tag_info.py
+++ b/plugins/modules/vmware_tag_info.py
@@ -23,8 +23,6 @@ author:
 notes:
 - Tested on vSphere 6.5
 requirements:
-- python >= 2.6
-- PyVmomi
 - vSphere Automation SDK
 extends_documentation_fragment:
 - community.vmware.vmware_rest_client.documentation

--- a/plugins/modules/vmware_tag_info.py
+++ b/plugins/modules/vmware_tag_info.py
@@ -20,8 +20,6 @@ description:
 - All variables and VMware object names are case sensitive.
 author:
 - Abhijeet Kasurde (@Akasurde)
-notes:
-- Tested on vSphere 6.5
 requirements:
 - vSphere Automation SDK
 extends_documentation_fragment:

--- a/plugins/modules/vmware_tag_manager.py
+++ b/plugins/modules/vmware_tag_manager.py
@@ -24,8 +24,6 @@ author:
 notes:
 - Tested on vSphere 6.5
 requirements:
-- python >= 2.6
-- PyVmomi
 - vSphere Automation SDK
 options:
     tag_names:

--- a/plugins/modules/vmware_tag_manager.py
+++ b/plugins/modules/vmware_tag_manager.py
@@ -21,8 +21,6 @@ description:
 author:
 - Abhijeet Kasurde (@Akasurde)
 - Frederic Van Reet (@GBrawl)
-notes:
-- Tested on vSphere 6.5
 requirements:
 - vSphere Automation SDK
 options:

--- a/plugins/modules/vmware_target_canonical_info.py
+++ b/plugins/modules/vmware_target_canonical_info.py
@@ -19,9 +19,6 @@ description:
 author:
 - Joseph Callen (@jcpowermac)
 - Abhijeet Kasurde (@Akasurde)
-requirements:
-    - Tested on vSphere 5.5 and 6.5
-    - PyVmomi installed
 options:
   target_id:
     description:

--- a/plugins/modules/vmware_vc_infraprofile_info.py
+++ b/plugins/modules/vmware_vc_infraprofile_info.py
@@ -24,8 +24,6 @@ author:
 notes:
 - Tested on vSphere 7.0
 requirements:
-- python >= 2.7
-- PyVmomi
 - vSphere Automation SDK
 options:
     decryption_key:

--- a/plugins/modules/vmware_vc_infraprofile_info.py
+++ b/plugins/modules/vmware_vc_infraprofile_info.py
@@ -21,8 +21,6 @@ description:
 version_added: '1.0.0'
 author:
 - Naveenkumar G P (@ngp)
-notes:
-- Tested on vSphere 7.0
 requirements:
 - vSphere Automation SDK
 options:

--- a/plugins/modules/vmware_vcenter_settings.py
+++ b/plugins/modules/vmware_vcenter_settings.py
@@ -20,9 +20,6 @@ author:
 - Christian Kotte (@ckotte)
 notes:
 - Tested with vCenter Server Appliance (vCSA) 6.5 and 6.7
-requirements:
-- python >= 2.6
-- PyVmomi
 options:
     database:
         description:

--- a/plugins/modules/vmware_vcenter_settings.py
+++ b/plugins/modules/vmware_vcenter_settings.py
@@ -18,8 +18,6 @@ description:
 - The statistics can be configured with the module C(vmware_vcenter_statistics).
 author:
 - Christian Kotte (@ckotte)
-notes:
-- Tested with vCenter Server Appliance (vCSA) 6.5 and 6.7
 options:
     database:
         description:

--- a/plugins/modules/vmware_vcenter_settings_info.py
+++ b/plugins/modules/vmware_vcenter_settings_info.py
@@ -17,9 +17,6 @@ description:
   - This module can be used to gather information about vCenter settings.
 author:
   - sky-joker (@sky-joker)
-requirements:
-  - python >= 2.7
-  - PyVmomi
 options:
   schema:
     description:

--- a/plugins/modules/vmware_vcenter_statistics.py
+++ b/plugins/modules/vmware_vcenter_statistics.py
@@ -18,8 +18,6 @@ description:
 - The remaining settings can be configured with the module C(vmware_vcenter_settings).
 author:
 - Christian Kotte (@ckotte)
-notes:
-- Tested with vCenter Server Appliance (vCSA) 6.5 and 6.7
 options:
     interval_past_day:
         description:

--- a/plugins/modules/vmware_vcenter_statistics.py
+++ b/plugins/modules/vmware_vcenter_statistics.py
@@ -20,9 +20,6 @@ author:
 - Christian Kotte (@ckotte)
 notes:
 - Tested with vCenter Server Appliance (vCSA) 6.5 and 6.7
-requirements:
-- python >= 2.6
-- PyVmomi
 options:
     interval_past_day:
         description:

--- a/plugins/modules/vmware_vm_config_option.py
+++ b/plugins/modules/vmware_vm_config_option.py
@@ -22,8 +22,6 @@ author:
 - Diane Wang (@Tomorrow9) <dianew@vmware.com>
 version_added: '1.15.0'
 notes:
-- Tested on vSphere 6.5
-- Tested on vSphere 6.7
 - Known issue on vSphere 7.0 (https://github.com/vmware/pyvmomi/issues/915)
 options:
   datacenter:

--- a/plugins/modules/vmware_vm_config_option.py
+++ b/plugins/modules/vmware_vm_config_option.py
@@ -25,10 +25,6 @@ notes:
 - Tested on vSphere 6.5
 - Tested on vSphere 6.7
 - Known issue on vSphere 7.0 (https://github.com/vmware/pyvmomi/issues/915)
-requirements:
-- python >= 2.6
-- PyVmomi
-- System.View privilege
 options:
   datacenter:
     description:

--- a/plugins/modules/vmware_vm_host_drs_rule.py
+++ b/plugins/modules/vmware_vm_host_drs_rule.py
@@ -77,9 +77,6 @@ options:
       - "Name of VM group to use with rule."
       - "Effective only if C(state) is set to C(present)."
     type: str
-requirements:
-  - "python >= 2.6"
-  - PyVmomi
 short_description: "Creates vm/host group in a given cluster"
 
 '''

--- a/plugins/modules/vmware_vm_host_drs_rule.py
+++ b/plugins/modules/vmware_vm_host_drs_rule.py
@@ -19,8 +19,6 @@ extends_documentation_fragment:
 - community.vmware.vmware.documentation
 
 module: vmware_vm_host_drs_rule
-notes:
-  - "Tested on vSphere 6.5 and 6.7"
 options:
   affinity_rule:
     default: true

--- a/plugins/modules/vmware_vm_info.py
+++ b/plugins/modules/vmware_vm_info.py
@@ -27,9 +27,6 @@ notes:
 - From 2.8 and onwards, information are returned as list of dict instead of dict.
 - Fact about C(moid) added in VMware collection 1.4.0.
 - Fact about C(datastore_url) is added in VMware collection 1.18.0.
-requirements:
-- python >= 2.6
-- PyVmomi
 options:
     vm_type:
       description:

--- a/plugins/modules/vmware_vm_info.py
+++ b/plugins/modules/vmware_vm_info.py
@@ -23,8 +23,6 @@ author:
 - Abhijeet Kasurde (@Akasurde)
 - Fedor Vompe (@sumkincpp)
 notes:
-- Tested on ESXi 6.7, vSphere 5.5 and vSphere 6.5
-- From 2.8 and onwards, information are returned as list of dict instead of dict.
 - Fact about C(moid) added in VMware collection 1.4.0.
 - Fact about C(datastore_url) is added in VMware collection 1.18.0.
 options:

--- a/plugins/modules/vmware_vm_shell.py
+++ b/plugins/modules/vmware_vm_shell.py
@@ -21,7 +21,6 @@ author:
   - Ritesh Khadgaray (@ritzk)
   - Abhijeet Kasurde (@Akasurde)
 notes:
-    - Tested on vSphere 5.5, 6.0 and 6.5.
     - Only the first match against vm_id is used, even if there are multiple matches.
 options:
     datacenter:

--- a/plugins/modules/vmware_vm_shell.py
+++ b/plugins/modules/vmware_vm_shell.py
@@ -23,9 +23,6 @@ author:
 notes:
     - Tested on vSphere 5.5, 6.0 and 6.5.
     - Only the first match against vm_id is used, even if there are multiple matches.
-requirements:
-    - "python >= 2.6"
-    - PyVmomi
 options:
     datacenter:
       description:

--- a/plugins/modules/vmware_vm_storage_policy.py
+++ b/plugins/modules/vmware_vm_storage_policy.py
@@ -20,8 +20,6 @@ description:
 version_added: '1.0.0'
 author:
 - Dustin Scott (@scottd018)
-notes:
-- Tested on vSphere 6.5
 options:
   name:
     description:

--- a/plugins/modules/vmware_vm_storage_policy.py
+++ b/plugins/modules/vmware_vm_storage_policy.py
@@ -22,9 +22,6 @@ author:
 - Dustin Scott (@scottd018)
 notes:
 - Tested on vSphere 6.5
-requirements:
-- python >= 2.7
-- PyVmomi
 options:
   name:
     description:

--- a/plugins/modules/vmware_vm_storage_policy_info.py
+++ b/plugins/modules/vmware_vm_storage_policy_info.py
@@ -22,9 +22,6 @@ author:
 - Abhijeet Kasurde (@Akasurde)
 notes:
 - Tested on vSphere 6.5
-requirements:
-- python >= 2.6
-- PyVmomi
 extends_documentation_fragment:
 - community.vmware.vmware.documentation
 

--- a/plugins/modules/vmware_vm_storage_policy_info.py
+++ b/plugins/modules/vmware_vm_storage_policy_info.py
@@ -20,8 +20,6 @@ description:
   for virtual machines and storage capabilities of storage providers.
 author:
 - Abhijeet Kasurde (@Akasurde)
-notes:
-- Tested on vSphere 6.5
 extends_documentation_fragment:
 - community.vmware.vmware.documentation
 

--- a/plugins/modules/vmware_vm_vm_drs_rule.py
+++ b/plugins/modules/vmware_vm_vm_drs_rule.py
@@ -19,9 +19,6 @@ author:
 - Abhijeet Kasurde (@Akasurde)
 notes:
 - Tested on vSphere 6.5
-requirements:
-- "python >= 2.6"
-- PyVmomi
 options:
   cluster_name:
     description:

--- a/plugins/modules/vmware_vm_vm_drs_rule.py
+++ b/plugins/modules/vmware_vm_vm_drs_rule.py
@@ -17,8 +17,6 @@ description:
 - This module can be used to configure VMware DRS Affinity rule for virtual machines in the given cluster.
 author:
 - Abhijeet Kasurde (@Akasurde)
-notes:
-- Tested on vSphere 6.5
 options:
   cluster_name:
     description:

--- a/plugins/modules/vmware_vm_vss_dvs_migrate.py
+++ b/plugins/modules/vmware_vm_vss_dvs_migrate.py
@@ -17,8 +17,6 @@ description:
     - Migrates a virtual machine from a standard vswitch to distributed
 author:
 - Joseph Callen (@jcpowermac)
-notes:
-    - Tested on vSphere 5.5
 options:
     vm_name:
         description:

--- a/plugins/modules/vmware_vm_vss_dvs_migrate.py
+++ b/plugins/modules/vmware_vm_vss_dvs_migrate.py
@@ -19,9 +19,6 @@ author:
 - Joseph Callen (@jcpowermac)
 notes:
     - Tested on vSphere 5.5
-requirements:
-    - "python >= 2.6"
-    - PyVmomi
 options:
     vm_name:
         description:

--- a/plugins/modules/vmware_vmkernel.py
+++ b/plugins/modules/vmware_vmkernel.py
@@ -31,9 +31,6 @@ notes:
     - You can only change from DHCP to static, and vSS to vDS, or vice versa, in one step, without creating a new device, with C(device) specified.
     - You can only create the VMKernel adapter on a vDS if authenticated to vCenter and not if authenticated to ESXi.
     - Tested on vSphere 5.5 and 6.5
-requirements:
-    - "python >= 2.6"
-    - PyVmomi
 options:
     vswitch_name:
       description:

--- a/plugins/modules/vmware_vmkernel.py
+++ b/plugins/modules/vmware_vmkernel.py
@@ -30,7 +30,6 @@ notes:
     - The option C(device) need to be used with DHCP because otherwise it's not possible to check if a VMkernel device is already present
     - You can only change from DHCP to static, and vSS to vDS, or vice versa, in one step, without creating a new device, with C(device) specified.
     - You can only create the VMKernel adapter on a vDS if authenticated to vCenter and not if authenticated to ESXi.
-    - Tested on vSphere 5.5 and 6.5
 options:
     vswitch_name:
       description:

--- a/plugins/modules/vmware_vmkernel_info.py
+++ b/plugins/modules/vmware_vmkernel_info.py
@@ -17,8 +17,6 @@ description:
 - This module can be used to gather VMKernel information about an ESXi host from given ESXi hostname or cluster name.
 author:
 - Abhijeet Kasurde (@Akasurde)
-notes:
-- Tested on vSphere 6.5
 options:
   cluster_name:
     description:

--- a/plugins/modules/vmware_vmkernel_info.py
+++ b/plugins/modules/vmware_vmkernel_info.py
@@ -19,9 +19,6 @@ author:
 - Abhijeet Kasurde (@Akasurde)
 notes:
 - Tested on vSphere 6.5
-requirements:
-- python >= 2.6
-- PyVmomi
 options:
   cluster_name:
     description:

--- a/plugins/modules/vmware_vmotion.py
+++ b/plugins/modules/vmware_vmotion.py
@@ -23,9 +23,6 @@ author:
 - Olivier Boukili (@oboukili)
 notes:
     - Tested on vSphere 6.0
-requirements:
-    - "python >= 2.6"
-    - pyVmomi
 options:
     vm_name:
       description:

--- a/plugins/modules/vmware_vmotion.py
+++ b/plugins/modules/vmware_vmotion.py
@@ -21,8 +21,6 @@ description:
 author:
 - Bede Carroll (@bedecarroll)
 - Olivier Boukili (@oboukili)
-notes:
-    - Tested on vSphere 6.0
 options:
     vm_name:
       description:

--- a/plugins/modules/vmware_vsan_cluster.py
+++ b/plugins/modules/vmware_vsan_cluster.py
@@ -19,9 +19,6 @@ author:
 - Russell Teague (@mtnbikenc)
 notes:
     - Tested on vSphere 5.5
-requirements:
-    - "python >= 2.6"
-    - PyVmomi
 options:
     cluster_uuid:
         description:

--- a/plugins/modules/vmware_vsan_cluster.py
+++ b/plugins/modules/vmware_vsan_cluster.py
@@ -17,8 +17,6 @@ description:
     - This module can be used to configure VSAN clustering on an ESXi host
 author:
 - Russell Teague (@mtnbikenc)
-notes:
-    - Tested on vSphere 5.5
 options:
     cluster_uuid:
         description:

--- a/plugins/modules/vmware_vsan_health_info.py
+++ b/plugins/modules/vmware_vsan_health_info.py
@@ -34,7 +34,6 @@ options:
         default: false
         type: bool
 requirements:
-    - PyVmomi
     - VMware vSAN Python's SDK
 extends_documentation_fragment:
 - community.vmware.vmware.documentation

--- a/plugins/modules/vmware_vspan_session.py
+++ b/plugins/modules/vmware_vspan_session.py
@@ -20,8 +20,6 @@ description:
    - This module can be used to create, delete or edit different kind of port mirroring sessions.
 author:
 - Peter Gyorgy (@gyorgypeter)
-notes:
-    - Tested on vSphere 6.7
 options:
     switch:
         description:

--- a/plugins/modules/vmware_vspan_session.py
+++ b/plugins/modules/vmware_vspan_session.py
@@ -22,9 +22,6 @@ author:
 - Peter Gyorgy (@gyorgypeter)
 notes:
     - Tested on vSphere 6.7
-requirements:
-    - "python > =  2.6"
-    - PyVmomi
 options:
     switch:
         description:

--- a/plugins/modules/vmware_vswitch.py
+++ b/plugins/modules/vmware_vswitch.py
@@ -21,8 +21,6 @@ author:
 - Joseph Callen (@jcpowermac)
 - Russell Teague (@mtnbikenc)
 - Abhijeet Kasurde (@Akasurde) <akasurde@redhat.com>
-notes:
-- Tested on vSphere 5.5 and 6.5
 options:
   switch:
     description:

--- a/plugins/modules/vmware_vswitch.py
+++ b/plugins/modules/vmware_vswitch.py
@@ -23,9 +23,6 @@ author:
 - Abhijeet Kasurde (@Akasurde) <akasurde@redhat.com>
 notes:
 - Tested on vSphere 5.5 and 6.5
-requirements:
-- python >= 2.6
-- PyVmomi
 options:
   switch:
     description:

--- a/plugins/modules/vmware_vswitch_info.py
+++ b/plugins/modules/vmware_vswitch_info.py
@@ -20,8 +20,6 @@ description:
 - See U(https://kb.vmware.com/s/article/2064511) for more details.
 author:
 - Abhijeet Kasurde (@Akasurde)
-notes:
-- Tested on vSphere 6.5
 options:
   policies:
     version_added: '2.4.0'

--- a/plugins/modules/vmware_vswitch_info.py
+++ b/plugins/modules/vmware_vswitch_info.py
@@ -22,9 +22,6 @@ author:
 - Abhijeet Kasurde (@Akasurde)
 notes:
 - Tested on vSphere 6.5
-requirements:
-- python >= 2.6
-- PyVmomi
 options:
   policies:
     version_added: '2.4.0'

--- a/plugins/modules/vsphere_copy.py
+++ b/plugins/modules/vsphere_copy.py
@@ -53,7 +53,6 @@ options:
 notes:
   - "This module ought to be run from a system that can access the vCenter or the ESXi directly and has the file to transfer.
     It can be the normal remote target or you can change it either by using C(transport: local) or using C(delegate_to)."
-  - Tested on vSphere 5.5 and ESXi 6.7
 extends_documentation_fragment:
 - community.vmware.vmware.documentation
 


### PR DESCRIPTION
##### SUMMARY
Python and pyVmomi requirements are already defined at the collection level. So they are, in the best case, redundant in the modules and, in the worst case (mostly, if not always), conflicting.

Additionally, all those `Tested on` documentation is quite misleading. A module might have been tested against a specific vCenter or ESXi version _originally_, but I assume that in most cases changes to the module weren't. Also, the CI tests run with a version not mentioned in the modules.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
nearly all :-P

##### ADDITIONAL INFORMATION
#1412 