### PR TITLE
Remove version_added: 1.x part 1

### DIFF
--- a/plugins/modules/vcenter_domain_user_group_info.py
+++ b/plugins/modules/vcenter_domain_user_group_info.py
@@ -50,7 +50,6 @@ options:
       - If I(find_groups) is C(True), domain groups will be included in the result.
     type: bool
     default: True
-version_added: '1.6.0'
 extends_documentation_fragment:
   - community.vmware.vmware.documentation
 '''

--- a/plugins/modules/vmware_cluster_ha.py
+++ b/plugins/modules/vmware_cluster_ha.py
@@ -176,7 +176,6 @@ options:
       type: str
       default: 'warning'
       choices: [ 'disabled', 'warning', 'restartConservative', 'restartAggressive' ]
-      version_added: '1.4.0'
     apd_delay:
       description:
       - The response recovery delay time in sec for storage failures categorized as All Paths Down (APD).
@@ -198,7 +197,6 @@ options:
       type: str
       default: 'warning'
       choices: [ 'disabled', 'warning', 'restartAggressive' ]
-      version_added: '1.4.0'
 extends_documentation_fragment:
 - community.vmware.vmware.documentation
 

--- a/plugins/modules/vmware_content_deploy_ovf_template.py
+++ b/plugins/modules/vmware_content_deploy_ovf_template.py
@@ -28,7 +28,6 @@ options:
       required: False
       default: 'normal'
       choices: [ 'debug', 'info', 'normal' ]
-      version_added: '1.12.0'
     template:
       description:
       - The name of OVF template from which VM to be deployed.
@@ -41,7 +40,6 @@ options:
       type: str
       required: False
       aliases: ['content_library', 'content_library_src']
-      version_added: '1.5.0'
     name:
       description:
       - The name of the VM to be deployed.
@@ -64,7 +62,6 @@ options:
       - If datastore is not specified, the recommended datastore from this cluster will be used.
       type: str
       required: False
-      version_added: '1.9.0'
     folder:
       description:
       - Name of the folder in datacenter in which to place deployed VM.

--- a/plugins/modules/vmware_content_deploy_template.py
+++ b/plugins/modules/vmware_content_deploy_template.py
@@ -32,7 +32,6 @@ options:
       required: False
       default: 'normal'
       choices: [ 'debug', 'info', 'normal' ]
-      version_added: '1.9.0'
     template:
       description:
       - The name of template from which VM to be deployed.
@@ -70,7 +69,6 @@ options:
        - Required if I(datastore) is not provided.
        type: str
        required: False
-       version_added: '1.7.0'
     folder:
       description:
       - Name of the folder in datacenter in which to place deployed VM.

--- a/plugins/modules/vmware_content_library_manager.py
+++ b/plugins/modules/vmware_content_library_manager.py
@@ -62,7 +62,6 @@ options:
       - This parameter is ignored, when I(state) is set to C(absent).
       type: str
       required: False
-      version_added: '1.7.0'
     ssl_thumbprint:
       description:
       - The SHA1 SSL thumbprint of the subscribed content library to subscribe to.
@@ -72,7 +71,6 @@ options:
         C(echo | openssl s_client -connect test-library.com:443 |& openssl x509 -fingerprint -noout)'
       type: str
       required: False
-      version_added: '1.7.0'
     update_on_demand:
       description:
       - Whether to download all content on demand.
@@ -82,7 +80,6 @@ options:
       - This parameter is ignored, when I(state) is set to C(absent).
       type: bool
       default: False
-      version_added: '1.7.0'
     state:
       description:
       - The state of content library.

--- a/plugins/modules/vmware_datastore_info.py
+++ b/plugins/modules/vmware_datastore_info.py
@@ -68,7 +68,6 @@ options:
      - Tags related to Datastore are shown if set to C(True).
      default: false
      type: bool
-     version_added: '1.16.0'
    properties:
      description:
      - Specify the properties to retrieve.

--- a/plugins/modules/vmware_deploy_ovf.py
+++ b/plugins/modules/vmware_deploy_ovf.py
@@ -40,7 +40,6 @@ options:
         - This is a required parameter, if C(cluster) is not set and C(hostname) is set to the vCenter server.
         - C(esxi_hostname) and C(cluster) are mutually exclusive parameters.
         - This parameter is case sensitive.
-        version_added: '1.9.0'
         type: str
     datastore:
         default: datastore1

--- a/plugins/modules/vmware_drs_group_manager.py
+++ b/plugins/modules/vmware_drs_group_manager.py
@@ -62,7 +62,6 @@ options:
       - If set to C(present), VMs/hosts will be added to the given DRS group.
       - If set to C(absent), VMs/hosts will be removed from the given DRS group.
     type: str
-version_added: '1.7.0'
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/vmware_dvs_host.py
+++ b/plugins/modules/vmware_dvs_host.py
@@ -40,7 +40,6 @@ options:
         type: list
         elements: str
     lag_uplinks:
-        version_added: '1.12.0'
         required: False
         type: list
         elements: dict

--- a/plugins/modules/vmware_dvs_portgroup.py
+++ b/plugins/modules/vmware_dvs_portgroup.py
@@ -51,7 +51,6 @@ options:
         choices:
             - 'static'
             - 'ephemeral'
-        version_added: '1.10.0'
     port_allocation:
         description:
             - Elastic port groups automatically increase or decrease the number of ports as needed.
@@ -62,7 +61,6 @@ options:
         choices:
             - 'elastic'
             - 'fixed'
-        version_added: '1.10.0'
     state:
         description:
             - Determines if the portgroup should be present or not.
@@ -109,7 +107,6 @@ options:
                     - 'allow'
                     - 'drop'
         type: dict
-        version_added: '1.10.0'
     network_policy:
         description:
             - Dictionary which configures the different security values for portgroup.
@@ -168,13 +165,11 @@ options:
                 - List of active uplinks used for load balancing.
                 type: list
                 elements: str
-                version_added: '1.10.0'
             standby_uplinks:
                 description:
                 - List of standby uplinks used for failover.
                 type: list
                 elements: str
-                version_added: '1.10.0'
         default: {
             'notify_switches': True,
             'load_balance_policy': 'loadbalance_srcid',

--- a/plugins/modules/vmware_dvs_portgroup_info.py
+++ b/plugins/modules/vmware_dvs_portgroup_info.py
@@ -34,7 +34,6 @@ options:
     - Show or hide MAC learning information of the DVS portgroup.
     type: bool
     default: True
-    version_added: '1.10.0'
   show_network_policy:
     description:
     - Show or hide network policies of DVS portgroup.
@@ -55,7 +54,6 @@ options:
     - Show or hide uplinks of DVS portgroup.
     type: bool
     default: True
-    version_added: '1.10.0'
   show_vlan_info:
     description:
     - Show or hide vlan information of the DVS portgroup.

--- a/plugins/modules/vmware_dvswitch.py
+++ b/plugins/modules/vmware_dvswitch.py
@@ -142,7 +142,6 @@ options:
             teaming_failover_interval: 0,
         }
     network_policy:
-        version_added: '1.11.0'
         description:
             - Dictionary which configures the different default security values for portgroups.
             - If set, these options are inherited by the portgroups of the DVS.

--- a/plugins/modules/vmware_first_class_disk.py
+++ b/plugins/modules/vmware_first_class_disk.py
@@ -13,7 +13,6 @@ DOCUMENTATION = r'''
 ---
 module: vmware_first_class_disk
 short_description: Manage VMware vSphere First Class Disks
-version_added: '1.7.0'
 description:
     - This module can be used to manage (create, delete, resize) VMware vSphere First Class Disks.
 author:

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -157,7 +157,6 @@ options:
         secure_boot:
             type: bool
             description: Whether to enable or disable (U)EFI secure boot.
-            version_added: '1.11.0'
         memory_reservation_lock:
             type: bool
             description:
@@ -211,7 +210,6 @@ options:
         iommu:
             type: bool
             description: Flag to specify if I/O MMU is enabled for this virtual machine.
-            version_added: '1.11.0'
   guest_id:
     type: str
     description:
@@ -320,7 +318,6 @@ options:
     - Make sure that the host or the cluster on which the virtual machine resides has available PMem resources.
     - To add or remove virtual NVDIMM device to the existing virtual machine, it must be in power off state.
     type: dict
-    version_added: '1.13.0'
     suboptions:
         state:
              type: str
@@ -475,7 +472,6 @@ options:
     - Incorrect key and values will be ignored.
     elements: dict
     type: list
-    version_added: '1.8.0'
   annotation:
     description:
     - A note or annotation to include in the virtual machine.
@@ -572,7 +568,6 @@ options:
             type: bool
             description:
             - Indicates whether the NIC is currently connected.
-            version_added: '1.5.0'
         start_connected:
             type: bool
             description:

--- a/plugins/modules/vmware_guest_controller.py
+++ b/plugins/modules/vmware_guest_controller.py
@@ -112,7 +112,6 @@ options:
          type: str
          choices: ['noSharing', 'physicalSharing', 'virtualSharing' ]
          default: 'noSharing'
-         version_added: 1.11.0
      type: list
      elements: dict
    gather_disk_controller_facts:

--- a/plugins/modules/vmware_guest_cross_vc_clone.py
+++ b/plugins/modules/vmware_guest_cross_vc_clone.py
@@ -100,7 +100,6 @@ options:
       - Specifies whether or not the new virtual machine should be marked as a template.
     type: bool
     default: False
-    version_added: 1.16.0
   state:
     description:
       - The state of Virtual Machine deployed.

--- a/plugins/modules/vmware_guest_disk.py
+++ b/plugins/modules/vmware_guest_disk.py
@@ -116,7 +116,6 @@ options:
            - The secondary machine holding the RDM uses C(True).
          type: bool
          default: False
-         version_added: '1.17.0'
        compatibility_mode:
          description: Compatibility mode for raw devices. Required when disk type C(type) is set to C(rdm).
          type: str
@@ -151,7 +150,6 @@ options:
          type: str
          choices: ['noSharing', 'physicalSharing', 'virtualSharing']
          default: 'noSharing'
-         version_added: '1.17.0'
        unit_number:
          description:
            - Disk Unit Number.

--- a/plugins/modules/vmware_guest_info.py
+++ b/plugins/modules/vmware_guest_info.py
@@ -82,7 +82,6 @@ options:
      - This parameter is added to maintain backward compatability.
      default: false
      type: bool
-     version_added: '1.4.0'
    schema:
      description:
      - Specify the output schema desired.

--- a/plugins/modules/vmware_guest_instant_clone.py
+++ b/plugins/modules/vmware_guest_instant_clone.py
@@ -130,7 +130,6 @@ options:
         description:
           - domain is used to set A fully qualified domain name (FQDN) or complete domain name for Instant Cloned Guest operating System.
         type: str
-    version_added: '1.11.0'
     type: list
     elements: dict
   wait_vm_tools:
@@ -138,17 +137,14 @@ options:
       - Whether waiting until vm tools start after rebooting an instant clone vm.
     type: bool
     default: True
-    version_added: '1.12.0'
   wait_vm_tools_timeout:
     description:
       - Define a timeout (in seconds) for I(the wait_vm_tools) parameter.
     type: int
     default: 300
-    version_added: '1.12.0'
 extends_documentation_fragment:
 - community.vmware.vmware.documentation
 
-version_added: '1.9.0'
 author:
 - Anant Chopra (@Anant99-sys)
 

--- a/plugins/modules/vmware_guest_network.py
+++ b/plugins/modules/vmware_guest_network.py
@@ -15,7 +15,6 @@ module: vmware_guest_network
 short_description: Manage network adapters of specified virtual machine in given vCenter infrastructure
 description:
   - This module is used to add, reconfigure, remove network adapter of given virtual machine.
-version_added: '1.0.0'
 author:
   - Diane Wang (@Tomorrow9) <dianew@vmware.com>
 notes:

--- a/plugins/modules/vmware_guest_powerstate.py
+++ b/plugins/modules/vmware_guest_powerstate.py
@@ -24,7 +24,6 @@ options:
       - This parameter is case sensitive.
     default: ha-datacenter
     type: str
-    version_added: '1.13.0'
   state:
     description:
     - Set the state of the virtual machine.
@@ -127,7 +126,6 @@ options:
         required: True
     type: list
     elements: dict
-    version_added: '1.11.0'
 extends_documentation_fragment:
 - community.vmware.vmware.documentation
 """

--- a/plugins/modules/vmware_guest_sendkey.py
+++ b/plugins/modules/vmware_guest_sendkey.py
@@ -88,7 +88,6 @@ options:
        delay between keys and/or strings.
      type: int
      default: 0
-     version_added: '1.4.0'
 extends_documentation_fragment:
 - community.vmware.vmware.documentation
 


### PR DESCRIPTION
##### SUMMARY
Now that version 1 is nearly EOL, I don't think that it's important if something has been added in 1.2, 1.4, 1.7 or wherever.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
vmware_guest_storage_policy
vmware_guest_tools_wait
vmware_guest_tpm
vmware_host_custom_attributes
vmware_host_datastore
vmware_host_iscsi
vmware_host_passthrough
vmware_host_scanhba
vmware_host_snmp
vmware_host_sriov
vmware_host_tcpip_stacks
vmware_object_custom_attributes_info
vmware_object_role_permission_info
vmware_recommended_datastore
vmware_resource_pool
vmware_tag_manager
vmware_vcenter_settings
vmware_vc_infraprofile_info
vmware_vm_config_option
vmware_vmotion
vmware_vm_storage_policy
vmware_vsan_health_info

##### ADDITIONAL INFORMATION
