### PR TITLE
[WIP] securityPolicy: Deprecated as of vSphere API 6.7

### DIFF
--- a/changelogs/fragments/vmware_dvs_portgroup-securityPolicy.yml
+++ b/changelogs/fragments/vmware_dvs_portgroup-securityPolicy.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+  - vmware_dvs_portgroup - Remove support for vSphere API less than 6.7.

--- a/changelogs/fragments/vmware_dvs_portgroup_info-securityPolicy.yml
+++ b/changelogs/fragments/vmware_dvs_portgroup_info-securityPolicy.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+  - vmware_dvs_portgroup_info - Remove support for vSphere API less than 6.7.

--- a/changelogs/fragments/vmware_dvswitch-securityPolicy.yml
+++ b/changelogs/fragments/vmware_dvswitch-securityPolicy.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+  - vmware_dvswitch - Remove support for vSphere API less than 6.7.

--- a/changelogs/fragments/vmware_dvswitch_uplink_pg-securityPolicyOverrideAllowed.yml
+++ b/changelogs/fragments/vmware_dvswitch_uplink_pg-securityPolicyOverrideAllowed.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+  - vmware_dvswitch_uplink_pg - Remove support for vSphere API less than 6.7.

--- a/changelogs/fragments/vmware_vspan_session-securityPolicy.yml
+++ b/changelogs/fragments/vmware_vspan_session-securityPolicy.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+  - vmware_vspan_session - Remove support for vSphere API less than 6.7.

--- a/plugins/module_utils/vmware.py
+++ b/plugins/module_utils/vmware.py
@@ -1098,13 +1098,6 @@ def quote_obj_name(object_name=None):
     return object_name
 
 
-def dvs_supports_mac_learning(dvs):
-    """
-    Test if the switch supports MAC learning
-    """
-    return hasattr(dvs.capability.featuresSupported, 'macLearningSupported') and dvs.capability.featuresSupported.macLearningSupported
-
-
 class PyVmomi(object):
     def __init__(self, module):
         """

--- a/plugins/modules/vmware_dvs_portgroup.py
+++ b/plugins/modules/vmware_dvs_portgroup.py
@@ -520,7 +520,7 @@ class VMwareDvsPortgroup(PyVmomi):
         config.policy.livePortMovingAllowed = self.module.params['port_policy']['live_port_move']
         config.policy.networkResourcePoolOverrideAllowed = self.module.params['port_policy']['network_rp_override']
         config.policy.portConfigResetAtDisconnect = self.module.params['port_policy']['port_config_reset_at_disconnect']
-        config.policy.securityPolicyOverrideAllowed = self.module.params['port_policy']['security_override']
+        config.policy.macManagementOverrideAllowed = self.module.params['port_policy']['security_override']
         config.policy.shapingOverrideAllowed = self.module.params['port_policy']['shaping_override']
         config.policy.trafficFilterOverrideAllowed = self.module.params['port_policy']['traffic_filter_override']
         config.policy.uplinkTeamingOverrideAllowed = self.module.params['port_policy']['uplink_teaming_override']
@@ -815,7 +815,7 @@ class VMwareDvsPortgroup(PyVmomi):
                 policy.livePortMovingAllowed != self.module.params['port_policy']['live_port_move'] or \
                 policy.networkResourcePoolOverrideAllowed != self.module.params['port_policy']['network_rp_override'] or \
                 policy.portConfigResetAtDisconnect != self.module.params['port_policy']['port_config_reset_at_disconnect'] or \
-                policy.securityPolicyOverrideAllowed != self.module.params['port_policy']['security_override'] or \
+                policy.macManagementOverrideAllowed != self.module.params['port_policy']['security_override'] or \
                 policy.shapingOverrideAllowed != self.module.params['port_policy']['shaping_override'] or \
                 policy.trafficFilterOverrideAllowed != self.module.params['port_policy']['traffic_filter_override'] or \
                 policy.uplinkTeamingOverrideAllowed != self.module.params['port_policy']['uplink_teaming_override'] or \

--- a/plugins/modules/vmware_dvs_portgroup_info.py
+++ b/plugins/modules/vmware_dvs_portgroup_info.py
@@ -251,7 +251,7 @@ class DVSPortgroupInfoManager(PyVmomi):
                         live_port_move=dvs_pg.config.policy.livePortMovingAllowed,
                         network_rp_override=dvs_pg.config.policy.networkResourcePoolOverrideAllowed,
                         port_config_reset_at_disconnect=dvs_pg.config.policy.portConfigResetAtDisconnect,
-                        security_override=dvs_pg.config.policy.securityPolicyOverrideAllowed,
+                        security_override=dvs_pg.config.policy.macManagementOverrideAllowed,
                         shaping_override=dvs_pg.config.policy.shapingOverrideAllowed,
                         traffic_filter_override=dvs_pg.config.policy.trafficFilterOverrideAllowed,
                         uplink_teaming_override=dvs_pg.config.policy.uplinkTeamingOverrideAllowed,

--- a/plugins/modules/vmware_dvs_portgroup_info.py
+++ b/plugins/modules/vmware_dvs_portgroup_info.py
@@ -138,7 +138,6 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.vmware.plugins.module_utils.vmware import (
     vmware_argument_spec,
     PyVmomi,
-    dvs_supports_mac_learning,
     get_all_objs,
     find_dvs_by_name)
 from ansible.module_utils.six.moves.urllib.parse import unquote
@@ -195,7 +194,6 @@ class DVSPortgroupInfoManager(PyVmomi):
         dvs_lists = self.dvsls
         result = dict()
         for dvs in dvs_lists:
-            switch_supports_mac_learning = dvs_supports_mac_learning(dvs)
             result[dvs.name] = list()
             for dvs_pg in dvs.portgroup:
                 mac_learning = dict()
@@ -216,22 +214,14 @@ class DVSPortgroupInfoManager(PyVmomi):
                 else:
                     port_allocation = 'fixed'
 
-                # If the dvSwitch supports MAC learning, it's a version where securityPolicy is deprecated
                 if self.module.params['show_network_policy']:
-                    if switch_supports_mac_learning and dvs_pg.config.defaultPortConfig.macManagementPolicy:
-                        network_policy = dict(
-                            forged_transmits=dvs_pg.config.defaultPortConfig.macManagementPolicy.forgedTransmits,
-                            promiscuous=dvs_pg.config.defaultPortConfig.macManagementPolicy.allowPromiscuous,
-                            mac_changes=dvs_pg.config.defaultPortConfig.macManagementPolicy.macChanges
-                        )
-                    elif dvs_pg.config.defaultPortConfig.securityPolicy:
-                        network_policy = dict(
-                            forged_transmits=dvs_pg.config.defaultPortConfig.securityPolicy.forgedTransmits.value,
-                            promiscuous=dvs_pg.config.defaultPortConfig.securityPolicy.allowPromiscuous.value,
-                            mac_changes=dvs_pg.config.defaultPortConfig.securityPolicy.macChanges.value
-                        )
+                    network_policy = dict(
+                        forged_transmits=dvs_pg.config.defaultPortConfig.macManagementPolicy.forgedTransmits,
+                        promiscuous=dvs_pg.config.defaultPortConfig.macManagementPolicy.allowPromiscuous,
+                        mac_changes=dvs_pg.config.defaultPortConfig.macManagementPolicy.macChanges
+                    )
 
-                if self.module.params['show_mac_learning'] and switch_supports_mac_learning:
+                if self.module.params['show_mac_learning']:
                     macLearningPolicy = dvs_pg.config.defaultPortConfig.macManagementPolicy.macLearningPolicy
                     mac_learning = dict(
                         allow_unicast_flooding=macLearningPolicy.allowUnicastFlooding,

--- a/plugins/modules/vmware_dvswitch.py
+++ b/plugins/modules/vmware_dvswitch.py
@@ -334,7 +334,7 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 from ansible_collections.community.vmware.plugins.module_utils.vmware import (
-    PyVmomi, TaskError, dvs_supports_mac_learning, find_dvs_by_name, vmware_argument_spec, wait_for_task
+    PyVmomi, TaskError, find_dvs_by_name, vmware_argument_spec, wait_for_task
 )
 
 
@@ -522,10 +522,7 @@ class VMwareDvSwitch(PyVmomi):
                 if changed_network_policy:
                     if spec.defaultPortConfig is None:
                         spec.defaultPortConfig = vim.dvs.VmwareDistributedVirtualSwitch.VmwarePortConfigPolicy()
-                    if isinstance(result[0], vim.dvs.VmwareDistributedVirtualSwitch.MacManagementPolicy):
-                        spec.defaultPortConfig.macManagementPolicy = result[0]
-                    else:
-                        spec.defaultPortConfig.securityPolicy = result[0]
+                    spec.defaultPortConfig.macManagementPolicy = result[0]
 
             # Set NetFlow config
             if self.netFlow_collector_ip is not None:
@@ -604,42 +601,22 @@ class VMwareDvSwitch(PyVmomi):
         promiscuous_previous = forged_transmits_previous = mac_changes_previous = None
         current_config = self.dvs.config.defaultPortConfig
 
-        # If the dvSwitch supports MAC learning, it's a version where securityPolicy is deprecated
-        if dvs_supports_mac_learning(self.dvs):
-            policy = vim.dvs.VmwareDistributedVirtualSwitch.MacManagementPolicy()
+        policy = vim.dvs.VmwareDistributedVirtualSwitch.MacManagementPolicy()
 
-            if 'promiscuous' in self.network_policy and current_config.macManagementPolicy.allowPromiscuous != self.network_policy['promiscuous']:
-                changed_promiscuous = True
-                promiscuous_previous = current_config.macManagementPolicy.allowPromiscuous
-                policy.allowPromiscuous = self.network_policy['promiscuous']
+        if 'promiscuous' in self.network_policy and current_config.macManagementPolicy.allowPromiscuous != self.network_policy['promiscuous']:
+            changed_promiscuous = True
+            promiscuous_previous = current_config.macManagementPolicy.allowPromiscuous
+            policy.allowPromiscuous = self.network_policy['promiscuous']
 
-            if 'forged_transmits' in self.network_policy and current_config.macManagementPolicy.forgedTransmits != self.network_policy['forged_transmits']:
-                changed_forged_transmits = True
-                forged_transmits_previous = current_config.macManagementPolicy.forgedTransmits
-                policy.forgedTransmits = self.network_policy['forged_transmits']
+        if 'forged_transmits' in self.network_policy and current_config.macManagementPolicy.forgedTransmits != self.network_policy['forged_transmits']:
+            changed_forged_transmits = True
+            forged_transmits_previous = current_config.macManagementPolicy.forgedTransmits
+            policy.forgedTransmits = self.network_policy['forged_transmits']
 
-            if 'mac_changes' in self.network_policy and current_config.macManagementPolicy.macChanges != self.network_policy['mac_changes']:
-                changed_mac_changes = True
-                mac_changes_previous = current_config.macManagementPolicy.macChanges
-                policy.macChanges = self.network_policy['mac_changes']
-
-        else:
-            policy = vim.dvs.VmwareDistributedVirtualSwitch.SecurityPolicy()
-
-            if 'promiscuous' in self.network_policy and current_config.securityPolicy.allowPromiscuous.value != self.network_policy['promiscuous']:
-                changed_promiscuous = True
-                promiscuous_previous = current_config.securityPolicy.allowPromiscuous.value
-                policy.allowPromiscuous = vim.BoolPolicy(value=self.network_policy['promiscuous'])
-
-            if 'forged_transmits' in self.network_policy and current_config.securityPolicy.forgedTransmits.value != self.network_policy['forged_transmits']:
-                changed_forged_transmits = True
-                forged_transmits_previous = current_config.securityPolicy.forgedTransmits.value
-                policy.forgedTransmits = vim.BoolPolicy(value=self.network_policy['forged_transmits'])
-
-            if 'mac_changes' in self.network_policy and current_config.securityPolicy.macChanges.value != self.network_policy['mac_changes']:
-                changed_mac_changes = True
-                mac_changes_previous = current_config.securityPolicy.macChanges.value
-                policy.macChanges = vim.BoolPolicy(value=self.network_policy['mac_changes'])
+        if 'mac_changes' in self.network_policy and current_config.macManagementPolicy.macChanges != self.network_policy['mac_changes']:
+            changed_mac_changes = True
+            mac_changes_previous = current_config.macManagementPolicy.macChanges
+            policy.macChanges = self.network_policy['mac_changes']
 
         changed = changed_promiscuous or changed_forged_transmits or changed_mac_changes
         return (policy, changed, changed_promiscuous, promiscuous_previous, changed_forged_transmits,
@@ -905,10 +882,7 @@ class VMwareDvSwitch(PyVmomi):
                 if config_spec.defaultPortConfig is None:
                     config_spec.defaultPortConfig = vim.dvs.VmwareDistributedVirtualSwitch.VmwarePortConfigPolicy()
 
-                if isinstance(policy, vim.dvs.VmwareDistributedVirtualSwitch.MacManagementPolicy):
-                    config_spec.defaultPortConfig.macManagementPolicy = policy
-                else:
-                    config_spec.defaultPortConfig.securityPolicy = policy
+                config_spec.defaultPortConfig.macManagementPolicy = policy
 
         # Check switch version
         if self.switch_version:

--- a/plugins/modules/vmware_dvswitch_uplink_pg.py
+++ b/plugins/modules/vmware_dvswitch_uplink_pg.py
@@ -268,7 +268,7 @@ class VMwareDvSwitchUplinkPortgroup(PyVmomi):
         uplink_pg_policy_spec.shapingOverrideAllowed = False
         uplink_pg_policy_spec.livePortMovingAllowed = False
         uplink_pg_policy_spec.uplinkTeamingOverrideAllowed = False
-        uplink_pg_policy_spec.securityPolicyOverrideAllowed = False
+        uplink_pg_policy_spec.macManagementOverrideAllowed = False
         uplink_pg_policy_spec.networkResourcePoolOverrideAllowed = False
         # Check policies
         if uplink_pg_config.policy.portConfigResetAtDisconnect != self.uplink_pg_reset:

--- a/plugins/modules/vmware_vspan_session.py
+++ b/plugins/modules/vmware_vspan_session.py
@@ -354,9 +354,8 @@ class VMwareVspanSession(PyVmomi):
         """
         # Creating the new port policy
         port_spec = []
-        vim_bool = vim.BoolPolicy(value=state)
-        port_policy = vim.dvs.VmwareDistributedVirtualSwitch.SecurityPolicy(allowPromiscuous=vim_bool)
-        port_settings = vim.dvs.VmwareDistributedVirtualSwitch.VmwarePortConfigPolicy(securityPolicy=port_policy)
+        port_policy = vim.dvs.VmwareDistributedVirtualSwitch.MacManagementPolicy(allowPromiscuous=state)
+        port_settings = vim.dvs.VmwareDistributedVirtualSwitch.VmwarePortConfigPolicy(macManagementPolicy=port_policy)
         for port in ports:
             temp_port_spec = vim.dvs.DistributedVirtualPort.ConfigSpec(
                 operation="edit",
@@ -409,14 +408,14 @@ class VMwareVspanSession(PyVmomi):
             dv_ports = self.dv_switch.FetchDVPorts(vim.dvs.PortCriteria(portKey=ports))
             # If a port is promiscuous set disable it, and add it to the array to enable it after the changes are made.
             for dv_port in dv_ports:
-                if dv_port.config.setting.securityPolicy.allowPromiscuous.value:
+                if dv_port.config.setting.macManagementPolicy.allowPromiscuous:
                     self.set_port_security_promiscuous([dv_port.key], False)
                     self.modified_ports.update({dv_port.key: True})
                     promiscuous_ports.append(dv_port.key)
         if ports_of_selected_session:
             current_dv_ports = self.dv_switch.FetchDVPorts(vim.dvs.PortCriteria(portKey=ports_of_selected_session))
             for dv_port in current_dv_ports:
-                if dv_port.config.setting.securityPolicy.allowPromiscuous.value:
+                if dv_port.config.setting.macManagementPolicy.allowPromiscuous:
                     self.set_port_security_promiscuous([dv_port.key], False)
                     self.modified_ports.update({dv_port.key: True})
         # Return the promiscuous ports array, to set them back after the config is finished.
@@ -597,7 +596,7 @@ class VMwareVspanSession(PyVmomi):
         if ports:
             dv_ports = self.dv_switch.FetchDVPorts(vim.dvs.PortCriteria(portKey=ports))
         for dv_port in dv_ports:
-            if dv_port.config.setting.securityPolicy.allowPromiscuous.value:
+            if dv_port.config.setting.macManagementPolicy.allowPromiscuous:
                 self.set_port_security_promiscuous([dv_port.key], False)
                 self.modified_ports.update({dv_port.key: True})
         # Now we can create the VspanSession


### PR DESCRIPTION
##### SUMMARY
As of vSphere API 6.7, `securityPolicy` in [VMwareDVSPortSetting (vim.dvs.VmwareDistributedVirtualSwitch.VmwarePortConfigPolicy)](https://vdc-download.vmware.com/vmwb-repository/dcr-public/bf660c0a-f060-46e8-a94d-4b5e6ffc77ad/208bc706-e281-49b6-a0ce-b402ec19ef82/SDK/vsphere-ws/docs/ReferenceGuide/vim.dvs.VmwareDistributedVirtualSwitch.VmwarePortConfigPolicy.html) and `securityPolicyOverrideAllowed` in [VMwareDVSPortgroupPolicy (vim.dvs.VmwareDistributedVirtualSwitch.VMwarePortgroupPolicy)](https://vdc-download.vmware.com/vmwb-repository/dcr-public/bf660c0a-f060-46e8-a94d-4b5e6ffc77ad/208bc706-e281-49b6-a0ce-b402ec19ef82/SDK/vsphere-ws/docs/ReferenceGuide/vim.dvs.VmwareDistributedVirtualSwitch.VMwarePortgroupPolicy.html) are deprecated. Instead, `macManagementPolicy` and `macManagementOverrideAllowed` should be used.

I think we should remove compatibility with < 6.7 for the upcoming major release 3. It makes our code simpler (and, therefor, easier to maintain) and 6.7 will reach End of General Support soon, anyway.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_dvs_portgroup_info
vmware_dvs_portgroup
vmware_dvswitch

##### ADDITIONAL INFORMATION