### PR TITLE
vmware_dvs_portgroup : Remove defaults and add explicit inheritance from switch defaults

### DIFF
--- a/changelogs/fragments/1483-vmware_dvs_portgroup.yml
+++ b/changelogs/fragments/1483-vmware_dvs_portgroup.yml
@@ -4,4 +4,5 @@ breaking_changes:
   - vmware_dvs_portgroup - Change the type of `net_flow` to string to allow setting it implicitly to inherited or to keep the value as-is
     (https://github.com/ansible-collections/community.vmware/pull/1483).
   - vmware_dvs_portgroup - Add a new sub-option `inherited` to the `in_traffic_shaping` parameter
+  - vmware_dvs_portgroup - Add a new sub-option `inherited` to the `out_traffic_shaping` parameter
     (https://github.com/ansible-collections/community.vmware/pull/1483).

--- a/changelogs/fragments/1483-vmware_dvs_portgroup.yml
+++ b/changelogs/fragments/1483-vmware_dvs_portgroup.yml
@@ -3,3 +3,5 @@ breaking_changes:
     (https://github.com/ansible-collections/community.vmware/pull/1483).
   - vmware_dvs_portgroup - Change the type of `net_flow` to string to allow setting it implicitly to inherited or to keep the value as-is
     (https://github.com/ansible-collections/community.vmware/pull/1483).
+  - vmware_dvs_portgroup - Add a new sub-option `inherited` to the `in_traffic_shaping` parameter
+    (https://github.com/ansible-collections/community.vmware/pull/1483).

--- a/changelogs/fragments/1483-vmware_dvs_portgroup.yml
+++ b/changelogs/fragments/1483-vmware_dvs_portgroup.yml
@@ -1,3 +1,5 @@
 breaking_changes:
   - vmware_dvs_portgroup - Remove the default for `network_policy` and add a new sub-option `inherited`
     (https://github.com/ansible-collections/community.vmware/pull/1483).
+  - vmware_dvs_portgroup - Change the type of `net_flow` to string to allow setting it implicitly to inherited or to keep the value as-is
+    (https://github.com/ansible-collections/community.vmware/pull/1483).

--- a/changelogs/fragments/1483-vmware_dvs_portgroup.yml
+++ b/changelogs/fragments/1483-vmware_dvs_portgroup.yml
@@ -4,5 +4,6 @@ breaking_changes:
   - vmware_dvs_portgroup - Change the type of `net_flow` to string to allow setting it implicitly to inherited or to keep the value as-is
     (https://github.com/ansible-collections/community.vmware/pull/1483).
   - vmware_dvs_portgroup - Add a new sub-option `inherited` to the `in_traffic_shaping` parameter
+    (https://github.com/ansible-collections/community.vmware/pull/1483).
   - vmware_dvs_portgroup - Add a new sub-option `inherited` to the `out_traffic_shaping` parameter
     (https://github.com/ansible-collections/community.vmware/pull/1483).

--- a/changelogs/fragments/1483-vmware_dvs_portgroup.yml
+++ b/changelogs/fragments/1483-vmware_dvs_portgroup.yml
@@ -1,0 +1,3 @@
+breaking_changes:
+  - vmware_dvs_portgroup - Remove the default for `network_policy` and add a new sub-option `inherited`
+    (https://github.com/ansible-collections/community.vmware/pull/1483).

--- a/plugins/modules/vmware_dvs_portgroup.py
+++ b/plugins/modules/vmware_dvs_portgroup.py
@@ -395,6 +395,7 @@ EXAMPLES = r'''
     port_binding: static
     state: present
     network_policy:
+      inherited: false
       promiscuous: true
       forged_transmits: true
       mac_changes: true

--- a/plugins/modules/vmware_dvs_portgroup.py
+++ b/plugins/modules/vmware_dvs_portgroup.py
@@ -904,7 +904,7 @@ def main():
                     burst_size=dict(type='int'),
                 ),
                 required_if=[
-                    ('inherited', False, ('average_bandwidth', 'peak_bandwith', 'burst_size'))
+                    ('inherited', False, ('average_bandwidth', 'peak_bandwidth', 'burst_size'))
                 ],
             ),
             out_traffic_shaping=dict(

--- a/tests/integration/targets/vmware_dvs_portgroup/tasks/main.yml
+++ b/tests/integration/targets/vmware_dvs_portgroup/tasks/main.yml
@@ -8,7 +8,7 @@
     setup_dvswitch: true
 
 - name: create basic portgroup
-  vmware_dvs_portgroup:
+  community.vmware.vmware_dvs_portgroup:
     validate_certs: false
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
@@ -30,7 +30,7 @@
         - dvs_pg_result_0001.changed
 
 - name: enable MAC learning
-  vmware_dvs_portgroup:
+  community.vmware.vmware_dvs_portgroup:
     validate_certs: false
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
@@ -54,7 +54,7 @@
         - enable_mac_learning_result.changed
 
 - name: enable MAC learning again (idempotency)
-  vmware_dvs_portgroup:
+  community.vmware.vmware_dvs_portgroup:
     validate_certs: false
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
@@ -78,7 +78,7 @@
         - not enable_mac_learning_again_result.changed
 
 - name: disable MAC learning
-  vmware_dvs_portgroup:
+  community.vmware.vmware_dvs_portgroup:
     validate_certs: false
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
@@ -102,7 +102,7 @@
         - disable_mac_learning_result.changed
 
 - name: disable MAC learning again (idempotency)
-  vmware_dvs_portgroup:
+  community.vmware.vmware_dvs_portgroup:
     validate_certs: false
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
@@ -126,7 +126,7 @@
         - not disable_mac_learning_again_result.changed
 
 - name: create basic VLAN portgroup
-  vmware_dvs_portgroup:
+  community.vmware.vmware_dvs_portgroup:
     validate_certs: false
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
@@ -145,7 +145,7 @@
         - dvs_pg_result_0002.changed
 
 - name: create basic trunk portgroup
-  vmware_dvs_portgroup:
+  community.vmware.vmware_dvs_portgroup:
     validate_certs: false
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
@@ -165,7 +165,7 @@
         - dvs_pg_result_0003.changed
 
 - name: create basic portgroup again
-  vmware_dvs_portgroup:
+  community.vmware.vmware_dvs_portgroup:
     validate_certs: false
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
@@ -184,7 +184,7 @@
         - not dvs_pg_result_0004.changed
 
 - name: create basic portgroup with all security and policy settings enabled
-  vmware_dvs_portgroup:
+  community.vmware.vmware_dvs_portgroup:
     validate_certs: false
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
@@ -196,6 +196,7 @@
     port_binding: static
     state: present
     network_policy:
+      inherited: false
       promiscuous: true
       forged_transmits: true
       mac_changes: true
@@ -219,7 +220,7 @@
         - dvs_pg_result_0005.changed
 
 - name: create basic portgroup with some security and policy settings enabled
-  vmware_dvs_portgroup:
+  community.vmware.vmware_dvs_portgroup:
     validate_certs: false
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
@@ -231,6 +232,7 @@
     port_binding: static
     state: present
     network_policy:
+      inherited: false
       promiscuous: true
       forged_transmits: true
       mac_changes: false
@@ -244,7 +246,7 @@
         - dvs_pg_result_0006.changed
 
 - name: Change forged_transmits to no
-  vmware_dvs_portgroup:
+  community.vmware.vmware_dvs_portgroup:
     validate_certs: false
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
@@ -256,6 +258,7 @@
     port_binding: static
     state: present
     network_policy:
+      inherited: false
       promiscuous: true
       forged_transmits: false
       mac_changes: false
@@ -269,7 +272,7 @@
         - dvs_pg_result_0007.changed
 
 - name: Change vlan_override to no
-  vmware_dvs_portgroup:
+  community.vmware.vmware_dvs_portgroup:
     validate_certs: false
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
@@ -281,6 +284,7 @@
     port_binding: static
     state: present
     network_policy:
+      inherited: false
       promiscuous: true
       forged_transmits: false
       mac_changes: false
@@ -294,7 +298,7 @@
         - dvs_pg_result_0008.changed
 
 - name: Change num_ports to 16
-  vmware_dvs_portgroup:
+  community.vmware.vmware_dvs_portgroup:
     validate_certs: false
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
@@ -306,6 +310,7 @@
     port_binding: static
     state: present
     network_policy:
+      inherited: false
       promiscuous: true
       forged_transmits: false
       mac_changes: false
@@ -319,7 +324,7 @@
         - dvs_pg_result_0009.changed
 
 - name: Change portgroup to ephemeral
-  vmware_dvs_portgroup:
+  community.vmware.vmware_dvs_portgroup:
     validate_certs: false
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
@@ -331,6 +336,7 @@
     port_binding: ephemeral
     state: present
     network_policy:
+      inherited: false
       promiscuous: true
       forged_transmits: false
       mac_changes: false
@@ -344,7 +350,7 @@
         - dvs_pg_result_0010.changed
 
 - name: delete basic portgroup
-  vmware_dvs_portgroup:
+  community.vmware.vmware_dvs_portgroup:
     validate_certs: false
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
@@ -363,7 +369,7 @@
         - dvs_pg_result_0011.changed
 
 - name: delete basic portgroup again
-  vmware_dvs_portgroup:
+  community.vmware.vmware_dvs_portgroup:
     validate_certs: false
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
@@ -382,7 +388,7 @@
         - not dvs_pg_result_0012.changed
 
 - name: Check valid VLAN id range in DVS Portgroup
-  vmware_dvs_portgroup:
+  community.vmware.vmware_dvs_portgroup:
     validate_certs: false
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
@@ -404,7 +410,7 @@
         - "'vlan_id range 1-4096 specified is incorrect. The valid vlan_id range is from 0 to 4094.' == '{{ dvs_pg_result_0013.msg }}'"
 
 - name: Change VLAN on basic VLAN portgroup
-  vmware_dvs_portgroup:
+  community.vmware.vmware_dvs_portgroup:
     validate_certs: false
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
@@ -423,7 +429,7 @@
         - dvs_pg_result_0014.changed
 
 - name: Change VLAN range on basic trunk portgroup
-  vmware_dvs_portgroup:
+  community.vmware.vmware_dvs_portgroup:
     validate_certs: false
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
@@ -443,7 +449,7 @@
         - dvs_pg_result_0015.changed
 
 - name: create complex trunk portgroup
-  vmware_dvs_portgroup:
+  community.vmware.vmware_dvs_portgroup:
     validate_certs: false
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
@@ -463,7 +469,7 @@
         - dvs_pg_result_0016.changed
 
 - name: change complex trunk portgroup
-  vmware_dvs_portgroup:
+  community.vmware.vmware_dvs_portgroup:
     validate_certs: false
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
@@ -483,7 +489,7 @@
         - dvs_pg_result_0017.changed
 
 - name: Check fail for missing PVLAN in dvs
-  vmware_dvs_portgroup:
+  community.vmware.vmware_dvs_portgroup:
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
@@ -507,7 +513,7 @@
 - name: Run tests and clean up
   block:
     - name: add distributed vSwitch
-      vmware_dvswitch:
+      community.vmware.vmware_dvswitch:
         validate_certs: false
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
@@ -527,7 +533,7 @@
             - dvs_result_0001 is changed
 
     - name: Configure PVLANs to test PVLAN dpg
-      vmware_dvswitch_pvlans:
+      community.vmware.vmware_dvswitch_pvlans:
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
@@ -547,7 +553,7 @@
           - pvlans_result is not failed
 
     - name: Create private vlan portgroup
-      vmware_dvs_portgroup:
+      community.vmware.vmware_dvs_portgroup:
         hostname: '{{ vcenter_hostname }}'
         username: '{{ vcenter_username }}'
         password: '{{ vcenter_password }}'
@@ -567,7 +573,7 @@
             - dvs_pg_result_0019.changed
 
     - name: Change private vlan id
-      vmware_dvs_portgroup:
+      community.vmware.vmware_dvs_portgroup:
         hostname: '{{ vcenter_hostname }}'
         username: '{{ vcenter_username }}'
         password: '{{ vcenter_password }}'
@@ -587,7 +593,7 @@
             - dvs_pg_result_0020.changed
 
     - name: Change private vlan to basic vlan portgroup
-      vmware_dvs_portgroup:
+      community.vmware.vmware_dvs_portgroup:
         hostname: '{{ vcenter_hostname }}'
         username: '{{ vcenter_username }}'
         password: '{{ vcenter_password }}'
@@ -606,7 +612,7 @@
             - dvs_pg_result_0021.changed
   always:
     - name: delete distributed vSwitch
-      vmware_dvswitch:
+      community.vmware.vmware_dvswitch:
         validate_certs: false
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
@@ -619,7 +625,7 @@
     - name: Integration test a dvPortGroup name with special characters
       block:
         - name: Create dvSwitch with special characters
-          vmware_dvswitch:
+          community.vmware.vmware_dvswitch:
             hostname: "{{ vcenter_hostname }}"
             username: "{{ vcenter_username }}"
             password: "{{ vcenter_password }}"
@@ -637,7 +643,7 @@
               - create_dvswitch_with_special_characters_result.changed is sameas true
 
         - name: Create dvPortGroup with special characters
-          vmware_dvs_portgroup:
+          community.vmware.vmware_dvs_portgroup:
             hostname: "{{ vcenter_hostname }}"
             username: "{{ vcenter_username }}"
             password: "{{ vcenter_password }}"
@@ -655,7 +661,7 @@
               - create_dvportgroup_with_special_characters_result.changed is sameas true
 
         - name: Create dvPortGroup with special characters(idempotency check)
-          vmware_dvs_portgroup:
+          community.vmware.vmware_dvs_portgroup:
             hostname: "{{ vcenter_hostname }}"
             username: "{{ vcenter_username }}"
             password: "{{ vcenter_password }}"
@@ -673,7 +679,7 @@
               - create_dvportgroup_with_special_characters_idempotency_check_result.changed is sameas false
 
         - name: Delete dvPortGroup with special characters
-          vmware_dvs_portgroup:
+          community.vmware.vmware_dvs_portgroup:
             hostname: "{{ vcenter_hostname }}"
             username: "{{ vcenter_username }}"
             password: "{{ vcenter_password }}"
@@ -691,7 +697,7 @@
               - delete_dvportgroup_with_special_characters_result.changed is sameas true
 
         - name: Delete dvPortGroup with special characters(idempotency check)
-          vmware_dvs_portgroup:
+          community.vmware.vmware_dvs_portgroup:
             hostname: "{{ vcenter_hostname }}"
             username: "{{ vcenter_username }}"
             password: "{{ vcenter_password }}"
@@ -709,7 +715,7 @@
               - delete_dvportgroup_with_special_characters_idempotency_check_result.changed is sameas false
 
         - name: Delete dvSwitch with special characters
-          vmware_dvswitch:
+          community.vmware.vmware_dvswitch:
             hostname: "{{ vcenter_hostname }}"
             username: "{{ vcenter_username }}"
             password: "{{ vcenter_password }}"
@@ -729,7 +735,7 @@
     # https://github.com/ansible-collections/community.vmware/issues/637
     # The test if the vmware_dvs_portgroup has the idempotency when it is configured the multiple VLAN.
     - name: Create the test dvs port group for the issues 637
-      vmware_dvs_portgroup:
+      community.vmware.vmware_dvs_portgroup:
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
@@ -741,6 +747,7 @@
         num_ports: 120
         port_binding: static
         network_policy:
+          inherited: false
           promiscuous: false
           forged_transmits: true
           mac_changes: true
@@ -752,7 +759,7 @@
           - create_test_dvs_port_group_issues_637_result.changed is sameas true
 
     - name: Create the test dvs port group for the issues 637(idempotency check)
-      vmware_dvs_portgroup:
+      community.vmware.vmware_dvs_portgroup:
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
@@ -764,6 +771,7 @@
         num_ports: 120
         port_binding: static
         network_policy:
+          inherited: false
           promiscuous: false
           forged_transmits: true
           mac_changes: true
@@ -775,7 +783,7 @@
           - create_test_dvs_port_group_issues_637_idempotency_check_result.changed is sameas false
 
     - name: Delete the test dvs port group for the issues 637
-      vmware_dvs_portgroup:
+      community.vmware.vmware_dvs_portgroup:
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
@@ -787,6 +795,7 @@
         num_ports: 120
         port_binding: static
         network_policy:
+          inherited: false
           promiscuous: false
           forged_transmits: true
           mac_changes: true

--- a/tests/integration/targets/vmware_vspan_session/tasks/main.yml
+++ b/tests/integration/targets/vmware_vspan_session/tasks/main.yml
@@ -42,6 +42,7 @@
     port_allocation: 'fixed'
     state: present
     network_policy:
+      inherited: false
       promiscuous: true
       forged_transmits: true
       mac_changes: true


### PR DESCRIPTION
##### SUMMARY
Apart from the things that are specific to a portgroup (like, for example, its name) there are a lot of settings that could either be inherited from the switch or defined at the PG level.

Most, if not all, parameters of the module don't allow this: They have defaults which means the settings from the switch are always overwritten. Or they implicitly set something to inherited if the parameter is unset. This is a problem because people can't use the module in a way of "I don't care about this setting, just leave it as it is" manner or explicitly state that this setting should be inherited.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_dvs_portgroup

##### ADDITIONAL INFORMATION
#1316