### PR TITLE
vmware_guest_boot_manager: Add initial integration test

### DIFF
--- a/tests/integration/targets/vmware_guest_boot_manager/aliases
+++ b/tests/integration/targets/vmware_guest_boot_manager/aliases
@@ -1,0 +1,3 @@
+cloud/vcenter
+needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_guest_boot_manager/tasks/main.yml
+++ b/tests/integration/targets/vmware_guest_boot_manager/tasks/main.yml
@@ -1,0 +1,44 @@
+# Test code for the vmware_guest_boot_manager module.
+# Copyright: (c) 2022, Mario Lenz <m@riolenz.de>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_attach_host: true
+    setup_datastore: true
+    setup_virtualmachines: true
+
+- name: Enter BIOS setup
+  community.vmware.vmware_guest_boot_manager:
+    validate_certs: false
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    name: "{{ virtual_machines[0].name }}"
+    enter_bios_setup: true
+  register: enter_bios_setup
+
+- ansible.builtin.debug: var=enter_bios_setup
+
+- name: assert that configuration is changed
+  assert:
+    that:
+    - enter_bios_setup.changed
+
+- name: Enter BIOS setup again (check idempotency)
+  community.vmware.vmware_guest_boot_manager:
+    validate_certs: false
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    name: "{{ virtual_machines[0].name }}"
+    enter_bios_setup: true
+  register: enter_bios_setup_again
+
+- ansible.builtin.debug: var=enter_bios_setup_again
+
+- name: assert that configuration is not changed again
+  assert:
+    that:
+    - not enter_bios_setup_again.changed

--- a/tests/integration/targets/vmware_guest_boot_manager/tasks/main.yml
+++ b/tests/integration/targets/vmware_guest_boot_manager/tasks/main.yml
@@ -25,20 +25,3 @@
   assert:
     that:
     - enter_bios_setup.changed
-
-- name: Enter BIOS setup again (check idempotency)
-  community.vmware.vmware_guest_boot_manager:
-    validate_certs: false
-    hostname: '{{ vcenter_hostname }}'
-    username: '{{ vcenter_username }}'
-    password: '{{ vcenter_password }}'
-    name: "{{ virtual_machines[0].name }}"
-    enter_bios_setup: true
-  register: enter_bios_setup_again
-
-- ansible.builtin.debug: var=enter_bios_setup_again
-
-- name: assert that configuration is not changed again
-  assert:
-    that:
-    - not enter_bios_setup_again.changed


### PR DESCRIPTION
##### SUMMARY
There are no integration tests for `vmware_guest_boot_manager` yet. This PR adds one, although it's still very simple.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_guest_boot_manager

##### ADDITIONAL INFORMATION
#28

I'll try to add another one when fixing #1257