### PR TITLE
vmware_host_firewall_manager: Remove deprecated functionality

### DIFF
--- a/changelogs/fragments/1196-vmware_host_firewall_manager-remove_deprecated_stuff.yml
+++ b/changelogs/fragments/1196-vmware_host_firewall_manager-remove_deprecated_stuff.yml
@@ -1,0 +1,3 @@
+removed_features:
+  - vmware_host_firewall_manager - The module doesn't accept a list for `allowed_hosts` anymore.
+  - vmware_host_firewall_manager - The module doesn't accept `allowed_hosts` without defining `all_ip` anymore.

--- a/plugins/modules/vmware_host_firewall_manager.py
+++ b/plugins/modules/vmware_host_firewall_manager.py
@@ -264,20 +264,19 @@ class VmwareFirewallManager(PyVmomi):
                 self.module.fail_json(msg="Please specify rules.enabled for rule set"
                                           " %s as it is required parameter." % rule_name)
 
-            allowed_hosts = rule_option.get('allowed_hosts', {})
-            ip_addresses = allowed_hosts.get('ip_address')
-            ip_networks = allowed_hosts.get('ip_network')
-            for ip_address in ip_addresses:
-                try:
-                    is_ipaddress(ip_address)
-                except ValueError:
-                    self.module.fail_json(msg="%s is not a valid IP." % ip_address)
+            allowed_hosts = rule_option.get('allowed_hosts')
+            if allowed_hosts is not None:
+                for ip_address in allowed_hosts.get('ip_address'):
+                    try:
+                        is_ipaddress(ip_address)
+                    except ValueError:
+                        self.module.fail_json(msg="%s is not a valid IP." % ip_address)
 
-            for ip_network in ip_networks:
-                try:
-                    is_ipaddress(ip_network)
-                except ValueError:
-                    self.module.fail_json(msg="%s is not a valid network" % ip_network)
+                for ip_network in allowed_hosts.get('ip_network'):
+                    try:
+                        is_ipaddress(ip_network)
+                    except ValueError:
+                        self.module.fail_json(msg="%s is not a valid network" % ip_network)
 
     def ensure(self):
         """

--- a/plugins/modules/vmware_host_firewall_manager.py
+++ b/plugins/modules/vmware_host_firewall_manager.py
@@ -270,13 +270,15 @@ class VmwareFirewallManager(PyVmomi):
                     try:
                         is_ipaddress(ip_address)
                     except ValueError:
-                        self.module.fail_json(msg="%s is not a valid IP." % ip_address)
+                        self.module.fail_json(msg="The provided IP address %s is not a valid IP"
+                                                  " for the rule %s" % (ip_address, rule_name))
 
                 for ip_network in allowed_hosts.get('ip_network'):
                     try:
                         is_ipaddress(ip_network)
                     except ValueError:
-                        self.module.fail_json(msg="%s is not a valid network" % ip_network)
+                        self.module.fail_json(msg="The provided IP network %s is not a valid network"
+                                                  " for the rule %s" % (ip_network, rule_name))
 
     def ensure(self):
         """
@@ -324,10 +326,10 @@ class VmwareFirewallManager(PyVmomi):
                 rule_allowed_ips = set(permitted_networking['allowed_hosts']['ip_address'])
                 rule_allowed_networks = set(permitted_networking['allowed_hosts']['ip_network'])
 
-                allowed_hosts = rule_option.get('allowed_hosts', {})
-                playbook_allows_all = allowed_hosts.get('all_ip', False)
-                playbook_allowed_ips = set(allowed_hosts.get('ip_address', []))
-                playbook_allowed_networks = set(allowed_hosts.get('ip_network', []))
+                allowed_hosts = rule_option.get('allowed_hosts')
+                playbook_allows_all = False if allowed_hosts is None else allowed_hosts.get('all_ip')
+                playbook_allowed_ips = set([]) if allowed_hosts is None else set(allowed_hosts.get('ip_address'))
+                playbook_allowed_networks = set([]) if allowed_hosts is None else set(allowed_hosts.get('ip_network'))
 
                 # compare what is configured on the firewall rule with what the playbook provides
                 allowed_all_ips_different = bool(rule_allows_all != playbook_allows_all)

--- a/tests/integration/targets/vmware_host_firewall_manager/tasks/main.yml
+++ b/tests/integration/targets/vmware_host_firewall_manager/tasks/main.yml
@@ -19,7 +19,9 @@
         allowed_hosts:
           all_ip: true
   register: all_hosts_result
+
 - debug: msg="{{ all_hosts_result }}"
+
 - name: ensure everything is changed for all hosts of {{ ccr1 }}
   assert:
     that:
@@ -47,7 +49,9 @@
       - name: vvold
         enabled: false
   register: host_result
+
 - debug: msg="{{ host_result }}"
+
 - name: ensure vvold is disabled for {{ host1 }}
   assert:
     that:
@@ -77,7 +81,9 @@
           all_ip: true
   register: all_hosts_result_check_mode
   check_mode: true
+
 - debug: var=all_hosts_result_check_mode
+
 - name: ensure everything is changed for all hosts of {{ ccr1 }}
   assert:
     that:
@@ -103,7 +109,9 @@
         enabled: false
   register: host_result_check_mode
   check_mode: true
+
 - debug: msg="{{ host_result_check_mode }}"
+
 - name: ensure vvold is disabled for {{ host1 }}
   assert:
         that:
@@ -137,7 +145,9 @@
           ip_network:
             - "192.168.200.0/24"
   register: all_hosts_ip_specific
+
 - debug: var=all_hosts_ip_specific
+
 - name: ensure everything is changed for all hosts of {{ ccr1 }}
   assert:
     that:
@@ -180,10 +190,14 @@
           ip_address:
             - "192.168.100.11"
   register: single_host_ip_specific
+
 - set_fact:
     nfc_state: "{{ single_host_ip_specific.rule_set_state[esxi1]['NFC'] }}"
+
 - debug: var=single_host_ip_specific
+
 - debug: var=nfc_state
+
 - name: ensure NFC is configured on that host
   assert:
     that:
@@ -215,13 +229,17 @@
             ip_address:
               - "1.2.3.4"
   register: using_list
+
 - debug: var=using_list
+
 - set_fact:
     nfc_state: "{{ using_list.rule_set_state[esxi1]['NFC'] }}"
+
 - name: ensure the correct host is set
   assert:
     that:
       - nfc_state.allowed_hosts.current_allowed_ip == ["1.2.3.4"]
+
 - name: Clean up the firewall rules
   community.vmware.vmware_host_firewall_manager:
     cluster_name: '{{ ccr1 }}'

--- a/tests/integration/targets/vmware_host_firewall_manager/tasks/main.yml
+++ b/tests/integration/targets/vmware_host_firewall_manager/tasks/main.yml
@@ -6,252 +6,255 @@
   vars:
     setup_attach_host: true
 
-- name: Enable vvold rule set on all hosts of {{ ccr1 }}
-  community.vmware.vmware_host_firewall_manager:
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    validate_certs: false
-    cluster_name: "{{ ccr1 }}"
-    rules:
-      - name: vvold
-        enabled: true
-        allowed_hosts:
-          all_ip: true
-  register: all_hosts_result
+- name: Run tests and clean up
+  block:
+    - name: Enable vvold rule set on all hosts of {{ ccr1 }}
+      community.vmware.vmware_host_firewall_manager:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        cluster_name: "{{ ccr1 }}"
+        rules:
+          - name: vvold
+            enabled: true
+            allowed_hosts:
+              all_ip: true
+      register: all_hosts_result
 
-- debug: msg="{{ all_hosts_result }}"
+    - debug: msg="{{ all_hosts_result }}"
 
-- name: ensure everything is changed for all hosts of {{ ccr1 }}
-  assert:
-    that:
-        - all_hosts_result.changed
-        - all_hosts_result.rule_set_state is defined
-
-- name: ensure info are gathered for all hosts of {{ ccr1 }}
-  assert:
-    that:
-        - all_hosts_result.rule_set_state[item]['vvold']['current_state'] == true
-        - all_hosts_result.rule_set_state[item]['vvold']['desired_state'] == true
-        - all_hosts_result.rule_set_state[item]['vvold']['previous_state'] == False
-  with_items:
-    - '{{ esxi1 }}'
-    - '{{ esxi2 }}'
-
-- name: Disable vvold for {{ host1 }}
-  community.vmware.vmware_host_firewall_manager:
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    validate_certs: false
-    esxi_hostname: '{{ esxi1 }}'
-    rules:
-      - name: vvold
-        enabled: false
-  register: host_result
-
-- debug: msg="{{ host_result }}"
-
-- name: ensure vvold is disabled for {{ host1 }}
-  assert:
-    that:
-        - host_result.changed
-        - host_result.rule_set_state is defined
-
-- name: ensure info are gathered for {{ host1 }}
-  assert:
-    that:
-        - host_result.rule_set_state[item]['vvold']['current_state'] == False
-        - host_result.rule_set_state[item]['vvold']['desired_state'] == False
-        - host_result.rule_set_state[item]['vvold']['previous_state'] == true
-  with_items:
-    - '{{ esxi1 }}'
-
-- name: Enable vvold rule set on all hosts of {{ ccr1 }} in check mode
-  community.vmware.vmware_host_firewall_manager:
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    validate_certs: false
-    cluster_name: "{{ ccr1 }}"
-    rules:
-      - name: vvold
-        enabled: true
-        allowed_hosts:
-          all_ip: true
-  register: all_hosts_result_check_mode
-  check_mode: true
-
-- debug: var=all_hosts_result_check_mode
-
-- name: ensure everything is changed for all hosts of {{ ccr1 }}
-  assert:
-    that:
-        - all_hosts_result_check_mode.changed
-        - all_hosts_result_check_mode.rule_set_state is defined
-
-- name: ensure info are gathered for all hosts of {{ ccr1 }}
-  assert:
-    that:
-        - all_hosts_result_check_mode.rule_set_state[esxi1]['vvold']['current_state'] == true
-        - all_hosts_result_check_mode.rule_set_state[esxi2]['vvold']['current_state'] == true
-        - all_hosts_result_check_mode.rule_set_state[esxi2]['vvold']['desired_state'] == true
-
-- name: Disable vvold for {{ host1 }} in check mode
-  community.vmware.vmware_host_firewall_manager:
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    validate_certs: false
-    esxi_hostname: '{{ esxi1 }}'
-    rules:
-      - name: vvold
-        enabled: false
-  register: host_result_check_mode
-  check_mode: true
-
-- debug: msg="{{ host_result_check_mode }}"
-
-- name: ensure vvold is disabled for {{ host1 }}
-  assert:
+    - name: ensure everything is changed for all hosts of {{ ccr1 }}
+      assert:
         that:
-        - host_result_check_mode.changed == False
-        - host_result_check_mode.rule_set_state is defined
+          - all_hosts_result.changed
+          - all_hosts_result.rule_set_state is defined
 
-- name: ensure info are gathered for {{ host1 }}
-  assert:
-    that:
-        - host_result_check_mode.rule_set_state[item]['vvold']['current_state'] == False
-        - host_result_check_mode.rule_set_state[item]['vvold']['desired_state'] == False
-        - host_result_check_mode.rule_set_state[item]['vvold']['previous_state'] == False
-  with_items:
-    - '{{ esxi1 }}'
+    - name: ensure info are gathered for all hosts of {{ ccr1 }}
+      assert:
+        that:
+          - all_hosts_result.rule_set_state[item]['vvold']['current_state'] == true
+          - all_hosts_result.rule_set_state[item]['vvold']['desired_state'] == true
+          - all_hosts_result.rule_set_state[item]['vvold']['previous_state'] == False
+      with_items:
+        - '{{ esxi1 }}'
+        - '{{ esxi2 }}'
 
-- name: Configure CIMHttpServer rule set on all hosts of {{ ccr1 }}
-  community.vmware.vmware_host_firewall_manager:
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    validate_certs: false
-    cluster_name: "{{ ccr1 }}"
-    rules:
-      - name: CIMHttpServer
-        enabled: true
-        allowed_hosts:
-          all_ip: false
-          ip_address:
-            - "192.168.100.11"
-            - "192.168.100.12"
-          ip_network:
-            - "192.168.200.0/24"
-  register: all_hosts_ip_specific
+    - name: Disable vvold for {{ host1 }}
+      community.vmware.vmware_host_firewall_manager:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        esxi_hostname: '{{ esxi1 }}'
+        rules:
+          - name: vvold
+            enabled: false
+      register: host_result
 
-- debug: var=all_hosts_ip_specific
+    - debug: msg="{{ host_result }}"
 
-- name: ensure everything is changed for all hosts of {{ ccr1 }}
-  assert:
-    that:
-      - all_hosts_ip_specific.changed
-      - all_hosts_ip_specific.rule_set_state is defined
+    - name: ensure vvold is disabled for {{ host1 }}
+      assert:
+        that:
+          - host_result.changed
+          - host_result.rule_set_state is defined
 
-- name: ensure CIMHttpServer is configured for all hosts in {{ ccr1 }}
-  assert:
-    that:
-      - all_hosts_ip_specific.rule_set_state[item]['CIMHttpServer']['current_state'] == true
-      - all_hosts_ip_specific.rule_set_state[item]['CIMHttpServer']['desired_state'] == true
-      - all_hosts_ip_specific.rule_set_state[item]['CIMHttpServer']['previous_state'] == true
-      - all_hosts_ip_specific.rule_set_state[item]['CIMHttpServer']['allowed_hosts']['current_allowed_all'] == False
-      - all_hosts_ip_specific.rule_set_state[item]['CIMHttpServer']['allowed_hosts']['previous_allowed_all'] == true
-      - all_hosts_ip_specific.rule_set_state[item]['CIMHttpServer']['allowed_hosts']['desired_allowed_all'] == False
-      - "'192.168.100.11' in all_hosts_ip_specific.rule_set_state[item]['CIMHttpServer']['allowed_hosts']['current_allowed_ip']"
-      - "'192.168.100.12' in all_hosts_ip_specific.rule_set_state[item]['CIMHttpServer']['allowed_hosts']['current_allowed_ip']"
-      - all_hosts_ip_specific.rule_set_state[item]['CIMHttpServer']['allowed_hosts']['previous_allowed_ip'] == []
-      - "'192.168.100.11' in all_hosts_ip_specific.rule_set_state[item]['CIMHttpServer']['allowed_hosts']['desired_allowed_ip']"
-      - "'192.168.100.12' in all_hosts_ip_specific.rule_set_state[item]['CIMHttpServer']['allowed_hosts']['desired_allowed_ip']"
-      - all_hosts_ip_specific.rule_set_state[item]['CIMHttpServer']['allowed_hosts']['current_allowed_networks'] == ["192.168.200.0/24"]
-      - all_hosts_ip_specific.rule_set_state[item]['CIMHttpServer']['allowed_hosts']['previous_allowed_networks'] == []
-      - all_hosts_ip_specific.rule_set_state[item]['CIMHttpServer']['allowed_hosts']['desired_allowed_networks'] == ["192.168.200.0/24"]
-  with_items:
-    - '{{ esxi1 }}'
-    - '{{ esxi2 }}'
+    - name: ensure info are gathered for {{ host1 }}
+      assert:
+        that:
+          - host_result.rule_set_state[item]['vvold']['current_state'] == False
+          - host_result.rule_set_state[item]['vvold']['desired_state'] == False
+          - host_result.rule_set_state[item]['vvold']['previous_state'] == true
+      with_items:
+        - '{{ esxi1 }}'
 
-- name: Configure the NFC firewall rule to only allow traffic from one IP on one ESXi host
-  community.vmware.vmware_host_firewall_manager:
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    validate_certs: false
-    esxi_hostname: "{{ esxi1 }}"
-    rules:
-      - name: NFC
-        enabled: true
-        allowed_hosts:
-          all_ip: false
-          ip_address:
-            - "192.168.100.11"
-  register: single_host_ip_specific
+    - name: Enable vvold rule set on all hosts of {{ ccr1 }} in check mode
+      community.vmware.vmware_host_firewall_manager:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        cluster_name: "{{ ccr1 }}"
+        rules:
+          - name: vvold
+            enabled: true
+            allowed_hosts:
+              all_ip: true
+      register: all_hosts_result_check_mode
+      check_mode: true
 
-- set_fact:
-    nfc_state: "{{ single_host_ip_specific.rule_set_state[esxi1]['NFC'] }}"
+    - debug: var=all_hosts_result_check_mode
 
-- debug: var=single_host_ip_specific
+    - name: ensure everything is changed for all hosts of {{ ccr1 }}
+      assert:
+        that:
+          - all_hosts_result_check_mode.changed
+          - all_hosts_result_check_mode.rule_set_state is defined
 
-- debug: var=nfc_state
+    - name: ensure info are gathered for all hosts of {{ ccr1 }}
+      assert:
+        that:
+          - all_hosts_result_check_mode.rule_set_state[esxi1]['vvold']['current_state'] == true
+            - all_hosts_result_check_mode.rule_set_state[esxi2]['vvold']['current_state'] == true
+          - all_hosts_result_check_mode.rule_set_state[esxi2]['vvold']['desired_state'] == true
 
-- name: ensure NFC is configured on that host
-  assert:
-    that:
-      - nfc_state.current_state == true
-      - nfc_state.desired_state == true
-      - nfc_state.previous_state == true
-      - nfc_state.allowed_hosts.current_allowed_all == False
-      - nfc_state.allowed_hosts.previous_allowed_all == true
-      - nfc_state.allowed_hosts.desired_allowed_all == False
-      - nfc_state.allowed_hosts.current_allowed_ip == ["192.168.100.11"]
-      - nfc_state.allowed_hosts.previous_allowed_all == true
-      - nfc_state.allowed_hosts.desired_allowed_ip == ["192.168.100.11"]
-      - nfc_state.allowed_hosts.current_allowed_networks == []
-      - nfc_state.allowed_hosts.previous_allowed_networks == []
-      - nfc_state.allowed_hosts.desired_allowed_networks == []
+    - name: Disable vvold for {{ host1 }} in check mode
+      community.vmware.vmware_host_firewall_manager:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        esxi_hostname: '{{ esxi1 }}'
+        rules:
+          - name: vvold
+            enabled: false
+      register: host_result_check_mode
+      check_mode: true
 
-- name: Ensure we can still pass the allowed_hosts configuration through a list for compat
-  community.vmware.vmware_host_firewall_manager:
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    validate_certs: false
-    esxi_hostname: "{{ esxi1 }}"
-    rules:
-      - name: NFC
-        enabled: true
-        allowed_hosts:
-          - all_ip: false
+    - debug: msg="{{ host_result_check_mode }}"
+
+    - name: ensure vvold is disabled for {{ host1 }}
+      assert:
+        that:
+          - host_result_check_mode.changed == False
+          - host_result_check_mode.rule_set_state is defined
+
+    - name: ensure info are gathered for {{ host1 }}
+      assert:
+        that:
+          - host_result_check_mode.rule_set_state[item]['vvold']['current_state'] == False
+          - host_result_check_mode.rule_set_state[item]['vvold']['desired_state'] == False
+          - host_result_check_mode.rule_set_state[item]['vvold']['previous_state'] == False
+      with_items:
+        - '{{ esxi1 }}'
+
+    - name: Configure CIMHttpServer rule set on all hosts of {{ ccr1 }}
+      community.vmware.vmware_host_firewall_manager:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        cluster_name: "{{ ccr1 }}"
+        rules:
+          - name: CIMHttpServer
+            enabled: true
+            allowed_hosts:
+              all_ip: false
+              ip_address:
+                - "192.168.100.11"
+                - "192.168.100.12"
+              ip_network:
+                - "192.168.200.0/24"
+      register: all_hosts_ip_specific
+
+    - debug: var=all_hosts_ip_specific
+
+    - name: ensure everything is changed for all hosts of {{ ccr1 }}
+      assert:
+        that:
+          - all_hosts_ip_specific.changed
+          - all_hosts_ip_specific.rule_set_state is defined
+
+    - name: ensure CIMHttpServer is configured for all hosts in {{ ccr1 }}
+      assert:
+        that:
+          - all_hosts_ip_specific.rule_set_state[item]['CIMHttpServer']['current_state'] == true
+          - all_hosts_ip_specific.rule_set_state[item]['CIMHttpServer']['desired_state'] == true
+          - all_hosts_ip_specific.rule_set_state[item]['CIMHttpServer']['previous_state'] == true
+          - all_hosts_ip_specific.rule_set_state[item]['CIMHttpServer']['allowed_hosts']['current_allowed_all'] == False
+          - all_hosts_ip_specific.rule_set_state[item]['CIMHttpServer']['allowed_hosts']['previous_allowed_all'] == true
+          - all_hosts_ip_specific.rule_set_state[item]['CIMHttpServer']['allowed_hosts']['desired_allowed_all'] == False
+          - "'192.168.100.11' in all_hosts_ip_specific.rule_set_state[item]['CIMHttpServer']['allowed_hosts']['current_allowed_ip']"
+          - "'192.168.100.12' in all_hosts_ip_specific.rule_set_state[item]['CIMHttpServer']['allowed_hosts']['current_allowed_ip']"
+          - all_hosts_ip_specific.rule_set_state[item]['CIMHttpServer']['allowed_hosts']['previous_allowed_ip'] == []
+          - "'192.168.100.11' in all_hosts_ip_specific.rule_set_state[item]['CIMHttpServer']['allowed_hosts']['desired_allowed_ip']"
+          - "'192.168.100.12' in all_hosts_ip_specific.rule_set_state[item]['CIMHttpServer']['allowed_hosts']['desired_allowed_ip']"
+          - all_hosts_ip_specific.rule_set_state[item]['CIMHttpServer']['allowed_hosts']['current_allowed_networks'] == ["192.168.200.0/24"]
+          - all_hosts_ip_specific.rule_set_state[item]['CIMHttpServer']['allowed_hosts']['previous_allowed_networks'] == []
+          - all_hosts_ip_specific.rule_set_state[item]['CIMHttpServer']['allowed_hosts']['desired_allowed_networks'] == ["192.168.200.0/24"]
+      with_items:
+        - '{{ esxi1 }}'
+        - '{{ esxi2 }}'
+
+    - name: Configure the NFC firewall rule to only allow traffic from one IP on one ESXi host
+      community.vmware.vmware_host_firewall_manager:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        esxi_hostname: "{{ esxi1 }}"
+        rules:
+          - name: NFC
+            enabled: true
+            allowed_hosts:
+              all_ip: false
+              ip_address:
+                - "192.168.100.11"
+      register: single_host_ip_specific
+
+    - set_fact:
+        nfc_state: "{{ single_host_ip_specific.rule_set_state[esxi1]['NFC'] }}"
+
+    - debug: var=single_host_ip_specific
+
+    - debug: var=nfc_state
+
+    - name: ensure NFC is configured on that host
+      assert:
+        that:
+          - nfc_state.current_state == true
+          - nfc_state.desired_state == true
+          - nfc_state.previous_state == true
+          - nfc_state.allowed_hosts.current_allowed_all == False
+          - nfc_state.allowed_hosts.previous_allowed_all == true
+          - nfc_state.allowed_hosts.desired_allowed_all == False
+          - nfc_state.allowed_hosts.current_allowed_ip == ["192.168.100.11"]
+          - nfc_state.allowed_hosts.previous_allowed_all == true
+          - nfc_state.allowed_hosts.desired_allowed_ip == ["192.168.100.11"]
+          - nfc_state.allowed_hosts.current_allowed_networks == []
+          - nfc_state.allowed_hosts.previous_allowed_networks == []
+          - nfc_state.allowed_hosts.desired_allowed_networks == []
+
+    - name: Ensure we can still pass the allowed_hosts configuration through a list for compat
+      community.vmware.vmware_host_firewall_manager:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        validate_certs: false
+        esxi_hostname: "{{ esxi1 }}"
+        rules:
+          - name: NFC
+            enabled: true
+            allowed_hosts:
+            all_ip: false
             ip_address:
               - "1.2.3.4"
-  register: using_list
+      register: using_list
 
-- debug: var=using_list
+    - debug: var=using_list
 
-- set_fact:
-    nfc_state: "{{ using_list.rule_set_state[esxi1]['NFC'] }}"
+    - set_fact:
+        nfc_state: "{{ using_list.rule_set_state[esxi1]['NFC'] }}"
 
-- name: ensure the correct host is set
-  assert:
-    that:
-      - nfc_state.allowed_hosts.current_allowed_ip == ["1.2.3.4"]
+    - name: ensure the correct host is set
+      assert:
+        that:
+          - nfc_state.allowed_hosts.current_allowed_ip == ["1.2.3.4"]
 
-- name: Clean up the firewall rules
-  community.vmware.vmware_host_firewall_manager:
-    cluster_name: '{{ ccr1 }}'
-    rules:
-        - name: vvold
-          enabled: false
-        - name: CIMHttpServer
-          enabled: true
-          allowed_hosts:
-            all_ip: true
-        - name: NFC
-          enabled: true
-          allowed_hosts:
-            all_ip: true
-  ignore_errors: true
+  always:
+    - name: Clean up the firewall rules
+      community.vmware.vmware_host_firewall_manager:
+        cluster_name: '{{ ccr1 }}'
+        rules:
+            - name: vvold
+              enabled: false
+            - name: CIMHttpServer
+              enabled: true
+              allowed_hosts:
+                all_ip: true
+            - name: NFC
+              enabled: true
+              allowed_hosts:
+                all_ip: true
+      ignore_errors: true

--- a/tests/integration/targets/vmware_host_firewall_manager/tasks/main.yml
+++ b/tests/integration/targets/vmware_host_firewall_manager/tasks/main.yml
@@ -7,7 +7,7 @@
     setup_attach_host: true
 
 - name: Enable vvold rule set on all hosts of {{ ccr1 }}
-  vmware_host_firewall_manager:
+  community.vmware.vmware_host_firewall_manager:
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
@@ -37,7 +37,7 @@
     - '{{ esxi2 }}'
 
 - name: Disable vvold for {{ host1 }}
-  vmware_host_firewall_manager:
+  community.vmware.vmware_host_firewall_manager:
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
@@ -64,7 +64,7 @@
     - '{{ esxi1 }}'
 
 - name: Enable vvold rule set on all hosts of {{ ccr1 }} in check mode
-  vmware_host_firewall_manager:
+  community.vmware.vmware_host_firewall_manager:
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
@@ -92,7 +92,7 @@
         - all_hosts_result_check_mode.rule_set_state[esxi2]['vvold']['desired_state'] == true
 
 - name: Disable vvold for {{ host1 }} in check mode
-  vmware_host_firewall_manager:
+  community.vmware.vmware_host_firewall_manager:
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
@@ -120,7 +120,7 @@
     - '{{ esxi1 }}'
 
 - name: Configure CIMHttpServer rule set on all hosts of {{ ccr1 }}
-  vmware_host_firewall_manager:
+  community.vmware.vmware_host_firewall_manager:
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
@@ -166,7 +166,7 @@
     - '{{ esxi2 }}'
 
 - name: Configure the NFC firewall rule to only allow traffic from one IP on one ESXi host
-  vmware_host_firewall_manager:
+  community.vmware.vmware_host_firewall_manager:
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
@@ -201,7 +201,7 @@
       - nfc_state.allowed_hosts.desired_allowed_networks == []
 
 - name: Ensure we can still pass the allowed_hosts configuration through a list for compat
-  vmware_host_firewall_manager:
+  community.vmware.vmware_host_firewall_manager:
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
@@ -223,7 +223,7 @@
     that:
       - nfc_state.allowed_hosts.current_allowed_ip == ["1.2.3.4"]
 - name: Clean up the firewall rules
-  vmware_host_firewall_manager:
+  community.vmware.vmware_host_firewall_manager:
     cluster_name: '{{ ccr1 }}'
     rules:
         - name: vvold

--- a/tests/integration/targets/vmware_host_firewall_manager/tasks/main.yml
+++ b/tests/integration/targets/vmware_host_firewall_manager/tasks/main.yml
@@ -96,7 +96,7 @@
       assert:
         that:
           - all_hosts_result_check_mode.rule_set_state[esxi1]['vvold']['current_state'] == true
-            - all_hosts_result_check_mode.rule_set_state[esxi2]['vvold']['current_state'] == true
+          - all_hosts_result_check_mode.rule_set_state[esxi2]['vvold']['current_state'] == true
           - all_hosts_result_check_mode.rule_set_state[esxi2]['vvold']['desired_state'] == true
 
     - name: Disable vvold for {{ host1 }} in check mode
@@ -227,9 +227,9 @@
           - name: NFC
             enabled: true
             allowed_hosts:
-            all_ip: false
-            ip_address:
-              - "1.2.3.4"
+              all_ip: false
+              ip_address:
+                - "1.2.3.4"
       register: using_list
 
     - debug: var=using_list


### PR DESCRIPTION
##### SUMMARY
Fixes #1197

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_host_firewall_manager

##### ADDITIONAL INFORMATION
https://github.com/ansible-collections/community.vmware/blob/ce764aaa1317960deeca086517e5f9d7e62f9cdd/plugins/modules/vmware_host_firewall_manager.py#L387-L395

and

https://github.com/ansible-collections/community.vmware/blob/ce764aaa1317960deeca086517e5f9d7e62f9cdd/plugins/modules/vmware_host_firewall_manager.py#L398-L406