### PR TITLE
vmware_object_custom_attributes_info: Support the global type of custom attribute

### DIFF
--- a/changelogs/fragments/1541-vmware_object_custom_attributes_info.yml
+++ b/changelogs/fragments/1541-vmware_object_custom_attributes_info.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_object_custom_attributes_info - Fixed an issue that has occurred an error if a custom attribute is the global type(https://github.com/ansible-collections/community.vmware/pull/1541).

--- a/plugins/modules/vmware_object_custom_attributes_info.py
+++ b/plugins/modules/vmware_object_custom_attributes_info.py
@@ -156,7 +156,7 @@ class VmwareCustomAttributesInfo(PyVmomi):
         for key, value in available_fields.items():
             attribute_result = {
                 'attribute': value['name'],
-                'type': self.to_json(value['type']).replace('vim.', ''),
+                'type': self.to_json(value['type']).replace('vim.', '') if value['type'] is not None else 'Global',
                 'key': key,
                 'value': None
             }

--- a/plugins/modules/vmware_object_custom_attributes_info.py
+++ b/plugins/modules/vmware_object_custom_attributes_info.py
@@ -111,6 +111,10 @@ from ansible_collections.community.vmware.plugins.module_utils.vmware import PyV
 class VmwareCustomAttributesInfo(PyVmomi):
     def __init__(self, module):
         super(VmwareCustomAttributesInfo, self).__init__(module)
+
+        if not self.is_vcenter():
+            self.module.fail_json(msg="You have to connect to a vCenter server!")
+
         self.object_type = self.params['object_type']
         self.object_name = self.params['object_name']
         self.moid = self.params['moid']

--- a/tests/integration/targets/vmware_object_custom_attributes_info/tasks/cleanup.yml
+++ b/tests/integration/targets/vmware_object_custom_attributes_info/tasks/cleanup.yml
@@ -1,0 +1,41 @@
+# Test code for the vmware_object_custom_attributes_info module.
+# Copyright: (c) 2022, sky-joker <sky.jokerxx@gmail.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Remove VM custom attribute definition
+  community.vmware.vmware_custom_attribute:
+    validate_certs: false
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    object_type: VirtualMachine
+    custom_attribute: "{{ item }}"
+    state: absent
+  loop:
+    - vm_example01
+    - vm_example02
+
+- name: Remove VM custom attribute definition for global type
+  community.vmware.vmware_custom_attribute:
+    validate_certs: false
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    object_type: Global
+    custom_attribute: "{{ item }}"
+    state: absent
+  loop:
+    - vm_example03_global
+
+- name: Remove ESXi custom attribute definition
+  community.vmware.vmware_custom_attribute:
+    validate_certs: false
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    object_type: HostSystem
+    custom_attribute: "{{ item }}"
+    state: absent
+  loop:
+    - esxi_example01
+    - esxi_example02

--- a/tests/integration/targets/vmware_object_custom_attributes_info/tasks/main.yml
+++ b/tests/integration/targets/vmware_object_custom_attributes_info/tasks/main.yml
@@ -6,7 +6,7 @@
     name: prepare_vmware_tests
   vars:
     setup_attach_host: true
-    setup_datastore: true 
+    setup_datastore: true
     setup_virtualmachines: true
 
 - name: Include tasks pre.yml
@@ -14,3 +14,6 @@
 
 - name: Include tasks vmware_object_custom_attributes_info_tests.yml
   include_tasks: vmware_object_custom_attributes_info_tests.yml
+
+- name: Include tasks cleanup
+  include_tasks: cleanup.yml

--- a/tests/integration/targets/vmware_object_custom_attributes_info/tasks/pre.yml
+++ b/tests/integration/targets/vmware_object_custom_attributes_info/tasks/pre.yml
@@ -2,28 +2,70 @@
 # Copyright: (c) 2021, sky-joker <sky.jokerxx@gmail.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+- name: Add VM custom attribute definition
+  community.vmware.vmware_custom_attribute:
+    validate_certs: false
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    object_type: VirtualMachine
+    custom_attribute: "{{ item }}"
+    state: present
+  loop:
+    - vm_example01
+    - vm_example02
+
+- name: Add VM custom attribute definition for global type
+  community.vmware.vmware_custom_attribute:
+    validate_certs: false
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    object_type: Global
+    custom_attribute: "{{ item }}"
+    state: present
+  loop:
+    - vm_example03_global
+
+- name: Add ESXi custom attribute definition
+  community.vmware.vmware_custom_attribute:
+    validate_certs: false
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    object_type: HostSystem
+    custom_attribute: "{{ item }}"
+    state: present
+  loop:
+    - esxi_example01
+    - esxi_example02
+
 - name: Add custom attributes to a virtual machine
-  community.vmware.vmware_guest_custom_attributes:
+  community.vmware.vmware_custom_attribute_manager:
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     validate_certs: false
-    name: "{{ virtual_machines.0.name }}"
-    attributes:
+    object_name: "{{ virtual_machines.0.name }}"
+    object_type: VirtualMachine
+    custom_attributes:
       - name: vm_example01
         value: test1
       - name: vm_example02
         value: test2
+      - name: vm_example03_global
+        value: test3
     state: present
 
 - name: Add custom attributes to an ESXi
-  community.vmware.vmware_host_custom_attributes:
+  community.vmware.vmware_custom_attribute_manager:
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     validate_certs: false
-    esxi_hostname: "{{ esxi1 }}"
-    attributes:
+    object_name: "{{ esxi1 }}"
+    object_type: HostSystem
+    custom_attributes:
       - name: esxi_example01
         value: test1
       - name: esxi_example02

--- a/tests/integration/targets/vmware_object_custom_attributes_info/tasks/vmware_object_custom_attributes_info_tests.yml
+++ b/tests/integration/targets/vmware_object_custom_attributes_info/tasks/vmware_object_custom_attributes_info_tests.yml
@@ -16,9 +16,19 @@
   assert:
     that:
       - vm_custom_attributes_result.custom_attributes | selectattr('attribute', 'equalto', 'vm_example01')
+      - vm_custom_attributes_result.custom_attributes | selectattr('attribute', 'equalto', 'vm_example01')
+        | selectattr('type', 'equalto', 'VirtualMachine')
       - vm_custom_attributes_result.custom_attributes | selectattr('value', 'equalto', 'test1')
+
       - vm_custom_attributes_result.custom_attributes | selectattr('attribute', 'equalto', 'vm_example02')
+      - vm_custom_attributes_result.custom_attributes | selectattr('attribute', 'equalto', 'vm_example02')
+        | selectattr('type', 'equalto', 'VirtualMachine')
       - vm_custom_attributes_result.custom_attributes | selectattr('value', 'equalto', 'test2')
+
+      - vm_custom_attributes_result.custom_attributes | selectattr('attribute', 'equalto', 'vm_example03_global')
+      - vm_custom_attributes_result.custom_attributes | selectattr('attribute', 'equalto', 'vm_example03_global')
+        | selectattr('type', 'equalto', 'Global')
+      - vm_custom_attributes_result.custom_attributes | selectattr('value', 'equalto', 'test3')
 
 - name: Gather custom attributes of an ESXi
   community.vmware.vmware_object_custom_attributes_info:
@@ -34,8 +44,13 @@
   assert:
     that:
       - esxi_custom_attributes_result.custom_attributes | selectattr('attribute', 'equalto', 'esxi_example01')
+      - esxi_custom_attributes_result.custom_attributes | selectattr('attribute', 'equalto', 'esxi_example01')
+       | selectattr('type', 'equalto', 'HostSystem')
       - esxi_custom_attributes_result.custom_attributes | selectattr('value', 'equalto', 'test1')
+
       - esxi_custom_attributes_result.custom_attributes | selectattr('attribute', 'equalto', 'esxi_example02')
+      - esxi_custom_attributes_result.custom_attributes | selectattr('attribute', 'equalto', 'esxi_example02')
+       | selectattr('type', 'equalto', 'HostSystem')
       - esxi_custom_attributes_result.custom_attributes | selectattr('value', 'equalto', 'test2')
 
 - name: Gather custom attributes of a virtual machine with moid
@@ -51,10 +66,20 @@
 - name: Make sure if custom attributes exist
   assert:
     that:
-      - vm_custom_attributes_with_moid_result.custom_attributes | selectattr('attribute', 'equalto', 'vm_example01')
-      - vm_custom_attributes_with_moid_result.custom_attributes | selectattr('value', 'equalto', 'test1')
-      - vm_custom_attributes_with_moid_result.custom_attributes | selectattr('attribute', 'equalto', 'vm_example02')
-      - vm_custom_attributes_with_moid_result.custom_attributes | selectattr('value', 'equalto', 'test2')
+      - vm_custom_attributes_result.custom_attributes | selectattr('attribute', 'equalto', 'vm_example01')
+      - vm_custom_attributes_result.custom_attributes | selectattr('attribute', 'equalto', 'vm_example01')
+        | selectattr('type', 'equalto', 'VirtualMachine')
+      - vm_custom_attributes_result.custom_attributes | selectattr('value', 'equalto', 'test1')
+
+      - vm_custom_attributes_result.custom_attributes | selectattr('attribute', 'equalto', 'vm_example02')
+      - vm_custom_attributes_result.custom_attributes | selectattr('attribute', 'equalto', 'vm_example02')
+        | selectattr('type', 'equalto', 'VirtualMachine')
+      - vm_custom_attributes_result.custom_attributes | selectattr('value', 'equalto', 'test2')
+
+      - vm_custom_attributes_result.custom_attributes | selectattr('attribute', 'equalto', 'vm_example03_global')
+      - vm_custom_attributes_result.custom_attributes | selectattr('attribute', 'equalto', 'vm_example03_global')
+        | selectattr('type', 'equalto', 'Global')
+      - vm_custom_attributes_result.custom_attributes | selectattr('value', 'equalto', 'test3')
 
 - name: Gather custom attributes of an ESXi with moid
   community.vmware.vmware_object_custom_attributes_info:
@@ -70,6 +95,11 @@
   assert:
     that:
       - esxi_custom_attributes_result.custom_attributes | selectattr('attribute', 'equalto', 'esxi_example01')
+      - esxi_custom_attributes_result.custom_attributes | selectattr('attribute', 'equalto', 'esxi_example01')
+       | selectattr('type', 'equalto', 'HostSystem')
       - esxi_custom_attributes_result.custom_attributes | selectattr('value', 'equalto', 'test1')
+
       - esxi_custom_attributes_result.custom_attributes | selectattr('attribute', 'equalto', 'esxi_example02')
+      - esxi_custom_attributes_result.custom_attributes | selectattr('attribute', 'equalto', 'esxi_example02')
+       | selectattr('type', 'equalto', 'HostSystem')
       - esxi_custom_attributes_result.custom_attributes | selectattr('value', 'equalto', 'test2')


### PR DESCRIPTION
##### SUMMARY

Fix the bug that occurs the error if the custom attribute is the global type.

fixes: https://github.com/ansible-collections/community.vmware/issues/1477

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

changelogs/fragments/1541-vmware_object_custom_attributes_info.yml
plugins/modules/vmware_object_custom_attributes_info.py
tests/integration/targets/vmware_object_custom_attributes_info/tasks/main.yml
tests/integration/targets/vmware_object_custom_attributes_info/tasks/pre.yml
tests/integration/targets/vmware_object_custom_attributes_info/tasks/vmware_object_custom_attributes_info_tests.yml
tests/integration/targets/vmware_object_custom_attributes_info/tasks/cleanup.yml

##### ADDITIONAL INFORMATION

tested on VCSA 7.0
