### PR TITLE
Fix non-matching defaults in docs

### DIFF
--- a/plugins/modules/vcenter_standard_key_provider.py
+++ b/plugins/modules/vcenter_standard_key_provider.py
@@ -47,6 +47,7 @@ options:
       - If C(kms_port) is not specified, the default port 5696 will be used.
       - C(kms_ip), C(kms_port) can be reconfigured for an existing KMS with name C(kms_name).
     type: list
+    default: []
     elements: dict
     suboptions:
       kms_name:

--- a/plugins/modules/vmware_content_library_manager.py
+++ b/plugins/modules/vmware_content_library_manager.py
@@ -36,7 +36,6 @@ options:
       - Process of updating content library only allows description change.
       type: str
       required: False
-      default: ''
     library_type:
       description:
       - The content library type.
@@ -61,6 +60,7 @@ options:
       - This is required only if I(library_type) is set to C(subscribed).
       - This parameter is ignored, when I(state) is set to C(absent).
       type: str
+      default: ''
       required: False
     ssl_thumbprint:
       description:
@@ -70,6 +70,7 @@ options:
       - 'The information can be extracted using openssl using the following example:
         C(echo | openssl s_client -connect test-library.com:443 |& openssl x509 -fingerprint -noout)'
       type: str
+      default: ''
       required: False
     update_on_demand:
       description:

--- a/plugins/modules/vmware_dvs_host.py
+++ b/plugins/modules/vmware_dvs_host.py
@@ -38,10 +38,12 @@ options:
         - The ESXi hosts vmnics to use with the Distributed vSwitch.
         required: False
         type: list
+        default: []
         elements: str
     lag_uplinks:
         required: False
         type: list
+        default: []
         elements: dict
         description:
         - The ESXi hosts vmnics to use with specific LAGs.
@@ -56,6 +58,7 @@ options:
                 - The ESXi hosts vmnics to use with the LAG.
                 required: False
                 type: list
+                default: []
                 elements: str
     state:
         description:

--- a/plugins/modules/vmware_dvswitch_lacp.py
+++ b/plugins/modules/vmware_dvswitch_lacp.py
@@ -80,6 +80,7 @@ options:
                 default: 'srcDestIpTcpUdpPortVlan'
         elements: dict
         type: list
+        default: []
 extends_documentation_fragment:
 - community.vmware.vmware.documentation
 

--- a/plugins/modules/vmware_dvswitch_nioc.py
+++ b/plugins/modules/vmware_dvswitch_nioc.py
@@ -65,6 +65,7 @@ options:
                 - Ignored unless version is "version3".
                 - Amount of bandwidth resource that is guaranteed available to the host infrastructure traffic class.
                 type: int
+                default: 0
 
             shares_level:
                 description:
@@ -80,6 +81,7 @@ options:
                 type: int
         required: False
         type: list
+        default: []
         elements: dict
 extends_documentation_fragment:
 - community.vmware.vmware.documentation

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -123,6 +123,7 @@ options:
     type: str
   hardware:
     type: dict
+    default: {}
     description:
     - "Manage virtual machine's hardware attributes."
     - All parameters case sensitive.
@@ -231,6 +232,7 @@ options:
     - 'Attributes C(controller_type), C(controller_number), C(unit_number) are used to configure multiple types of disk
       controllers and disks for creating or reconfiguring virtual machine. Added in Ansible 2.10.'
     type: list
+    default: []
     elements: dict
     suboptions:
         size:
@@ -318,6 +320,7 @@ options:
     - Make sure that the host or the cluster on which the virtual machine resides has available PMem resources.
     - To add or remove virtual NVDIMM device to the existing virtual machine, it must be in power off state.
     type: dict
+    default: {}
     suboptions:
         state:
              type: str
@@ -344,6 +347,7 @@ options:
       configuration support.'
     - For C(ide) controller, hot-add or hot-remove CD-ROM is not supported.
     type: raw
+    default: []
     suboptions:
         type:
             type: str
@@ -472,6 +476,7 @@ options:
     - Incorrect key and values will be ignored.
     elements: dict
     type: list
+    default: []
   annotation:
     description:
     - A note or annotation to include in the virtual machine.
@@ -484,6 +489,7 @@ options:
     - Incorrect key and values will be ignored.
     elements: dict
     type: list
+    default: []
   networks:
     description:
     - A list of networks (in the order of the NICs).
@@ -493,6 +499,7 @@ options:
       They are set by the customization via vmware-tools.
       If you want to set the value of the options to a guest, you need to clone from a template with installed OS and vmware-tools(also Perl when Linux).
     type: list
+    default: []
     elements: dict
     suboptions:
         name:
@@ -698,11 +705,13 @@ options:
             - List of commands to run at first user logon.
             - Specific to Windows customization.
     type: dict
+    default: {}
   vapp_properties:
     description:
     - A list of vApp properties.
     - 'For full list of attributes and types refer to: U(https://code.vmware.com/apis/704/vsphere/vim.vApp.PropertyInfo.html)'
     type: list
+    default: []
     elements: dict
     suboptions:
         id:

--- a/plugins/modules/vmware_guest_sendkey.py
+++ b/plugins/modules/vmware_guest_sendkey.py
@@ -80,6 +80,7 @@ options:
      - If both C(keys_send) and C(string_send) are specified, keys in C(keys_send) list will be sent in front of the C(string_send).
      - Values C(HOME) and C(END) are added in version 1.17.0.
      type: list
+     default: []
      elements: str
    sleep_time:
      description:

--- a/plugins/modules/vmware_host_active_directory.py
+++ b/plugins/modules/vmware_host_active_directory.py
@@ -22,15 +22,18 @@ options:
     description:
         - AD Domain to join.
     type: str
+    default: ''
     aliases: [ domain, domain_name ]
   ad_user:
     description:
         - Username for AD domain join.
     type: str
+    default: ''
   ad_password:
     description:
         - Password for AD domain join.
     type: str
+    default: ''
   ad_state:
      description:
         - Whether the ESXi host is joined to an AD domain or not.

--- a/plugins/modules/vmware_host_snmp.py
+++ b/plugins/modules/vmware_host_snmp.py
@@ -31,6 +31,7 @@ options:
     description:
         - List of SNMP community strings.
     type: list
+    default: []
     elements: str
   snmp_port:
     description:


### PR DESCRIPTION
##### SUMMARY
Fix various non-matching `default` values exposed by ansible/ansible#79267.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
vcenter_standard_key_provider
vmware_content_library_manager
vmware_dvs_host
vmware_dvswitch_lacp
vmware_dvswitch_nioc
vmware_guest
vmware_guest_sendkey
vmware_host_active_directory
vmware_host_snmp

##### ADDITIONAL INFORMATION
