### PR TITLE
vmware_host_lockdown: VmwareLockdownManager object has no attribute warn

### DIFF
--- a/changelogs/fragments/1540-vmware_host_lockdown.yml
+++ b/changelogs/fragments/1540-vmware_host_lockdown.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_host_lockdown - Fix issue `'VmwareLockdownManager' object has no attribute 'warn'` (https://github.com/ansible-collections/community.vmware/pull/1540).

--- a/plugins/modules/vmware_host_lockdown.py
+++ b/plugins/modules/vmware_host_lockdown.py
@@ -149,10 +149,10 @@ class VmwareLockdownManager(PyVmomi):
         desired_state = self.params.get('state')
 
         if desired_state == 'present':
-            self.warn("'present' will be removed in a future version. Please use 'normal' instead.")
+            self.module.warn("'present' will be removed in a future version. Please use 'normal' instead.")
             desired_state = 'normal'
         elif desired_state == 'absent':
-            self.warn("'absent' will be removed in a future version. Please use 'disabled' instead.")
+            self.module.warn("'absent' will be removed in a future version. Please use 'disabled' instead.")
             desired_state = 'disabled'
 
         for host in self.hosts:


### PR DESCRIPTION
##### SUMMARY
Fix `AttributeError: 'VmwareLockdownManager' object has no attribute 'warn'` in `vmware_host_lockdown`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_host_lockdown

##### ADDITIONAL INFORMATION
https://github.com/ansible-collections/community.vmware/blob/9ed11829dfeac42e3d1b32536f2cb2a51c805c83/plugins/modules/vmware_host_lockdown.py#L152

https://github.com/ansible-collections/community.vmware/blob/9ed11829dfeac42e3d1b32536f2cb2a51c805c83/plugins/modules/vmware_host_lockdown.py#L155