### PR TITLE
vmware_vswitch: Fix the broken logic of the failback parameter

### DIFF
--- a/changelogs/fragments/1431-vmware_vswitch-fix_failback.yml
+++ b/changelogs/fragments/1431-vmware_vswitch-fix_failback.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_vswitch - Fix broken logic of `failback` parameter (https://github.com/ansible-collections/community.vmware/issues/1431).

--- a/plugins/modules/vmware_vswitch.py
+++ b/plugins/modules/vmware_vswitch.py
@@ -648,9 +648,10 @@ class VMwareHostVirtualSwitch(PyVmomi):
         # Check failback
         if teaming_failback is not None:
             results['failback'] = teaming_failback
-            if teaming_policy.rollingOrder is not teaming_failback:
-                results['notify_switches_previous'] = teaming_policy.rollingOrder
-                teaming_policy.rollingOrder = teaming_failback
+            current_failback = not teaming_policy.rollingOrder
+            if current_failback != teaming_failback:
+                results['failback_previous'] = current_failback
+                teaming_policy.rollingOrder = not teaming_failback
                 changed = True
 
         # Check teaming failover order


### PR DESCRIPTION
##### SUMMARY
When using `vmware_vswitch` module to set a vSwitch teaming failback mode, the actual operation is opposite of what's [documented](https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_vswitch_module.html#parameters).
`failback: no` actually sets vSwitch Failback=yes and vice versa.

Fixes #1431

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_vswitch

##### ADDITIONAL INFORMATION
According to the [documentation](https://vdc-download.vmware.com/vmwb-repository/dcr-public/bf660c0a-f060-46e8-a94d-4b5e6ffc77ad/208bc706-e281-49b6-a0ce-b402ec19ef82/SDK/vsphere-ws/docs/ReferenceGuide/vim.host.NetworkPolicy.NicTeamingPolicy.html) rollingOrder works directly opposed to how people understand failback:

> For example, assume the explicit link order is (vmnic9, vmnic0), therefore vmnic9 goes down, vmnic0 comes up. However, when vmnic9 comes backup, if rollingOrder is set to be true, vmnic0 continues to be used, otherwise, vmnic9 is restored as specified in the explicitly order.

So you get a _failback_ behavior if you set `rollingOrder` to `false`. 