### PR TITLE
Remove version_added: 1.x part 2

### DIFF
--- a/plugins/modules/vmware_cluster_info.py
+++ b/plugins/modules/vmware_cluster_info.py
@@ -47,7 +47,6 @@ options:
      choices: ['summary', 'vsphere']
      default: 'summary'
      type: str
-     version_added: "1.0.0"
    properties:
      description:
        - Specify the properties to retrieve.
@@ -60,7 +59,6 @@ options:
        - Only valid when C(schema) is C(vsphere).
      type: list
      elements: str
-     version_added: "1.0.0"
 extends_documentation_fragment:
 - community.vmware.vmware.documentation
 

--- a/plugins/modules/vmware_cluster_vsan.py
+++ b/plugins/modules/vmware_cluster_vsan.py
@@ -47,7 +47,6 @@ options:
       type: bool
       default: false
     advanced_options:
-      version_added: "1.1.0"
       description:
       - Advanced VSAN Options.
       suboptions:

--- a/plugins/modules/vmware_guest_storage_policy.py
+++ b/plugins/modules/vmware_guest_storage_policy.py
@@ -28,7 +28,6 @@ module: vmware_guest_storage_policy
 short_description: Set VM Home and disk(s) storage policy profiles.
 description:
     - This module can be used to enforce storage policy profiles per disk and/or VM Home on a virtual machine.
-version_added: 1.9.0
 author:
     - Tyler Gates (@tgates81)
 options:

--- a/plugins/modules/vmware_guest_tools_wait.py
+++ b/plugins/modules/vmware_guest_tools_wait.py
@@ -70,7 +70,6 @@ options:
      - Name of the datacenter.
      - The datacenter to search for a virtual machine.
      type: str
-     version_added: '1.15.0'
 extends_documentation_fragment:
 - community.vmware.vmware.documentation
 

--- a/plugins/modules/vmware_guest_tpm.py
+++ b/plugins/modules/vmware_guest_tpm.py
@@ -19,7 +19,6 @@ description: >
    running in your environment must be ESXi 6.7 or later (Windows guest OS), or 7.0 Update 2 (Linux guest OS).
 author:
 - Diane Wang (@Tomorrow9) <dianew@vmware.com>
-version_added: '1.16.0'
 options:
   name:
     description:

--- a/plugins/modules/vmware_host_custom_attributes.py
+++ b/plugins/modules/vmware_host_custom_attributes.py
@@ -16,7 +16,6 @@ description:
     - This module can be used to add, remove and update custom attributes for the given ESXi host.
 author:
     - Hunter Christain (@exp-hc)
-version_added: '1.11.0'
 options:
    esxi_hostname:
      description:

--- a/plugins/modules/vmware_host_datastore.py
+++ b/plugins/modules/vmware_host_datastore.py
@@ -74,7 +74,6 @@ options:
     - A use case example in I(auto_expand), it can be used to expand a datastore capacity after increasing LUN volume.
     type: bool
     default: True
-    version_added: '1.13.0'
   state:
     description:
     - "present: Mount datastore on host if datastore is absent else do nothing."

--- a/plugins/modules/vmware_host_iscsi.py
+++ b/plugins/modules/vmware_host_iscsi.py
@@ -32,7 +32,6 @@ options:
         - The name for the iSCSI HBA adapter.
         - This is iSCSI qualified name.
         type: str
-        version_added: '1.7.0'
         aliases:
         - initiator_iqn
       alias:

--- a/plugins/modules/vmware_host_passthrough.py
+++ b/plugins/modules/vmware_host_passthrough.py
@@ -18,7 +18,6 @@ description:
   - This module can be managed PCI device passthrough settings on host.
 notes:
   - Supports C(check_mode).
-version_added: '1.11.0'
 options:
   cluster:
     description:

--- a/plugins/modules/vmware_host_scanhba.py
+++ b/plugins/modules/vmware_host_scanhba.py
@@ -39,7 +39,6 @@ options:
     required: false
     default: true
     type: bool
-    version_added: '1.17.0'
   refresh_storage:
     description:
     - Refresh the storage system in vCenter/ESXi Web Client for each host found
@@ -52,7 +51,6 @@ options:
     required: false
     default: false
     type: bool
-    version_added: '1.17.0'
 extends_documentation_fragment:
 - community.vmware.vmware.documentation
 

--- a/plugins/modules/vmware_host_snmp.py
+++ b/plugins/modules/vmware_host_snmp.py
@@ -73,12 +73,10 @@ options:
     description:
         - System contact who manages the system.
     type: str
-    version_added: '1.17.0'
   sys_location:
     description:
         - System location.
     type: str
-    version_added: '1.17.0'
 extends_documentation_fragment:
 - community.vmware.vmware.documentation
 

--- a/plugins/modules/vmware_host_sriov.py
+++ b/plugins/modules/vmware_host_sriov.py
@@ -18,7 +18,6 @@ description:
 - This module can be used to configure, enable or disable SR-IOV functions on ESXi host.
 - Module does not reboot the host after changes, but puts it in output "rebootRequired" state.
 - User can specify an ESXi hostname or Cluster name. In case of cluster name, all ESXi hosts are updated.
-version_added: '1.0.0'
 author:
 - Viktor Tsymbalyuk (@victron)
 options:

--- a/plugins/modules/vmware_host_tcpip_stacks.py
+++ b/plugins/modules/vmware_host_tcpip_stacks.py
@@ -16,7 +16,6 @@ author:
   - sky-joker (@sky-joker)
 description:
   - This module can be used to modify the TCP/IP stacks configuration.
-version_added: '1.10.0'
 options:
   esxi_hostname:
     description:
@@ -59,7 +58,6 @@ options:
         description:
           - The ipv6 gateway address.
         type: str
-        version_added: '1.11.0'
       congestion_algorithm:
         description:
           - The TCP congest control algorithm.
@@ -86,7 +84,6 @@ options:
         description:
           - The ipv6 gateway address.
         type: str
-        version_added: '1.11.0'
       congestion_algorithm:
         description:
           - The TCP congest control algorithm.
@@ -113,7 +110,6 @@ options:
         description:
           - The ipv6 gateway address.
         type: str
-        version_added: '1.11.0'
       congestion_algorithm:
         description:
           - The TCP congest control algorithm.
@@ -140,7 +136,6 @@ options:
         description:
           - The ipv6 gateway address.
         type: str
-        version_added: '1.11.0'
       congestion_algorithm:
         description:
           - The TCP congest control algorithm.

--- a/plugins/modules/vmware_object_custom_attributes_info.py
+++ b/plugins/modules/vmware_object_custom_attributes_info.py
@@ -18,7 +18,6 @@ description:
   - This module can be gathered custom attributes of an object.
 notes:
   - Supports C(check_mode).
-version_added: '1.11.0'
 options:
   object_type:
     description:

--- a/plugins/modules/vmware_object_role_permission_info.py
+++ b/plugins/modules/vmware_object_role_permission_info.py
@@ -30,7 +30,6 @@ options:
     - If provided, actual permissions on the specified object are returned for the principal, instead of roles.
     type: str
     required: False
-    version_added: '1.12.0'
   object_name:
     description:
     - The object name to assigned permission.
@@ -53,7 +52,6 @@ options:
     type: 'str'
 extends_documentation_fragment:
 - community.vmware.vmware.documentation
-version_added: "1.11.0"
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/vmware_recommended_datastore.py
+++ b/plugins/modules/vmware_recommended_datastore.py
@@ -35,7 +35,6 @@ options:
     required: True
 extends_documentation_fragment:
 - community.vmware.vmware.documentation
-version_added: '1.11.0'
 """
 
 

--- a/plugins/modules/vmware_resource_pool.py
+++ b/plugins/modules/vmware_resource_pool.py
@@ -36,14 +36,12 @@ options:
             - This parameter is required if C(cluster) or C(parent_resource_pool) is not specified.
             - The C(cluster), C(esxi_hostname) and C(parent_resource_pool) parameters are mutually exclusive.
         type: str
-        version_added: '1.5.0'
     parent_resource_pool:
         description:
             - Name of the parent resource pool.
             - This parameter is required if C(cluster) or C(esxi_hostname) is not specified.
             - The C(cluster), C(esxi_hostname) and C(parent_resource_pool) parameters are mutually exclusive.
         type: str
-        version_added: '1.9.0'
     resource_pool:
         description:
             - Resource pool name to manage.
@@ -81,7 +79,6 @@ options:
             - This value is only set if I(cpu_shares) is set to C(custom).
         type: int
         default: 4000
-        version_added: '1.4.0'
     mem_expandable_reservations:
         description:
             - In a resource pool with an expandable reservation, the reservation on a resource pool can grow beyond the specified value.
@@ -114,7 +111,6 @@ options:
             - This value is only set if I(mem_shares) is set to C(custom).
         type: int
         default: 163840
-        version_added: '1.4.0'
     state:
         description:
             - Add or remove the resource pool

--- a/plugins/modules/vmware_tag_manager.py
+++ b/plugins/modules/vmware_tag_manager.py
@@ -71,7 +71,6 @@ options:
       - Required if C(object_name) is not set.
       required: False
       type: str
-      version_added: '1.4.0'
 extends_documentation_fragment:
 - community.vmware.vmware_rest_client.documentation
 

--- a/plugins/modules/vmware_vc_infraprofile_info.py
+++ b/plugins/modules/vmware_vc_infraprofile_info.py
@@ -18,7 +18,6 @@ description:
 - Module to manage VMware vCenter infra profile configs.
 - vCenter infra profile Library feature is introduced in vSphere 7.0 version, so this module is not supported in the earlier versions of vSphere.
 - All variables and VMware object names are case sensitive.
-version_added: '1.0.0'
 author:
 - Naveenkumar G P (@ngp)
 requirements:

--- a/plugins/modules/vmware_vcenter_settings.py
+++ b/plugins/modules/vmware_vcenter_settings.py
@@ -227,7 +227,6 @@ options:
       - A dictionary of advanced settings.
       default: {}
       type: dict
-      version_added: '1.11.0'
 extends_documentation_fragment:
 - community.vmware.vmware.documentation
 

--- a/plugins/modules/vmware_vm_config_option.py
+++ b/plugins/modules/vmware_vm_config_option.py
@@ -20,7 +20,6 @@ description: >
    for specified guest OS ID.
 author:
 - Diane Wang (@Tomorrow9) <dianew@vmware.com>
-version_added: '1.15.0'
 notes:
 - Known issue on vSphere 7.0 (https://github.com/vmware/pyvmomi/issues/915)
 options:

--- a/plugins/modules/vmware_vm_storage_policy.py
+++ b/plugins/modules/vmware_vm_storage_policy.py
@@ -17,7 +17,6 @@ description:
 - A vSphere storage policy defines metadata that describes storage requirements
   for virtual machines and storage capabilities of storage providers.
 - Currently, only tag-based storage policy creation is supported.
-version_added: '1.0.0'
 author:
 - Dustin Scott (@scottd018)
 options:

--- a/plugins/modules/vmware_vmotion.py
+++ b/plugins/modules/vmware_vmotion.py
@@ -73,7 +73,6 @@ options:
       - Name of the destination datacenter the datastore is located on.
       - Optional, required only when datastores are shared across datacenters.
       type: str
-      version_added: '1.11.0'
     destination_resourcepool:
       description:
       - Name of the destination resource pool where the virtual machine should be running.

--- a/plugins/modules/vmware_vsan_health_info.py
+++ b/plugins/modules/vmware_vsan_health_info.py
@@ -21,7 +21,6 @@ options:
         required: false
         type: str
         aliases: [ 'datacenter_name' ]
-        version_added: '1.6.0'
     cluster_name:
         description:
             - Name of the vSAN cluster.


### PR DESCRIPTION
##### SUMMARY
Now that version 1 is nearly EOL, I don't think that it's important if something has been added in 1.2, 1.4, 1.7 or wherever.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
vmware_cluster_info
vmware_cluster_vsan
vmware_guest_storage_policy
vmware_guest_tools_wait
vmware_guest_tpm
vmware_host_custom_attributes
vmware_host_datastore
vmware_host_iscsi
vmware_host_passthrough
vmware_host_scanhba
vmware_host_snmp
vmware_host_sriov
vmware_host_tcpip_stacks
vmware_object_custom_attributes_info
vmware_object_role_permission_info
vmware_recommended_datastore
vmware_resource_pool
vmware_tag_manager
vmware_vcenter_settings
vmware_vc_infraprofile_info
vmware_vm_config_option
vmware_vmotion
vmware_vm_storage_policy
vmware_vsan_health_info

##### ADDITIONAL INFORMATION

