### PR TITLE
fix replace http with https for port 443 on cfg restore

### DIFF
--- a/changelogs/fragments/1440-vmware_cfg_backup-fails-to-restore-port-80-blocked.yaml
+++ b/changelogs/fragments/1440-vmware_cfg_backup-fails-to-restore-port-80-blocked.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_cfg_backup - Fix a bug that failed the restore when port 80 is blocked (https://github.com/ansible-collections/community.vmware/issues/1440).

--- a/plugins/modules/vmware_cfg_backup.py
+++ b/plugins/modules/vmware_cfg_backup.py
@@ -135,6 +135,8 @@ class VMwareConfigurationBackup(PyVmomi):
 
         url = self.host.configManager.firmwareSystem.QueryFirmwareConfigUploadURL()
         url = url.replace('*', self.cfg_hurl)
+        if self.module.params["port"] == 443:
+            url = url.replace("http:", "https:")
         # find manually the url if there is a redirect because urllib2 -per RFC- doesn't do automatic redirects for PUT requests
         try:
             open_url(url=url, method='HEAD', validate_certs=self.validate_certs)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
It seems like the URL returned from `self.host.configManager.firmwareSystem.QueryFirmwareConfigUploadURL()` returns the url with `http://` instead of `https://` and does not take the port into consideration. I tested it with the load_configuration() method and the fix works for my environment. Similar to #1335 which was for save_configuration()
 
Fixes #1440 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`vmware_cfg_backup`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
diff --git a/plugins/modules/vmware_cfg_backup.py b/plugins/modules/vmware_cfg_backup.py
index bb9c863..1007a6b 100644
--- a/plugins/modules/vmware_cfg_backup.py
+++ b/plugins/modules/vmware_cfg_backup.py
@@ -135,6 +135,8 @@ class VMwareConfigurationBackup(PyVmomi):
 
         url = self.host.configManager.firmwareSystem.QueryFirmwareConfigUploadURL()
         url = url.replace('*', self.cfg_hurl)
+        if self.module.params["port"] == 443:
+            url = url.replace("http:", "https:")
         # find manually the url if there is a redirect because urllib2 -per RFC- doesn't do automatic redirects for PUT requests
         try:
             open_url(url=url, method='HEAD', validate_certs=self.validate_certs)

```
