### PR TITLE
vmware_guest_disk: Add iolimit modifications on an existing disk with…

### DIFF
--- a/changelogs/fragments/1466-vmware_guest_disk-change_iolimit_without_size.yml
+++ b/changelogs/fragments/1466-vmware_guest_disk-change_iolimit_without_size.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_guest_disk - Adding `iolimit` modifications of an existing disk without changing size (https://github.com/ansible-collections/community.vmware/pull/1466).

--- a/plugins/modules/vmware_guest_disk.py
+++ b/plugins/modules/vmware_guest_disk.py
@@ -720,10 +720,10 @@ class PyVmomiHelper(PyVmomi):
                                         disk_change = True
                                         disk_change_list.append(disk_change)
                                     if 'shares' in disk['iolimit']:
-                                        if (disk['iolimit']['shares']['level'] != 'custom' and \
-                                            sharesval.get(disk['iolimit']['shares']['level'], 0) != disk_spec.device.storageIOAllocation.shares.shares) or \
-                                            (disk['iolimit']['shares']['level'] == 'custom' and \
-                                                disk['iolimit']['shares']['level_value'] != disk_spec.device.storageIOAllocation.shares.shares):
+                                        if (disk['iolimit']['shares']['level'] != 'custom' and
+                                            and sharesval.get(disk['iolimit']['shares']['level'], 0) != disk_spec.device.storageIOAllocation.shares.shares) or \
+                                            (disk['iolimit']['shares']['level'] == 'custom'
+                                             and disk['iolimit']['shares']['level_value'] != disk_spec.device.storageIOAllocation.shares.shares):
                                             # set the operation to edit so that it knows to keep other settings
                                             disk_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.edit
                                             disk_spec.device.storageIOAllocation.shares = vim.SharesInfo()

--- a/plugins/modules/vmware_guest_disk.py
+++ b/plugins/modules/vmware_guest_disk.py
@@ -657,7 +657,7 @@ class PyVmomiHelper(PyVmomi):
         results = dict(changed=False, disk_data=None, disk_changes=dict())
         new_added_disk_ctl = list()
 
-        sharesval = {'low':500,'normal':1000,'high':2000}
+        sharesval = {'low': 500, 'normal': 1000, 'high': 2000}
 
         # Deal with controller
         for disk in disk_data:
@@ -720,10 +720,10 @@ class PyVmomiHelper(PyVmomi):
                                         disk_change = True
                                         disk_change_list.append(disk_change)
                                     if 'shares' in disk['iolimit']:
-                                        if (disk['iolimit']['shares']['level'] != 'custom' and \
-                                            sharesval.get(disk['iolimit']['shares']['level'],0) != disk_spec.device.storageIOAllocation.shares.shares) or \
-                                            (disk['iolimit']['shares']['level'] == 'custom' and \
-                                            disk['iolimit']['shares']['level_value'] != disk_spec.device.storageIOAllocation.shares.shares):
+                                        if (disk['iolimit']['shares']['level'] != 'custom' and
+                                            sharesval.get(disk['iolimit']['shares']['level'], 0) != disk_spec.device.storageIOAllocation.shares.shares) or \
+                                            (disk['iolimit']['shares']['level'] == 'custom' and
+                                                disk['iolimit']['shares']['level_value'] != disk_spec.device.storageIOAllocation.shares.shares):
                                             # set the operation to edit so that it knows to keep other settings
                                             disk_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.edit
                                             disk_spec.device.storageIOAllocation.shares = vim.SharesInfo()

--- a/plugins/modules/vmware_guest_disk.py
+++ b/plugins/modules/vmware_guest_disk.py
@@ -720,7 +720,7 @@ class PyVmomiHelper(PyVmomi):
                                         disk_change = True
                                         disk_change_list.append(disk_change)
                                     if 'shares' in disk['iolimit']:
-                                        if (disk['iolimit']['shares']['level'] != 'custom' and
+                                        if (disk['iolimit']['shares']['level'] != 'custom'
                                             and sharesval.get(disk['iolimit']['shares']['level'], 0) != disk_spec.device.storageIOAllocation.shares.shares) or \
                                             (disk['iolimit']['shares']['level'] == 'custom'
                                              and disk['iolimit']['shares']['level_value'] != disk_spec.device.storageIOAllocation.shares.shares):

--- a/plugins/modules/vmware_guest_disk.py
+++ b/plugins/modules/vmware_guest_disk.py
@@ -720,9 +720,9 @@ class PyVmomiHelper(PyVmomi):
                                         disk_change = True
                                         disk_change_list.append(disk_change)
                                     if 'shares' in disk['iolimit']:
-                                        if (disk['iolimit']['shares']['level'] != 'custom' and
+                                        if (disk['iolimit']['shares']['level'] != 'custom' and \
                                             sharesval.get(disk['iolimit']['shares']['level'], 0) != disk_spec.device.storageIOAllocation.shares.shares) or \
-                                            (disk['iolimit']['shares']['level'] == 'custom' and
+                                            (disk['iolimit']['shares']['level'] == 'custom' and \
                                                 disk['iolimit']['shares']['level_value'] != disk_spec.device.storageIOAllocation.shares.shares):
                                             # set the operation to edit so that it knows to keep other settings
                                             disk_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.edit


### PR DESCRIPTION
##### SUMMARY
This commit add iolimit modifications on an existing disk without changing size.

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
plugin community.vmware.vmware_guest_disk

##### ADDITIONAL INFORMATION
As of today, one can't change an existing disk iops limit and/or shares level without also changing the disk size.
Idempotency is only done on disk size, so task will "ok" whatever iolimit is set to.
This commit fix that

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
- name: Gather disk info from virtual machine using name
  community.vmware.vmware_guest_disk_info:
    datacenter: "{{ vmware_datacenter }}"
    hostname: "{{ vmware_vcenter }}"
    username: "{{ vmware_username }}"
    password: "{{ vmware_password }}"
    name: "{{ inventory_hostname }}"
  delegate_to: localhost
  register: disk_info

- name: Apply iops
  community.vmware.vmware_guest_disk:
    datacenter: "{{ vmware_datacenter }}"
    hostname: "{{ vmware_vcenter }}"
    username: "{{ vmware_username }}"
    password: "{{ vmware_password }}"
    name: "{{ inventory_hostname }}"
    disk:
      - filename: '{{ disk_info.guest_disk_info["0"].backing_filename }}'
        size_gb: "{{ vm_disk_size }}"
        type: "{{ vm_disk_type }}"
        datastore: "{{ vm_datastore }}"
        disk_mode: '{{ disk_info.guest_disk_info["0"].backing_diskmode }}'
        scsi_controller: '{{ disk_info.guest_disk_info["0"].controller_bus_number }}'
        unit_number: '{{ disk_info.guest_disk_info["0"].unit_number }}'
        iolimit:
          limit: "{{ vm_disk_iops }}"
          shares:
            level: normal
```
