### PR TITLE
2.x: vmware_dvs_portgroup: Fix deleting portgroups

### DIFF
--- a/changelogs/fragments/1522-vmware_dvs_portgroup.yml
+++ b/changelogs/fragments/1522-vmware_dvs_portgroup.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_dvs_portgroup - Fix an issue when deleting portgroups (https://github.com/ansible-collections/community.vmware/issues/1522).

--- a/plugins/modules/vmware_dvs_portgroup.py
+++ b/plugins/modules/vmware_dvs_portgroup.py
@@ -628,6 +628,7 @@ class VMwareDvsPortgroup(PyVmomi):
     def process_state(self):
         dvspg_states = {
             'absent': {
+                'update': self.state_destroy_dvspg,
                 'present': self.state_destroy_dvspg,
                 'absent': self.state_exit_unchanged,
             },


### PR DESCRIPTION
##### SUMMARY
Backport #1523 

If `check_dvspg_state()` returns `update`, this might crash the module if the `state` is set to `absent`. This is because `dvspg_states['absent']['update']` doesn't exist.

In that case, the module should just remove the portgroup.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_dvs_portgroup

##### ADDITIONAL INFORMATION
https://github.com/ansible-collections/community.vmware/blob/6364b294a281dcbcb0b2a8b7d8bd8317fbc0f355/plugins/modules/vmware_dvs_portgroup.py#L628-L641