### PR TITLE
vmware_host_logbundle: retry on download error

### DIFF
--- a/tests/integration/targets/vmware_host_logbundle/tasks/main.yml
+++ b/tests/integration/targets/vmware_host_logbundle/tasks/main.yml
@@ -163,6 +163,7 @@
     performance_data:
       duration: 10
       interval: 5
+  retries: 3
   register: fetch_logbundle_result
 
 - assert:
@@ -200,6 +201,7 @@
     performance_data:
       duration: 10
       interval: 5
+  retries: 3
   register: fetch_logbundle_result
 
 - assert:


### PR DESCRIPTION
It's rather comment to get a downlowd error. e.g:

```
Connection failure: The read operation timed out
```
