### PR TITLE
Backport vmware_tag_manager: Fix Tagging cardinality violation

### DIFF
--- a/changelogs/fragments/1501-vmware_tag_manager-Fix_failure_when_changing_single_cardinal_tag_category.yml
+++ b/changelogs/fragments/1501-vmware_tag_manager-Fix_failure_when_changing_single_cardinal_tag_category.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_tag_manager - Fix an issue that causes a failure when changing a single cardinal tag category (https://github.com/ansible-collections/community.vmware/issues/1501).

--- a/plugins/modules/vmware_tag_manager.py
+++ b/plugins/modules/vmware_tag_manager.py
@@ -342,20 +342,20 @@ class VmwareTagManager(VmwareRestClient):
                         self.module.fail_json(msg="%s" % self.get_error_message(error))
 
         elif action == 'set':
-            for tag_obj in tag_objs:
-                if tag_obj not in available_tag_obj:
-                    # Tag is not already applied
-                    try:
-                        self.tag_association_svc.attach(tag_id=tag_obj.id, object_id=self.dynamic_managed_object)
-                        changed = True
-                    except Error as error:
-                        self.module.fail_json(msg="%s" % self.get_error_message(error))
-
             for av_tag in available_tag_obj:
                 if av_tag not in tag_objs:
                     # Tag not in the defined list
                     try:
                         self.tag_association_svc.detach(tag_id=av_tag.id, object_id=self.dynamic_managed_object)
+                        changed = True
+                    except Error as error:
+                        self.module.fail_json(msg="%s" % self.get_error_message(error))
+
+            for tag_obj in tag_objs:
+                if tag_obj not in available_tag_obj:
+                    # Tag is not already applied
+                    try:
+                        self.tag_association_svc.attach(tag_id=tag_obj.id, object_id=self.dynamic_managed_object)
                         changed = True
                     except Error as error:
                         self.module.fail_json(msg="%s" % self.get_error_message(error))


### PR DESCRIPTION
##### SUMMARY

This pull request fixes #1501 and ensures that the value of a single cardinal tag category can be modified without any issue. 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_tag_manager

##### ADDITIONAL INFORMATION
The correct behavior can be easily ensured by changing the order of tag addition and tag removal. At first, you have to remove the tags that are not longer part of the target state and add the new tags afterwards. The issue arises because the tags got added first, resulting in a cardinality violation for single cardinal tag categories.