### PR TITLE
Generic modules for custom attributes

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -21,6 +21,8 @@ action_groups:
   - vmware_content_deploy_ovf_template
   - vmware_content_library_info
   - vmware_content_library_manager
+  - vmware_custom_attribute
+  - vmware_custom_attribute_manager
   - vmware_datacenter
   - vmware_datacenter_info
   - vmware_datastore_cluster

--- a/plugins/modules/vmware_custom_attribute.py
+++ b/plugins/modules/vmware_custom_attribute.py
@@ -1,0 +1,168 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2022, Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = r'''
+---
+module: vmware_custom_attribute
+short_description: Manage custom attributes definitions
+description:
+  - This module can be used to add and remove custom attributes definitions for various vSphere objects.
+author:
+  - Mario Lenz (@mariolenz)
+options:
+  custom_attribute:
+    description:
+      - Name of the custom attribute.
+    required: True
+    type: str
+  object_type:
+    description:
+      - Type of the object the custom attribute is associated with.
+    type: str
+    choices:
+      - Datacenter
+      - Cluster
+      - HostSystem
+      - ResourcePool
+      - Folder
+      - VirtualMachine
+      - DistributedVirtualSwitch
+      - DistributedVirtualPortgroup
+      - Datastore
+    required: True
+  state:
+    description:
+      - Manage definition of custom attributes.
+      - If set to C(present) and definition not present, then custom attribute definition is created.
+      - If set to C(present) and definition is present, then no action taken.
+      - If set to C(absent) and definition is present, then custom attribute definition is removed.
+      - If set to C(absent) and definition is absent, then no action taken.
+    default: 'present'
+    choices: ['present', 'absent']
+    type: str
+extends_documentation_fragment:
+- community.vmware.vmware.documentation
+
+'''
+
+EXAMPLES = r'''
+- name: Add VM Custom Attribute Definition
+  community.vmware.vmware_guest_custom_attribute_defs:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    state: present
+    object_type: VirtualMachine
+    custom_attribute: custom_attr_def_1
+  delegate_to: localhost
+  register: defs
+
+- name: Remove VM Custom Attribute Definition
+  community.vmware.vmware_guest_custom_attribute_defs:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    state: absent
+    object_type: VirtualMachine
+    custom_attribute: custom_attr_def_1
+  delegate_to: localhost
+  register: defs
+'''
+
+RETURN = r'''
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, vmware_argument_spec
+
+try:
+    from pyVmomi import vim
+except ImportError:
+    pass
+
+
+class CustomAttribute(PyVmomi):
+    def __init__(self, module):
+        super(CustomAttribute, self).__init__(module)
+
+        object_types_map = {
+            'Datacenter': vim.Datacenter,
+            'Cluster': vim.ClusterComputeResource,
+            'HostSystem': vim.HostSystem,
+            'ResourcePool': vim.ResourcePool,
+            'Folder': vim.Folder,
+            'VirtualMachine': vim.VirtualMachine,
+            'DistributedVirtualSwitch': vim.DistributedVirtualSwitch,
+            'DistributedVirtualPortgroup': vim.DistributedVirtualPortgroup,
+            'Datastore': vim.Datastore
+        }
+
+        self.object_type = object_types_map[self.params['object_type']]
+
+    def remove_custom_def(self, field):
+        changed = False
+        for x in self.custom_field_mgr:
+            if x.name == field and x.managedObjectType == self.object_type:
+                changed = True
+                if not self.module.check_mode:
+                    self.content.customFieldsManager.RemoveCustomFieldDef(key=x.key)
+                break
+        return {'changed': changed, 'failed': False}
+
+    def add_custom_def(self, field):
+        changed = False
+        found = False
+        for x in self.custom_field_mgr:
+            if x.name == field and x.managedObjectType == self.object_type:
+                found = True
+                break
+
+        if not found:
+            changed = True
+            if not self.module.check_mode:
+                self.content.customFieldsManager.AddFieldDefinition(name=field, moType=self.object_type)
+        return {'changed': changed, 'failed': False}
+
+
+def main():
+    argument_spec = vmware_argument_spec()
+    argument_spec.update(
+        custom_attribute=dict(type='str', no_log=False, required=True),
+        object_type=dict(type='str', required=True, choices=[
+            'Datacenter',
+            'Cluster',
+            'HostSystem',
+            'ResourcePool',
+            'Folder',
+            'VirtualMachine',
+            'DistributedVirtualSwitch',
+            'DistributedVirtualPortgroup',
+            'Datastore'
+        ]),
+        state=dict(type='str', default='present', choices=['absent', 'present']),
+    )
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    pyv = CustomAttribute(module)
+    results = dict(changed=False, custom_attribute_defs=list())
+    if module.params['state'] == "present":
+        results = pyv.add_custom_def(module.params['custom_attribute'])
+    elif module.params['state'] == "absent":
+        results = pyv.remove_custom_def(module.params['custom_attribute'])
+
+    module.exit_json(**results)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/vmware_custom_attribute.py
+++ b/plugins/modules/vmware_custom_attribute.py
@@ -93,6 +93,9 @@ class CustomAttribute(PyVmomi):
     def __init__(self, module):
         super(CustomAttribute, self).__init__(module)
 
+        if not self.is_vcenter():
+            self.module.fail_json(msg="You have to connect to a vCenter server!")
+
         object_types_map = {
             'Datacenter': vim.Datacenter,
             'Cluster': vim.ClusterComputeResource,

--- a/plugins/modules/vmware_custom_attribute.py
+++ b/plugins/modules/vmware_custom_attribute.py
@@ -28,15 +28,16 @@ options:
       - Type of the object the custom attribute is associated with.
     type: str
     choices:
-      - Datacenter
       - Cluster
+      - Datacenter
+      - Datastore
+      - DistributedVirtualPortgroup
+      - DistributedVirtualSwitch
+      - Folder
+      - Global
       - HostSystem
       - ResourcePool
-      - Folder
       - VirtualMachine
-      - DistributedVirtualSwitch
-      - DistributedVirtualPortgroup
-      - Datastore
     required: True
   state:
     description:
@@ -97,15 +98,16 @@ class CustomAttribute(PyVmomi):
             self.module.fail_json(msg="You have to connect to a vCenter server!")
 
         object_types_map = {
-            'Datacenter': vim.Datacenter,
             'Cluster': vim.ClusterComputeResource,
+            'Datacenter': vim.Datacenter,
+            'Datastore': vim.Datastore,
+            'DistributedVirtualPortgroup': vim.DistributedVirtualPortgroup,
+            'DistributedVirtualSwitch': vim.DistributedVirtualSwitch,
+            'Folder': vim.Folder,
+            'Global': None,
             'HostSystem': vim.HostSystem,
             'ResourcePool': vim.ResourcePool,
-            'Folder': vim.Folder,
-            'VirtualMachine': vim.VirtualMachine,
-            'DistributedVirtualSwitch': vim.DistributedVirtualSwitch,
-            'DistributedVirtualPortgroup': vim.DistributedVirtualPortgroup,
-            'Datastore': vim.Datastore
+            'VirtualMachine': vim.VirtualMachine
         }
 
         self.object_type = object_types_map[self.params['object_type']]
@@ -140,15 +142,16 @@ def main():
     argument_spec.update(
         custom_attribute=dict(type='str', no_log=False, required=True),
         object_type=dict(type='str', required=True, choices=[
-            'Datacenter',
             'Cluster',
+            'Datacenter',
+            'Datastore',
+            'DistributedVirtualPortgroup',
+            'DistributedVirtualSwitch',
+            'Folder',
+            'Global',
             'HostSystem',
             'ResourcePool',
-            'Folder',
-            'VirtualMachine',
-            'DistributedVirtualSwitch',
-            'DistributedVirtualPortgroup',
-            'Datastore'
+            'VirtualMachine'
         ]),
         state=dict(type='str', default='present', choices=['absent', 'present']),
     )

--- a/plugins/modules/vmware_custom_attribute.py
+++ b/plugins/modules/vmware_custom_attribute.py
@@ -55,7 +55,7 @@ extends_documentation_fragment:
 
 EXAMPLES = r'''
 - name: Add VM Custom Attribute Definition
-  community.vmware.vmware_guest_custom_attribute_defs:
+  community.vmware.vmware_custom_attribute:
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
@@ -66,7 +66,7 @@ EXAMPLES = r'''
   register: defs
 
 - name: Remove VM Custom Attribute Definition
-  community.vmware.vmware_guest_custom_attribute_defs:
+  community.vmware.vmware_custom_attribute:
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"

--- a/plugins/modules/vmware_custom_attribute_manager.py
+++ b/plugins/modules/vmware_custom_attribute_manager.py
@@ -58,9 +58,8 @@ options:
     required: True
   state:
     description:
-      - The action to take.
-      - If set to C(present), then custom attribute is added or updated.
-      - If set to C(absent), then custom attribute is removed.
+      - If set to C(present), the custom attribute is set to the given value.
+      - If set to C(absent), the custom attribute is cleared. The given value is ignored in this case.
     default: 'present'
     choices: ['present', 'absent']
     type: str
@@ -71,7 +70,7 @@ extends_documentation_fragment:
 
 EXAMPLES = r'''
 - name: Add virtual machine custom attributes
-  community.vmware.vmware_guest_custom_attributes:
+  community.vmware.vmware_custom_attribute_manager:
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
@@ -84,7 +83,7 @@ EXAMPLES = r'''
   delegate_to: localhost
 
 - name: Add multiple virtual machine custom attributes
-  community.vmware.vmware_guest_custom_attributes:
+  community.vmware.vmware_custom_attribute_manager:
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
@@ -99,7 +98,7 @@ EXAMPLES = r'''
   delegate_to: localhost
 
 - name: Remove virtual machine Attribute
-  community.vmware.vmware_guest_custom_attributes:
+  community.vmware.vmware_custom_attribute_manager:
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"

--- a/plugins/modules/vmware_custom_attribute_manager.py
+++ b/plugins/modules/vmware_custom_attribute_manager.py
@@ -1,0 +1,233 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright, (c) 2022, Mario Lenz <m@riolenz.de>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = r'''
+---
+module: vmware_custom_attribute_manager
+short_description: Manage custom attributes from VMware for the given vSphere object
+description:
+  - This module can be used to add, remove and update custom attributes for the given vSphere object.
+author:
+  - Mario Lenz (@mariolenz)
+options:
+  custom_attributes:
+    description:
+      - A list of name and value of custom attributes that needs to be manage.
+      - Value of custom attribute is not required and will be ignored, if C(state) is set to C(absent).
+    suboptions:
+      name:
+        description:
+          - Name of the attribute.
+        type: str
+        required: True
+      value:
+        description:
+          - Value of the attribute.
+        type: str
+        default: ''
+    required: True
+    type: list
+    elements: dict
+  object_name:
+    description:
+      - Name of the vSphere object to work with.
+    type: str
+    required: True
+  object_type:
+    description:
+      - Type of the object the custom attribute is associated with.
+    type: str
+    choices:
+      - Datacenter
+      - Cluster
+      - HostSystem
+      - ResourcePool
+      - Folder
+      - VirtualMachine
+      - DistributedVirtualSwitch
+      - DistributedVirtualPortgroup
+      - Datastore
+    required: True
+  state:
+    description:
+      - The action to take.
+      - If set to C(present), then custom attribute is added or updated.
+      - If set to C(absent), then custom attribute is removed.
+    default: 'present'
+    choices: ['present', 'absent']
+    type: str
+extends_documentation_fragment:
+- community.vmware.vmware.documentation
+
+'''
+
+EXAMPLES = r'''
+- name: Add virtual machine custom attributes
+  community.vmware.vmware_guest_custom_attributes:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    object_name: vm1
+    object_type: VirtualMachine
+    state: present
+    custom_attributes:
+      - name: MyAttribute
+        value: MyValue
+  delegate_to: localhost
+
+- name: Add multiple virtual machine custom attributes
+  community.vmware.vmware_guest_custom_attributes:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    object_name: vm1
+    object_type: VirtualMachine
+    state: present
+    custom_attributes:
+      - name: MyAttribute
+        value: MyValue
+      - name: MyAttribute2
+        value: MyValue2
+  delegate_to: localhost
+
+- name: Remove virtual machine Attribute
+  community.vmware.vmware_guest_custom_attributes:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    object_name: vm1
+    object_type: VirtualMachine
+    state: absent
+    custom_attributes:
+      - name: MyAttribute
+  delegate_to: localhost
+  register: attributes
+'''
+
+RETURN = r'''
+'''
+
+try:
+    from pyVmomi import vim
+except ImportError:
+    pass
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, vmware_argument_spec
+
+
+class CustomAttributeManager(PyVmomi):
+    def __init__(self, module):
+        super(CustomAttributeManager, self).__init__(module)
+
+        self.custom_attributes = self.params['custom_attributes']
+
+        object_types_map = {
+            'Datacenter': vim.Datacenter,
+            'Cluster': vim.ClusterComputeResource,
+            'HostSystem': vim.HostSystem,
+            'ResourcePool': vim.ResourcePool,
+            'Folder': vim.Folder,
+            'VirtualMachine': vim.VirtualMachine,
+            'DistributedVirtualSwitch': vim.DistributedVirtualSwitch,
+            'DistributedVirtualPortgroup': vim.DistributedVirtualPortgroup,
+            'Datastore': vim.Datastore
+        }
+
+        self.object_type = object_types_map[self.params['object_type']]
+
+        self.object_name = self.params['object_name']
+        self.obj = self.find_object_by_name(self.params['object_name'], self.object_type)
+        if self.obj is None:
+            module.fail_json(msg="Unable to manage custom attributes for non-existing"
+                                 " object %s." % self.object_name)
+
+        for ca in self.custom_attributes:
+            for x in self.custom_field_mgr:
+                if x.name == ca.name and x.managedObjectType == self.object_type:
+                    ca['key'] = x.key
+                    break
+
+        for ca in self.custom_attributes:
+            if 'key' not in ca:
+                self.module.fail_json(msg="Custom attribute %s does not exist for object type %s." % (ca.name, self.params['object_type']))
+
+    def set_custom_attribute(self):
+        changed = False
+
+        for ca in self.custom_attributes:
+            for x in self.obj.customValue:
+                if ca.key == x.key and ca.value != x.value:
+                    changed = True
+                    if not self.module.check_mode:
+                        self.content.customFieldsManager.SetField(entity=self.obj, key=ca.key, value=ca.value)
+
+        return {'changed': changed, 'failed': False}
+
+    def remove_custom_attribute(self):
+        changed = False
+
+        for ca in self.custom_attributes:
+            for x in self.obj.customValue:
+                if ca.key == x.key and x.value is not None:
+                    changed = True
+                    if not self.module.check_mode:
+                        self.content.customFieldsManager.SetField(entity=self.obj, key=ca.key, value=None)
+
+        return {'changed': changed, 'failed': False}
+
+
+def main():
+    argument_spec = vmware_argument_spec()
+    argument_spec.update(
+        custom_attributes=dict(
+            type='list',
+            required=True,
+            elements='dict',
+            options=dict(
+                name=dict(type='str', required=True),
+                value=dict(type='str', default=''),
+            )
+        ),
+        object_name=dict(type='str', required=True),
+        object_type=dict(type='str', required=True, choices=[
+            'Datacenter',
+            'Cluster',
+            'HostSystem',
+            'ResourcePool',
+            'Folder',
+            'VirtualMachine',
+            'DistributedVirtualSwitch',
+            'DistributedVirtualPortgroup',
+            'Datastore'
+        ]),
+        state=dict(type='str', default='present',
+                   choices=['absent', 'present']),
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    pyv = CustomAttributeManager(module)
+    results = {'changed': False, 'failed': False}
+
+    if module.params['state'] == "present":
+        results = pyv.set_custom_attributes()
+    elif module.params['state'] == "absent":
+        results = pyv.remove_custom_attributes()
+
+    module.exit_json(**results)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/vmware_custom_attribute_manager.py
+++ b/plugins/modules/vmware_custom_attribute_manager.py
@@ -46,15 +46,15 @@ options:
       - Type of the object the custom attribute is associated with.
     type: str
     choices:
-      - Datacenter
       - Cluster
+      - Datacenter
+      - Datastore
+      - DistributedVirtualPortgroup
+      - DistributedVirtualSwitch
+      - Folder
       - HostSystem
       - ResourcePool
-      - Folder
       - VirtualMachine
-      - DistributedVirtualSwitch
-      - DistributedVirtualPortgroup
-      - Datastore
     required: True
   state:
     description:
@@ -128,15 +128,15 @@ class CustomAttributeManager(PyVmomi):
         super(CustomAttributeManager, self).__init__(module)
 
         object_types_map = {
-            'Datacenter': vim.Datacenter,
             'Cluster': vim.ClusterComputeResource,
+            'Datacenter': vim.Datacenter,
+            'Datastore': vim.Datastore,
+            'DistributedVirtualPortgroup': vim.DistributedVirtualPortgroup,
+            'DistributedVirtualSwitch': vim.DistributedVirtualSwitch,
+            'Folder': vim.Folder,
             'HostSystem': vim.HostSystem,
             'ResourcePool': vim.ResourcePool,
-            'Folder': vim.Folder,
-            'VirtualMachine': vim.VirtualMachine,
-            'DistributedVirtualSwitch': vim.DistributedVirtualSwitch,
-            'DistributedVirtualPortgroup': vim.DistributedVirtualPortgroup,
-            'Datastore': vim.Datastore
+            'VirtualMachine': vim.VirtualMachine
         }
 
         self.object_type = object_types_map[self.params['object_type']]
@@ -204,15 +204,15 @@ def main():
         ),
         object_name=dict(type='str', required=True),
         object_type=dict(type='str', required=True, choices=[
-            'Datacenter',
             'Cluster',
+            'Datacenter',
+            'Datastore',
+            'DistributedVirtualPortgroup',
+            'DistributedVirtualSwitch',
+            'Folder',
             'HostSystem',
             'ResourcePool',
-            'Folder',
-            'VirtualMachine',
-            'DistributedVirtualSwitch',
-            'DistributedVirtualPortgroup',
-            'Datastore'
+            'VirtualMachine'
         ]),
         state=dict(type='str', default='present',
                    choices=['absent', 'present']),

--- a/plugins/modules/vmware_custom_attribute_manager.py
+++ b/plugins/modules/vmware_custom_attribute_manager.py
@@ -127,6 +127,9 @@ class CustomAttributeManager(PyVmomi):
     def __init__(self, module):
         super(CustomAttributeManager, self).__init__(module)
 
+        if not self.is_vcenter():
+            self.module.fail_json(msg="You have to connect to a vCenter server!")
+
         object_types_map = {
             'Cluster': vim.ClusterComputeResource,
             'Datacenter': vim.Datacenter,

--- a/tests/integration/targets/vmware_custom_attribute/aliases
+++ b/tests/integration/targets/vmware_custom_attribute/aliases
@@ -1,0 +1,3 @@
+cloud/vcenter
+needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_only

--- a/tests/integration/targets/vmware_custom_attribute/tasks/main.yml
+++ b/tests/integration/targets/vmware_custom_attribute/tasks/main.yml
@@ -1,0 +1,74 @@
+# Test code for the vmware_custom_attribute module.
+# Copyright: (c) 2022, Mario Lenz <@riolenz.de>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- import_role:
+    name: prepare_vmware_tests
+
+- name: add VM custom attribute definition
+  community.vmware.vmware_custom_attribute:
+    validate_certs: false
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    object_type: VirtualMachine
+    custom_attribute: sample_5
+    state: present
+  register: add_attrib_def
+
+- debug: var=add_attrib_def
+
+- assert:
+    that:
+      - add_attrib_def is changed
+
+- name: add attribute definition again
+  community.vmware.vmware_custom_attribute:
+    validate_certs: false
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    object_type: VirtualMachine
+    custom_attribute: sample_5
+    state: present
+  register: add_attrib_def
+
+- debug: var=add_attrib_def
+
+- assert:
+    that:
+      - not (add_attrib_def is changed)
+
+- name: remove attribute definition
+  community.vmware.vmware_custom_attribute:
+    validate_certs: false
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    object_type: VirtualMachine
+    custom_attribute: sample_5
+    state: absent
+  register: remove_attrib_def
+
+- debug: var=remove_attrib_def
+
+- assert:
+    that:
+      - remove_attrib_def is changed
+
+- name: remove attribute definition again
+  community.vmware.vmware_custom_attribute:
+    validate_certs: false
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    object_type: VirtualMachine
+    custom_attribute: sample_5
+    state: absent
+  register: remove_attrib_def
+
+- debug: var=remove_attrib_def
+
+- assert:
+    that:
+      - not (remove_attrib_def is changed)

--- a/tests/integration/targets/vmware_custom_attribute/tasks/main.yml
+++ b/tests/integration/targets/vmware_custom_attribute/tasks/main.yml
@@ -22,7 +22,7 @@
     that:
       - add_attrib_def is changed
 
-- name: add attribute definition again
+- name: add VM custom attribute definition again
   community.vmware.vmware_custom_attribute:
     validate_certs: false
     hostname: "{{ vcenter_hostname }}"
@@ -39,7 +39,7 @@
     that:
       - not (add_attrib_def is changed)
 
-- name: remove attribute definition
+- name: remove VM custom attribute definition
   community.vmware.vmware_custom_attribute:
     validate_certs: false
     hostname: "{{ vcenter_hostname }}"
@@ -56,13 +56,81 @@
     that:
       - remove_attrib_def is changed
 
-- name: remove attribute definition again
+- name: remove VM custom attribute definition again
   community.vmware.vmware_custom_attribute:
     validate_certs: false
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     object_type: VirtualMachine
+    custom_attribute: sample_5
+    state: absent
+  register: remove_attrib_def
+
+- debug: var=remove_attrib_def
+
+- assert:
+    that:
+      - not (remove_attrib_def is changed)
+
+- name: add Global custom attribute definition
+  community.vmware.vmware_custom_attribute:
+    validate_certs: false
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    object_type: Global
+    custom_attribute: sample_5
+    state: present
+  register: add_attrib_def
+
+- debug: var=add_attrib_def
+
+- assert:
+    that:
+      - add_attrib_def is changed
+
+- name: add Global custom attribute definition again
+  community.vmware.vmware_custom_attribute:
+    validate_certs: false
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    object_type: Global
+    custom_attribute: sample_5
+    state: present
+  register: add_attrib_def
+
+- debug: var=add_attrib_def
+
+- assert:
+    that:
+      - not (add_attrib_def is changed)
+
+- name: remove Global custom attribute definition
+  community.vmware.vmware_custom_attribute:
+    validate_certs: false
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    object_type: Global
+    custom_attribute: sample_5
+    state: absent
+  register: remove_attrib_def
+
+- debug: var=remove_attrib_def
+
+- assert:
+    that:
+      - remove_attrib_def is changed
+
+- name: remove Global custom attribute definition again
+  community.vmware.vmware_custom_attribute:
+    validate_certs: false
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    object_type: Global
     custom_attribute: sample_5
     state: absent
   register: remove_attrib_def

--- a/tests/integration/targets/vmware_custom_attribute_manager/aliases
+++ b/tests/integration/targets/vmware_custom_attribute_manager/aliases
@@ -1,0 +1,3 @@
+cloud/vcenter
+needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_custom_attribute_manager/tasks/main.yml
+++ b/tests/integration/targets/vmware_custom_attribute_manager/tasks/main.yml
@@ -95,7 +95,7 @@
     that:
       - guest_info_0002 is not changed
 
-- name: Remove custom attribute to the given virtual machine
+- name: Remove custom attribute from the given virtual machine
   community.vmware.vmware_custom_attribute_manager:
     validate_certs: false
     hostname: '{{ vcenter_hostname }}'
@@ -115,7 +115,7 @@
     that:
       - guest_info_0004 is changed
 
-- name: Remove custom attribute to the given virtual machine again
+- name: Remove custom attribute from the given virtual machine again
   community.vmware.vmware_custom_attribute_manager:
     validate_certs: false
     hostname: '{{ vcenter_hostname }}'
@@ -144,7 +144,7 @@
     object_name: "{{ esxi_hosts[0] }}"
     object_type: HostSystem
     state: present
-    attributes:
+    custom_attributes:
       - name: 'esx_attribute_1'
         value: 'esx_attribute_1_value'
       - name: 'esx_attribute_2'
@@ -166,7 +166,7 @@
     object_name: "{{ esxi_hosts[0] }}"
     object_type: HostSystem
     state: present
-    attributes:
+    custom_attributes:
       - name: 'esx_attribute_1'
         value: 'esx_attribute_1_value'
       - name: 'esx_attribute_2'
@@ -188,7 +188,7 @@
     object_name: "{{ esxi_hosts[0] }}"
     object_type: HostSystem
     state: absent
-    attributes:
+    custom_attributes:
       - name: 'esx_attribute_1'
       - name: 'esx_attribute_2'
   register: host_info_0003
@@ -208,7 +208,7 @@
     object_name: "{{ esxi_hosts[0] }}"
     object_type: HostSystem
     state: absent
-    attributes:
+    custom_attributes:
       - name: 'esx_attribute_1'
       - name: 'esx_attribute_2'
   register: host_info_0004

--- a/tests/integration/targets/vmware_custom_attribute_manager/tasks/main.yml
+++ b/tests/integration/targets/vmware_custom_attribute_manager/tasks/main.yml
@@ -1,0 +1,262 @@
+# Test code for the vmware_custom_attribute_manager module.
+# Copyright: (c) 2022, Mario Lenz <m@riolenz.de>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_attach_host: true
+    setup_datastore: true
+    setup_virtualmachines: true
+
+- name: Create custom attributes needed for tests
+  block:
+    - name: Add VM custom attribute 1
+      community.vmware.vmware_custom_attribute:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        object_type: VirtualMachine
+        custom_attribute: vm_attribute_1
+        state: present
+
+    - name: Add VM custom attribute 2
+      community.vmware.vmware_custom_attribute:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        object_type: VirtualMachine
+        custom_attribute: vm_attribute_2
+        state: present
+
+    - name: Add ESX custom attribute 1
+      community.vmware.vmware_custom_attribute:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        object_type: HostSystem
+        custom_attribute: esx_attribute_1
+        state: present
+
+    - name: Add ESX custom attribute 2
+      community.vmware.vmware_custom_attribute:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        object_type: HostSystem
+        custom_attribute: esx_attribute_2
+        state: present
+
+- name: Add custom attribute to the given virtual machine
+  community.vmware.vmware_custom_attribute_manager:
+    validate_certs: false
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    object_name: "{{ virtual_machines[0].name }}"
+    object_type: VirtualMachine
+    state: present
+    custom_attributes:
+      - name: 'vm_attribute_1'
+        value: 'vm_attribute_1_value'
+      - name: 'vm_attribute_2'
+        value: 'vm_attribute_2_value'
+  register: guest_info_0001
+
+- debug: var=guest_info_0001
+
+- assert:
+    that:
+      - guest_info_0001 is changed
+
+- name: Add custom attribute to the given virtual machine again
+  community.vmware.vmware_custom_attribute_manager:
+    validate_certs: false
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    object_name: "{{ virtual_machines[0].name }}"
+    object_type: VirtualMachine
+    state: present
+    custom_attributes:
+      - name: 'vm_attribute_1'
+        value: 'vm_attribute_1_value'
+      - name: 'vm_attribute_2'
+        value: 'vm_attribute_2_value'
+  register: guest_info_0002
+
+- debug: var=guest_info_0002
+
+- assert:
+    that:
+      - guest_info_0002 is not changed
+
+- name: Remove custom attribute to the given virtual machine
+  community.vmware.vmware_custom_attribute_manager:
+    validate_certs: false
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    object_name: "{{ virtual_machines[0].name }}"
+    object_type: VirtualMachine
+    state: absent
+    custom_attributes:
+      - name: 'vm_attribute_1'
+      - name: 'vm_attribute_2'
+  register: guest_info_0004
+
+- debug: var=guest_info_0004
+
+- assert:
+    that:
+      - guest_info_0004 is changed
+
+- name: Remove custom attribute to the given virtual machine again
+  community.vmware.vmware_custom_attribute_manager:
+    validate_certs: false
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    object_name: "{{ virtual_machines[0].name }}"
+    object_type: VirtualMachine
+    state: absent
+    custom_attributes:
+      - name: 'vm_attribute_1'
+      - name: 'vm_attribute_2'
+  register: guest_info_0005
+
+- debug: var=guest_info_0005
+
+- assert:
+    that:
+      - guest_info_0005 is not changed
+
+- name: Add custom attribute to the given ESXi host
+  community.vmware.vmware_custom_attribute_manager:
+    validate_certs: false
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    object_name: "{{ esxi_hosts[0] }}"
+    object_type: HostSystem
+    state: present
+    attributes:
+      - name: 'esx_attribute_1'
+        value: 'esx_attribute_1_value'
+      - name: 'esx_attribute_2'
+        value: 'esx_attribute_2_value'
+  register: host_info_0001
+
+- debug: var=host_info_0001
+
+- assert:
+    that:
+      - host_info_0001 is changed
+
+- name: Add custom attribute to the given ESXi host again
+  community.vmware.vmware_custom_attribute_manager:
+    validate_certs: false
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    object_name: "{{ esxi_hosts[0] }}"
+    object_type: HostSystem
+    state: present
+    attributes:
+      - name: 'esx_attribute_1'
+        value: 'esx_attribute_1_value'
+      - name: 'esx_attribute_2'
+        value: 'esx_attribute_2_value'
+  register: host_info_0002
+
+- debug: var=host_info_0002
+
+- assert:
+    that:
+      - host_info_0002 is not changed
+
+- name: Remove custom attribute from the given ESXi host
+  community.vmware.vmware_custom_attribute_manager:
+    validate_certs: false
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    object_name: "{{ esxi_hosts[0] }}"
+    object_type: HostSystem
+    state: absent
+    attributes:
+      - name: 'esx_attribute_1'
+      - name: 'esx_attribute_2'
+  register: host_info_0003
+
+- debug: var=host_info_0003
+
+- assert:
+    that:
+      - host_info_0003 is changed
+
+- name: Remove custom attribute from the given ESXi host again
+  community.vmware.vmware_custom_attribute_manager:
+    validate_certs: false
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    object_name: "{{ esxi_hosts[0] }}"
+    object_type: HostSystem
+    state: absent
+    attributes:
+      - name: 'esx_attribute_1'
+      - name: 'esx_attribute_2'
+  register: host_info_0004
+
+- debug: var=host_info_0004
+
+- assert:
+    that:
+      - host_info_0004 is not changed
+
+- name: Clean up custom attributes
+  block:
+    - name: Remove VM custom attribute 1
+      community.vmware.vmware_custom_attribute:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        object_type: VirtualMachine
+        custom_attribute: vm_attribute_1
+        state: absent
+
+    - name: Remove VM custom attribute 2
+      community.vmware.vmware_custom_attribute:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        object_type: VirtualMachine
+        custom_attribute: vm_attribute_2
+        state: absent
+
+    - name: Remove ESX custom attribute 1
+      community.vmware.vmware_custom_attribute:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        object_type: HostSystem
+        custom_attribute: esx_attribute_1
+        state: absent
+
+    - name: Remove ESX custom attribute 2
+      community.vmware.vmware_custom_attribute:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        object_type: HostSystem
+        custom_attribute: esx_attribute_2
+        state: absent

--- a/tests/integration/targets/vmware_custom_attribute_manager/tasks/main.yml
+++ b/tests/integration/targets/vmware_custom_attribute_manager/tasks/main.yml
@@ -11,6 +11,16 @@
 
 - name: Create custom attributes needed for tests
   block:
+    - name: Add Global custom attribute
+      community.vmware.vmware_custom_attribute:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        object_type: Global
+        custom_attribute: global_attribute
+        state: present
+
     - name: Add VM custom attribute 1
       community.vmware.vmware_custom_attribute:
         validate_certs: false
@@ -65,6 +75,8 @@
         value: 'vm_attribute_1_value'
       - name: 'vm_attribute_2'
         value: 'vm_attribute_2_value'
+      - name: 'global_attribute'
+        value: 'global_attribute_value'
   register: guest_info_0001
 
 - debug: var=guest_info_0001
@@ -87,6 +99,8 @@
         value: 'vm_attribute_1_value'
       - name: 'vm_attribute_2'
         value: 'vm_attribute_2_value'
+      - name: 'global_attribute'
+        value: 'global_attribute_value'
   register: guest_info_0002
 
 - debug: var=guest_info_0002
@@ -107,6 +121,7 @@
     custom_attributes:
       - name: 'vm_attribute_1'
       - name: 'vm_attribute_2'
+      - name: 'global_attribute'
   register: guest_info_0004
 
 - debug: var=guest_info_0004
@@ -127,6 +142,7 @@
     custom_attributes:
       - name: 'vm_attribute_1'
       - name: 'vm_attribute_2'
+      - name: 'global_attribute'
   register: guest_info_0005
 
 - debug: var=guest_info_0005
@@ -221,6 +237,16 @@
 
 - name: Clean up custom attributes
   block:
+    - name: Remove Global custom attribute
+      community.vmware.vmware_custom_attribute:
+        validate_certs: false
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        object_type: Global
+        custom_attribute: global_attribute
+        state: present
+
     - name: Remove VM custom attribute 1
       community.vmware.vmware_custom_attribute:
         validate_certs: false

--- a/tests/integration/targets/vmware_custom_attribute_manager/tasks/main.yml
+++ b/tests/integration/targets/vmware_custom_attribute_manager/tasks/main.yml
@@ -245,7 +245,7 @@
         password: "{{ vcenter_password }}"
         object_type: Global
         custom_attribute: global_attribute
-        state: present
+        state: absent
 
     - name: Remove VM custom attribute 1
       community.vmware.vmware_custom_attribute:


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1688

##### SUMMARY
Fixes #1250 

There's a generic module for gathering custom attribute info from all object types.

But there are no generic modules to _manage_  custom attributes on all object types. Just modules to manage custom attributes on VMs and ESXi hosts.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
vmware_custom_attribute
vmware_custom_attribute_manager

##### ADDITIONAL INFORMATION
