### PR TITLE
vmware_guest_file_operation: add a new parameter for timeout

### DIFF
--- a/changelogs/fragments/1323-vmware_guest_file_operation.yml
+++ b/changelogs/fragments/1323-vmware_guest_file_operation.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_guest_file_operation - Add a new parameter for timeout(https://github.com/ansible-collections/community.vmware/pull/1513).

--- a/plugins/modules/vmware_guest_file_operation.py
+++ b/plugins/modules/vmware_guest_file_operation.py
@@ -147,6 +147,12 @@ options:
                 type: str
         required: False
         type: dict
+    timeout:
+        description:
+            - Timeout seconds for fetching or copying a file.
+        type: int
+        default: 100
+        version_added: '3.1.0'
 
 extends_documentation_fragment:
 - community.vmware.vmware.documentation
@@ -197,6 +203,22 @@ EXAMPLES = r'''
         src: "/root/test.zip"
         dest: "files/test.zip"
   delegate_to: localhost
+
+- name: If a timeout error occurs, specify any timeout value
+  community.vmware.vmware_guest_file_operation:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter: "{{ datacenter_name }}"
+    vm_id: "{{ guest_name }}"
+    vm_username: "{{ guest_username }}"
+    vm_password: "{{ guest_userpassword }}"
+    timeout: 10000
+    copy:
+        src: "files/test.zip"
+        dest: "/root/test.zip"
+        overwrite: False
+  delegate_to: localhost
 '''
 
 RETURN = r'''
@@ -222,6 +244,7 @@ class VmwareGuestFileManager(PyVmomi):
         datacenter_name = module.params['datacenter']
         cluster_name = module.params['cluster']
         folder = module.params['folder']
+        self.timeout = module.params['timeout']
 
         datacenter = None
         if datacenter_name:
@@ -345,7 +368,7 @@ class VmwareGuestFileManager(PyVmomi):
                                                                           guestFilePath=src)
             url = fileTransferInfo.url
             url = url.replace("*", hostname)
-            resp, info = urls.fetch_url(self.module, url, method="GET")
+            resp, info = urls.fetch_url(self.module, url, method="GET", timeout=self.timeout)
             if info.get('status') != 200 or not resp:
                 self.module.fail_json(msg="Failed to fetch file : %s" % info.get('msg', ''), body=info.get('body', ''))
             try:
@@ -403,7 +426,7 @@ class VmwareGuestFileManager(PyVmomi):
                                                            fileAttributes=file_attributes, overwrite=overwrite,
                                                            fileSize=file_size)
             url = url.replace("*", hostname)
-            resp, info = urls.fetch_url(self.module, url, data=data, method="PUT")
+            resp, info = urls.fetch_url(self.module, url, data=data, method="PUT", timeout=self.timeout)
 
             status_code = info["status"]
             if status_code != 200:
@@ -470,7 +493,8 @@ def main():
                 src=dict(required=True, type='str'),
                 dest=dict(required=True, type='str'),
             )
-        )
+        ),
+        timeout=dict(type='int', default=100)
     )
     )
 

--- a/plugins/modules/vmware_guest_file_operation.py
+++ b/plugins/modules/vmware_guest_file_operation.py
@@ -204,7 +204,7 @@ EXAMPLES = r'''
         dest: "files/test.zip"
   delegate_to: localhost
 
-- name: If a timeout error occurs, specify any timeout value
+- name: If a timeout error occurs, specify a high(er) timeout value
   community.vmware.vmware_guest_file_operation:
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"


### PR DESCRIPTION
##### SUMMARY

If a timeout occurs during to fetch or copy of a file, the error is displayed with vmware_guest_file_operation module.

```
TASK [test] **********************************************************************************************************************************************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "problem during file transfer, http message:{'url': 'https://esxi-05.homelab:443/guestFile?id=266&token=52a2c34f-349f-a6fe-9b71-ce9ac9066ee2266', 'status': -1, 'msg': 'Request failed: <urlopen error The write operation timed out>'}", "uuid": "421a224e-f587-a9ff-0354-42b2d9949297"}
```

This PR adds the timeout parameter to resolve the above error.

fixes: https://github.com/ansible-collections/community.vmware/issues/1323

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

plugins/modules/vmware_guest_file_operation.py

##### ADDITIONAL INFORMATION

tested VCSA 7.0.1