### PR TITLE
vmware_drs_group_manager: Improve error handling

### DIFF
--- a/changelogs/fragments/1448-vmware_drs_group_manager-error_msg.yml
+++ b/changelogs/fragments/1448-vmware_drs_group_manager-error_msg.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_drs_group_manager - Improve error handling (https://github.com/ansible-collections/community.vmware/pull/1448).

--- a/plugins/modules/vmware_drs_group_manager.py
+++ b/plugins/modules/vmware_drs_group_manager.py
@@ -192,16 +192,19 @@ class VmwareDrsGroupMemberManager(PyVmomi):
             self._datacenter_obj = self.find_datacenter_by_name(self._datacenter_name)
 
             if self._datacenter_obj is None:
-                raise Exception("Datacenter '%s' not found" % self._datacenter_name)
+                self.module.fail_json(msg="Datacenter '%s' not found" % self._datacenter_name)
 
         self._cluster_obj = self.find_cluster_by_name(self._cluster_name, self._datacenter_obj)
 
         # Throw error if cluster does not exist
         if self._cluster_obj is None:
-            raise Exception("Cluster '%s' not found" % self._cluster_name)
+            self.module.fail_json(msg="Cluster '%s' not found" % self._cluster_name)
 
         # get group
         self._group_obj = self._get_group_by_name()
+        if self._group_obj is None:
+            self.module.fail_json(msg="Cluster %s does not have a DRS group %s" % (self._cluster_name, self._group_name))
+
         # Set result here. If nothing is to be updated, result is already set
         self._set_result(self._group_obj)
 
@@ -251,8 +254,7 @@ class VmwareDrsGroupMemberManager(PyVmomi):
                     vm_obj = find_vm_by_id(content=self.content, vm_id=vm,
                                            vm_id_type='vm_name', cluster=cluster_obj)
                     if vm_obj is None:
-                        raise Exception("VM %s does not exist in cluster %s" % (vm,
-                                                                                self._cluster_name))
+                        self.module.fail_json(msg="VM %s does not exist in cluster %s" % (vm, self._cluster_name))
                     self._vm_obj_list.append(vm_obj)
 
     def _set_host_obj_list(self, host_list=None):
@@ -274,7 +276,7 @@ class VmwareDrsGroupMemberManager(PyVmomi):
                     # Get host data
                     host_obj = self.find_hostsystem_by_name(host)
                     if host_obj is None and self.module.check_mode is False:
-                        raise Exception("ESXi host %s does not exist in cluster %s" % (host, self._cluster_name))
+                        self.module.fail_json(msg="ESXi host %s does not exist in cluster %s" % (host, self._cluster_name))
                     self._host_obj_list.append(host_obj)
 
     def _get_group_by_name(self, group_name=None, cluster_obj=None):
@@ -469,7 +471,7 @@ class VmwareDrsGroupMemberManager(PyVmomi):
         elif self._host_list is None:
             self._manage_vm_group()
         else:
-            raise Exception('Failed, no hosts or vms defined')
+            self.module.fail_json(msg="Failed, no hosts or vms defined")
 
 
 def main():


### PR DESCRIPTION
##### SUMMARY
`vmware_drs_group_manager` raises exceptions instead of calling  `fail_json()`.

Additionally, if the DRS group doesn't exist the module fails with `'NoneType' object has no attribute 'vm'` or `'NoneType' object has no attribute 'host'` which isn't really helpful.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_drs_group_manager

##### ADDITIONAL INFORMATION
#1415
