### PR TITLE
prepare 2.9.1 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,14 @@ community.vmware Release Notes
 .. contents:: Topics
 
 
+v2.9.1
+======
+
+Bugfixes
+--------
+
+- 2.9.0 wasn't released correctly, some changes are missing from the package. Releasing 2.9.1 to fix this.
+
 v2.9.0
 ======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -1298,3 +1298,11 @@ releases:
     - 1440-vmware_cfg_backup-fails-to-restore-port-80-blocked.yaml
     - 1448-vmware_drs_group_manager-error_msg.yml
     release_date: '2022-09-06'
+  2.9.1:
+    changes:
+      bugfixes:
+      - 2.9.0 wasn't released correctly, some changes are missing from the package.
+        Releasing 2.9.1 to fix this.
+    fragments:
+    - 2.9.1-fix-release.yml
+    release_date: '2022-09-07'

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -5,7 +5,7 @@ name: vmware
 # https://github.com/ansible-network/releases/tree/master/ansible_releases/cmd
 # A script based on https://pypi.org/project/pbr/ will generate the version
 # key. The version value depends on the tag or the last git tag.
-version: 2.9.0
+version: 2.9.1
 readme: README.md
 authors:
   - Ansible (https://github.com/ansible)


### PR DESCRIPTION
2.9.0 wasn't released correctly, some changes are missing from the package. Releasing 2.9.1 to fix this.