### PR TITLE
Fixes #1503: vmware_tag_manager: Tag processing is very slow

### DIFF
--- a/changelogs/fragments/1503-vmware_tag_manager-fix_performance_issue_during_tag_processing.yml
+++ b/changelogs/fragments/1503-vmware_tag_manager-fix_performance_issue_during_tag_processing.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_tag_manager - Fix a performance issue during tag processing (https://github.com/ansible-collections/community.vmware/issues/1503).

--- a/plugins/module_utils/vmware_rest_client.py
+++ b/plugins/module_utils/vmware_rest_client.py
@@ -486,29 +486,32 @@ class VmwareRestClient(object):
 
         return self.search_svc_object_by_name(service=self.api_client.tagging.Category, svc_obj_name=category_name)
 
-    def get_tag_by_category(self, tag_name=None, category_name=None):
+    def get_tag_by_category(self, tag_name=None, category_name=None, category_id=None):
         """
         Return tag object by name and category name specified
         Args:
             tag_name: Name of tag
-            category_name: Name of category
-
+            category_name: Name of category (mutually exclusive with 'category_id')
+            category_id: Id of category, if known in advance (mutually exclusive with 'category_name')
         Returns: Tag object if found else None
         """
 
         if not tag_name:
             return None
 
-        if category_name:
-            category_obj = self.get_category_by_name(category_name=category_name)
+        if category_id or category_name:
+            if not category_id:
+                category_obj = self.get_category_by_name(category_name=category_name)
 
-            if not category_obj:
-                return None
+                if not category_obj:
+                    return None
 
-            for tag_object in self.api_client.tagging.Tag.list():
+                category_id = category_obj.id
+
+            for tag_object in self.api_client.tagging.Tag.list_tags_for_category(category_id):
                 tag_obj = self.api_client.tagging.Tag.get(tag_object)
 
-                if tag_obj.name == tag_name and tag_obj.category_id == category_obj.id:
+                if tag_obj.name == tag_name:
                     return tag_obj
         else:
             return self.search_svc_object_by_name(service=self.api_client.tagging.Tag, svc_obj_name=tag_name)

--- a/plugins/modules/vmware_tag_manager.py
+++ b/plugins/modules/vmware_tag_manager.py
@@ -318,7 +318,9 @@ class VmwareTagManager(VmwareRestClient):
                     # User specified only tag
                     tag_name = tag
 
-            if category_name:
+            if category_obj:
+                tag_obj = self.get_tag_by_category(tag_name=tag_name, category_id=category_obj.id)
+            elif category_name:
                 tag_obj = self.get_tag_by_category(tag_name=tag_name, category_name=category_name)
             else:
                 tag_obj = self.get_tag_by_name(tag_name=tag_name)


### PR DESCRIPTION
##### SUMMARY

Fixes #1503

This fix solves the performance issue during tag processing.

Signed-off-by: Christoph Fiehe <c.fiehe@eurodata.de>

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
vmware_tag_manager

##### ADDITIONAL INFORMATION
Instead of iterating over the full set of available tags, it is possible to limit the requested set, so that only tags are returned that belong to the specified Category Id.

The performance issue is caused by this loop:
```
for tag_object in self.api_client.tagging.Tag.list():
    [...]
```
It can be replaced by:
```
for tag_object in self.api_client.tagging.Tag.list_tags_for_category(category_id):
    [...]
```