### PR TITLE
3.0.0: Removing support for ansible-core version < 2.13.0

### DIFF
--- a/changelogs/fragments/3.0.0-required_ansible_version.yml
+++ b/changelogs/fragments/3.0.0-required_ansible_version.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+  - Removed support for ansible-core version < 2.13.0.

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,5 +1,5 @@
 ---
-requires_ansible: '>=2.12.0'
+requires_ansible: '>=2.13.0'
 
 action_groups:
   vmware:

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -1,2 +1,0 @@
-plugins/modules/vmware_deploy_ovf.py use-argspec-type-path!skip
-plugins/modules/vmware_host_acceptance.py validate-modules:parameter-state-invalid-choice


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1647

##### SUMMARY
3.0.0 won't support ansible-core < 2.13.0.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME

##### ADDITIONAL INFORMATION
