### PR TITLE
vmware_guest_boot_manager: Remove secure_boot_enabled default

### DIFF
--- a/changelogs/fragments/1257-vmware_guest_boot_manager-remove_secure_boot_default.yml
+++ b/changelogs/fragments/1257-vmware_guest_boot_manager-remove_secure_boot_default.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+  - vmware_guest_boot_manager - Remove default for `secure_boot_enabled` parameter (https://github.com/ansible-collections/community.vmware/issues/1257).

--- a/tests/integration/targets/vmware_guest_boot_manager/tasks/main.yml
+++ b/tests/integration/targets/vmware_guest_boot_manager/tasks/main.yml
@@ -9,19 +9,68 @@
     setup_datastore: true
     setup_virtualmachines: true
 
-- name: Enter BIOS setup
+- name: Enable Secure Boot
   community.vmware.vmware_guest_boot_manager:
     validate_certs: false
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
     name: "{{ virtual_machines[0].name }}"
-    enter_bios_setup: true
-  register: enter_bios_setup
+    boot_firmware: efi
+    secure_boot_enabled: true
+  register: enable_secure_boot
 
-- ansible.builtin.debug: var=enter_bios_setup
+- ansible.builtin.debug: var=enable_secure_boot
 
-- name: assert that configuration is changed
+- name: Get VM boot info 1
+  community.vmware.vmware_guest_boot_info:
+    validate_certs: false
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    name: "{{ virtual_machines[0].name }}"
+  register: boot_info1
+
+- ansible.builtin.debug: var=boot_info1
+
+- name: assert that Secure Boot is enabled
   assert:
     that:
-    - enter_bios_setup.changed
+    - enable_secure_boot.changed
+    - boot_info1.vm_boot_info.current_secure_boot_enabled is true
+
+- name: Issue https://github.com/ansible-collections/community.vmware/issues/1257
+  block:
+    - name: Enter BIOS setup
+      community.vmware.vmware_guest_boot_manager:
+        validate_certs: false
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        name: "{{ virtual_machines[0].name }}"
+        enter_bios_setup: true
+      register: enter_bios_setup
+
+    - ansible.builtin.debug: var=enter_bios_setup
+
+    - name: Get VM boot info 2
+      community.vmware.vmware_guest_boot_info:
+        validate_certs: false
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        name: "{{ virtual_machines[0].name }}"
+      register: boot_info2
+
+    - ansible.builtin.debug: var=boot_info2
+
+    - name: assert that configuration is changed
+      assert:
+        that:
+        - enter_bios_setup.changed
+        - boot_info2.vm_boot_info.current_enter_bios_setup is true
+
+    - name: assert that Secure Boot is still enabled
+      assert:
+        that:
+        - boot_info2.vm_boot_info.current_secure_boot_enabled is true


### PR DESCRIPTION
##### SUMMARY
Fixes #1257

When using this module to enable `enter_bios_setup` on a VM with UEFI and Secure Boot enabled, it will disable Secure Boot. I think the best way to fix this is to _not_ have a default for `secure_boot_enabled `.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_guest_boot_manager

##### ADDITIONAL INFORMATION
See #1257 for more information.