### PR TITLE
Fix access to None-type attribute

### DIFF
--- a/plugins/modules/vmware_guest_network.py
+++ b/plugins/modules/vmware_guest_network.py
@@ -839,14 +839,19 @@ class PyVmomiHelper(PyVmomi):
                 diff['after'].update(
                     {
                         nic_mac: {
-                            'vlan_id': self._get_vlanid_from_network(network_obj),
-                            'network_name': network_obj.name,
                             'label': label,
                             'mac_address': nic_mac,
                             'unit_number': 40000
                         }
                     }
                 )
+                if network_obj:
+                    diff['after'][nic_mac].update(
+                        {
+                            'vlan_id': self._get_vlanid_from_network(network_obj),
+                            'network_name': network_obj.name
+                        }
+                    )
 
         if self.module.check_mode:
             network_info = [diff['after'][i] for i in diff['after']]


### PR DESCRIPTION
If network_obj is None and check mode is enabled access to name attribute fails.

##### SUMMARY
If running in check mode to fetch all network interfaces on some VMs the current code run into error because of an access to an attribute of network_obj which is None.
This will update the relevant attributes only if network_obj is not None (same as in the code block above).

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_guest_network
