### PR TITLE
Remove version_added 1.x from doc_fragments in inventory

### DIFF
--- a/docs/community.vmware.vmware_category_info_module.rst
+++ b/docs/community.vmware.vmware_category_info_module.rst
@@ -117,7 +117,6 @@ Parameters
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
                     </div>
-                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.12.0</div>
                 </td>
                 <td>
                 </td>
@@ -135,7 +134,6 @@ Parameters
                     <div style="font-size: small">
                         <span style="color: purple">integer</span>
                     </div>
-                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.12.0</div>
                 </td>
                 <td>
                 </td>

--- a/docs/community.vmware.vmware_category_module.rst
+++ b/docs/community.vmware.vmware_category_module.rst
@@ -222,7 +222,6 @@ Parameters
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
                     </div>
-                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.12.0</div>
                 </td>
                 <td>
                 </td>
@@ -240,7 +239,6 @@ Parameters
                     <div style="font-size: small">
                         <span style="color: purple">integer</span>
                     </div>
-                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.12.0</div>
                 </td>
                 <td>
                 </td>

--- a/docs/community.vmware.vmware_content_deploy_ovf_template_module.rst
+++ b/docs/community.vmware.vmware_content_deploy_ovf_template_module.rst
@@ -262,7 +262,6 @@ Parameters
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
                     </div>
-                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.12.0</div>
                 </td>
                 <td>
                 </td>
@@ -280,7 +279,6 @@ Parameters
                     <div style="font-size: small">
                         <span style="color: purple">integer</span>
                     </div>
-                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.12.0</div>
                 </td>
                 <td>
                 </td>

--- a/docs/community.vmware.vmware_content_deploy_template_module.rst
+++ b/docs/community.vmware.vmware_content_deploy_template_module.rst
@@ -271,7 +271,6 @@ Parameters
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
                     </div>
-                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.12.0</div>
                 </td>
                 <td>
                 </td>
@@ -289,7 +288,6 @@ Parameters
                     <div style="font-size: small">
                         <span style="color: purple">integer</span>
                     </div>
-                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.12.0</div>
                 </td>
                 <td>
                 </td>

--- a/docs/community.vmware.vmware_content_library_info_module.rst
+++ b/docs/community.vmware.vmware_content_library_info_module.rst
@@ -133,7 +133,6 @@ Parameters
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
                     </div>
-                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.12.0</div>
                 </td>
                 <td>
                 </td>
@@ -151,7 +150,6 @@ Parameters
                     <div style="font-size: small">
                         <span style="color: purple">integer</span>
                     </div>
-                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.12.0</div>
                 </td>
                 <td>
                 </td>

--- a/docs/community.vmware.vmware_content_library_manager_module.rst
+++ b/docs/community.vmware.vmware_content_library_manager_module.rst
@@ -192,7 +192,6 @@ Parameters
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
                     </div>
-                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.12.0</div>
                 </td>
                 <td>
                 </td>
@@ -210,7 +209,6 @@ Parameters
                     <div style="font-size: small">
                         <span style="color: purple">integer</span>
                     </div>
-                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.12.0</div>
                 </td>
                 <td>
                 </td>

--- a/docs/community.vmware.vmware_host_inventory_inventory.rst
+++ b/docs/community.vmware.vmware_host_inventory_inventory.rst
@@ -8,7 +8,6 @@ community.vmware.vmware_host_inventory
 **VMware ESXi hostsystem inventory source**
 
 
-Version added: 1.11.0
 
 .. contents::
    :local:
@@ -494,7 +493,6 @@ Parameters
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
                     </div>
-                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.12.0</div>
                 </td>
                 <td>
                 </td>
@@ -515,7 +513,6 @@ Parameters
                     <div style="font-size: small">
                         <span style="color: purple">integer</span>
                     </div>
-                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.12.0</div>
                 </td>
                 <td>
                 </td>

--- a/docs/community.vmware.vmware_object_rename_module.rst
+++ b/docs/community.vmware.vmware_object_rename_module.rst
@@ -194,7 +194,6 @@ Parameters
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
                     </div>
-                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.12.0</div>
                 </td>
                 <td>
                 </td>
@@ -212,7 +211,6 @@ Parameters
                     <div style="font-size: small">
                         <span style="color: purple">integer</span>
                     </div>
-                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.12.0</div>
                 </td>
                 <td>
                 </td>

--- a/docs/community.vmware.vmware_tag_info_module.rst
+++ b/docs/community.vmware.vmware_tag_info_module.rst
@@ -117,7 +117,6 @@ Parameters
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
                     </div>
-                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.12.0</div>
                 </td>
                 <td>
                 </td>
@@ -135,7 +134,6 @@ Parameters
                     <div style="font-size: small">
                         <span style="color: purple">integer</span>
                     </div>
-                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.12.0</div>
                 </td>
                 <td>
                 </td>

--- a/docs/community.vmware.vmware_tag_manager_module.rst
+++ b/docs/community.vmware.vmware_tag_manager_module.rst
@@ -178,7 +178,6 @@ Parameters
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
                     </div>
-                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.12.0</div>
                 </td>
                 <td>
                 </td>
@@ -196,7 +195,6 @@ Parameters
                     <div style="font-size: small">
                         <span style="color: purple">integer</span>
                     </div>
-                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.12.0</div>
                 </td>
                 <td>
                 </td>

--- a/docs/community.vmware.vmware_tag_module.rst
+++ b/docs/community.vmware.vmware_tag_module.rst
@@ -134,7 +134,6 @@ Parameters
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
                     </div>
-                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.12.0</div>
                 </td>
                 <td>
                 </td>
@@ -152,7 +151,6 @@ Parameters
                     <div style="font-size: small">
                         <span style="color: purple">integer</span>
                     </div>
-                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.12.0</div>
                 </td>
                 <td>
                 </td>

--- a/docs/community.vmware.vmware_vc_infraprofile_info_module.rst
+++ b/docs/community.vmware.vmware_vc_infraprofile_info_module.rst
@@ -215,7 +215,6 @@ Parameters
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
                     </div>
-                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.12.0</div>
                 </td>
                 <td>
                 </td>
@@ -233,7 +232,6 @@ Parameters
                     <div style="font-size: small">
                         <span style="color: purple">integer</span>
                     </div>
-                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.12.0</div>
                 </td>
                 <td>
                 </td>

--- a/docs/community.vmware.vmware_vm_inventory_inventory.rst
+++ b/docs/community.vmware.vmware_vm_inventory_inventory.rst
@@ -496,7 +496,6 @@ Parameters
                     <div style="font-size: small">
                         <span style="color: purple">string</span>
                     </div>
-                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.12.0</div>
                 </td>
                 <td>
                 </td>
@@ -517,7 +516,6 @@ Parameters
                     <div style="font-size: small">
                         <span style="color: purple">integer</span>
                     </div>
-                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 1.12.0</div>
                 </td>
                 <td>
                 </td>

--- a/plugins/doc_fragments/vmware_rest_client.py
+++ b/plugins/doc_fragments/vmware_rest_client.py
@@ -56,12 +56,10 @@ options:
     - If the value is not specified in the task, the value of environment variable C(VMWARE_PROXY_HOST) will be used instead.
     type: str
     required: False
-    version_added: '1.12.0'
   proxy_port:
     description:
     - Port of the HTTP proxy that will receive all HTTPS requests and relay them.
     - If the value is not specified in the task, the value of environment variable C(VMWARE_PROXY_PORT) will be used instead.
     type: int
     required: False
-    version_added: '1.12.0'
 '''

--- a/plugins/inventory/vmware_host_inventory.py
+++ b/plugins/inventory/vmware_host_inventory.py
@@ -21,7 +21,6 @@ DOCUMENTATION = r"""
       - constructed
     requirements:
       - "vSphere Automation SDK - For tag feature"
-    version_added: "1.11.0"
     options:
         hostname:
             description: Name of vCenter or ESXi server.
@@ -135,7 +134,6 @@ DOCUMENTATION = r"""
           - This feature depends on a version of pyvmomi>=v6.7.1.2018.12.
           type: str
           required: False
-          version_added: '1.12.0'
           env:
             - name: VMWARE_PROXY_HOST
         proxy_port:
@@ -143,7 +141,6 @@ DOCUMENTATION = r"""
           - Port of the HTTP proxy that will receive all HTTPS requests and relay them.
           type: int
           required: False
-          version_added: '1.12.0'
           env:
             - name: VMWARE_PROXY_PORT
 """

--- a/plugins/inventory/vmware_vm_inventory.py
+++ b/plugins/inventory/vmware_vm_inventory.py
@@ -145,7 +145,6 @@ DOCUMENTATION = r'''
           - This feature depends on a version of pyvmomi>=v6.7.1.2018.12.
           type: str
           required: False
-          version_added: '1.12.0'
           env:
             - name: VMWARE_PROXY_HOST
         proxy_port:
@@ -153,7 +152,6 @@ DOCUMENTATION = r'''
           - Port of the HTTP proxy that will receive all HTTPS requests and relay them.
           type: int
           required: False
-          version_added: '1.12.0'
           env:
             - name: VMWARE_PROXY_PORT
 '''


### PR DESCRIPTION
##### SUMMARY
Now that version 1 is nearly EOL, I don't think that it's important if something has been added in 1.2, 1.4, 1.7 or wherever.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
plugins/doc_fragments/vmware_rest_client.py
vmware_host_inventory
vmware_vm_inventory

##### ADDITIONAL INFORMATION
#1473
#1474