### PR TITLE
vmware_cluster_drs - Add predictive DRS Setting

### DIFF
--- a/changelogs/fragments/1542-vmware_cluster_drs.yaml
+++ b/changelogs/fragments/1542-vmware_cluster_drs.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - vmware_cluster_drs - Add predictive DRS Setting (https://github.com/ansible-collections/community.vmware/pull/1542).
+  - vmware_cluster_drs - Add predictive DRS Setting and invert the drs_vmotion_rate => same like in the vcenter (https://github.com/ansible-collections/community.vmware/pull/1542).

--- a/changelogs/fragments/1542-vmware_cluster_drs.yaml
+++ b/changelogs/fragments/1542-vmware_cluster_drs.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_cluster_drs - Add predictive DRS Setting

--- a/changelogs/fragments/1542-vmware_cluster_drs.yaml
+++ b/changelogs/fragments/1542-vmware_cluster_drs.yaml
@@ -1,2 +1,5 @@
 minor_changes:
-  - vmware_cluster_drs - Add predictive DRS Setting and invert the drs_vmotion_rate => same like in the vcenter (https://github.com/ansible-collections/community.vmware/pull/1542).
+  - vmware_cluster_drs - Add predictive DRS Setting (https://github.com/ansible-collections/community.vmware/pull/1542).
+bugfixes:
+  - vmware_cluster_drs - Fix drs_vmotion_rate so that the value corresponds to the vCenter UI.
+    Previously, choosing 1 / 2 configured a migration threshold of 5 / 4 and vice versa (https://github.com/ansible-collections/community.vmware/pull/1542).

--- a/changelogs/fragments/1542-vmware_cluster_drs.yaml
+++ b/changelogs/fragments/1542-vmware_cluster_drs.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - vmware_cluster_drs - Add predictive DRS Setting
+  - vmware_cluster_drs - Add predictive DRS Setting (https://github.com/ansible-collections/community.vmware/pull/1542).

--- a/plugins/modules/vmware_cluster_drs.py
+++ b/plugins/modules/vmware_cluster_drs.py
@@ -58,6 +58,8 @@ options:
     drs_vmotion_rate:
       description:
       - Threshold for generated ClusterRecommendations.
+      - 1: lowest
+      - 5: highest
       type: int
       default: 3
       choices: [ 1, 2, 3, 4, 5 ]
@@ -137,6 +139,7 @@ class VMwareCluster(PyVmomi):
         self.enable_drs = module.params['enable']
         self.datacenter = None
         self.cluster = None
+        self.drs_vmotion_rate = [5, 4, 3, 2, 1][self.params.get('drs_vmotion_rate') -1]
 
         self.datacenter = find_datacenter_by_name(self.content, self.datacenter_name)
         if self.datacenter is None:
@@ -162,7 +165,7 @@ class VMwareCluster(PyVmomi):
         if drs_config.enabled != self.enable_drs or \
                 drs_config.enableVmBehaviorOverrides != self.params.get('drs_enable_vm_behavior_overrides') or \
                 drs_config.defaultVmBehavior != self.params.get('drs_default_vm_behavior') or \
-                drs_config.vmotionRate != self.params.get('drs_vmotion_rate') or \
+                drs_config.vmotionRate != self.drs_vmotion_rate or \
                 self.cluster.configurationEx.proactiveDrsConfig.enabled != self.params.get('predictive_drs'):
             return True
 
@@ -185,7 +188,7 @@ class VMwareCluster(PyVmomi):
                 cluster_config_spec.drsConfig.enabled = self.enable_drs
                 cluster_config_spec.drsConfig.enableVmBehaviorOverrides = self.params.get('drs_enable_vm_behavior_overrides')
                 cluster_config_spec.drsConfig.defaultVmBehavior = self.params.get('drs_default_vm_behavior')
-                cluster_config_spec.drsConfig.vmotionRate = self.params.get('drs_vmotion_rate')
+                cluster_config_spec.drsConfig.vmotionRate = self.drs_vmotion_rate
                 cluster_config_spec.proactiveDrsConfig.enabled = self.params.get('predictive_drs')
 
                 if self.changed_advanced_settings:

--- a/plugins/modules/vmware_cluster_drs.py
+++ b/plugins/modules/vmware_cluster_drs.py
@@ -67,6 +67,7 @@ options:
       default: {}
       type: dict
     predictive_drs:
+      version_added: '3.3.0'
       description:
       - In addition to real-time metrics, DRS will respond to forecasted metrics provided by vRealize Operations Manager.
       - You must also configure Predictive DRS in a version of vRealize Operations that supports this feature.

--- a/plugins/modules/vmware_cluster_drs.py
+++ b/plugins/modules/vmware_cluster_drs.py
@@ -66,9 +66,14 @@ options:
       - A dictionary of advanced DRS settings.
       default: {}
       type: dict
+    predictive_drs:
+      description:
+      - In addition to real-time metrics, DRS will respond to forecasted metrics provided by vRealize Operations Manager.
+      - You must also configure Predictive DRS in a version of vRealize Operations that supports this feature.
+      type: bool
+      default: False
 extends_documentation_fragment:
 - community.vmware.vmware.documentation
-
 '''
 
 EXAMPLES = r'''
@@ -81,7 +86,6 @@ EXAMPLES = r'''
     cluster_name: cluster
     enable: true
   delegate_to: localhost
-
 - name: Enable DRS and distribute a more even number of virtual machines across hosts for availability
   community.vmware.vmware_cluster_drs:
     hostname: '{{ vcenter_hostname }}'
@@ -93,7 +97,6 @@ EXAMPLES = r'''
     advanced_settings:
       'TryBalanceVmsPerHost': '1'
   delegate_to: localhost
-
 - name: Enable DRS and set default VM behavior to partially automated
   community.vmware.vmware_cluster_drs:
     hostname: "{{ vcenter_hostname }}"
@@ -153,14 +156,14 @@ class VMwareCluster(PyVmomi):
         """
         Check DRS configuration diff
         Returns: True if there is diff, else False
-
         """
         drs_config = self.cluster.configurationEx.drsConfig
 
         if drs_config.enabled != self.enable_drs or \
                 drs_config.enableVmBehaviorOverrides != self.params.get('drs_enable_vm_behavior_overrides') or \
                 drs_config.defaultVmBehavior != self.params.get('drs_default_vm_behavior') or \
-                drs_config.vmotionRate != self.params.get('drs_vmotion_rate'):
+                drs_config.vmotionRate != self.params.get('drs_vmotion_rate') or \
+                self.cluster.configurationEx.proactiveDrsConfig.enabled != self.params.get('predictive_drs'):
             return True
 
         if self.changed_advanced_settings:
@@ -171,7 +174,6 @@ class VMwareCluster(PyVmomi):
     def configure_drs(self):
         """
         Manage DRS configuration
-
         """
         changed, result = False, None
 
@@ -179,10 +181,12 @@ class VMwareCluster(PyVmomi):
             if not self.module.check_mode:
                 cluster_config_spec = vim.cluster.ConfigSpecEx()
                 cluster_config_spec.drsConfig = vim.cluster.DrsConfigInfo()
+                cluster_config_spec.proactiveDrsConfig = vim.cluster.ProactiveDrsConfigInfo()
                 cluster_config_spec.drsConfig.enabled = self.enable_drs
                 cluster_config_spec.drsConfig.enableVmBehaviorOverrides = self.params.get('drs_enable_vm_behavior_overrides')
                 cluster_config_spec.drsConfig.defaultVmBehavior = self.params.get('drs_default_vm_behavior')
                 cluster_config_spec.drsConfig.vmotionRate = self.params.get('drs_vmotion_rate')
+                cluster_config_spec.proactiveDrsConfig.enabled = self.params.get('predictive_drs')
 
                 if self.changed_advanced_settings:
                     cluster_config_spec.drsConfig.option = self.changed_advanced_settings
@@ -220,6 +224,7 @@ def main():
                               choices=[1, 2, 3, 4, 5],
                               default=3),
         advanced_settings=dict(type='dict', default=dict(), required=False),
+        predictive_drs=dict(type='bool', default=False),
     ))
 
     module = AnsibleModule(

--- a/plugins/modules/vmware_cluster_drs.py
+++ b/plugins/modules/vmware_cluster_drs.py
@@ -57,9 +57,7 @@ options:
       choices: [ fullyAutomated, manual, partiallyAutomated ]
     drs_vmotion_rate:
       description:
-      - Threshold for generated ClusterRecommendations.
-      - 1: lowest
-      - 5: highest
+      - Threshold for generated ClusterRecommendations ranging from 1 (lowest) to 5 (highest).
       type: int
       default: 3
       choices: [ 1, 2, 3, 4, 5 ]

--- a/plugins/modules/vmware_cluster_drs.py
+++ b/plugins/modules/vmware_cluster_drs.py
@@ -139,7 +139,7 @@ class VMwareCluster(PyVmomi):
         self.enable_drs = module.params['enable']
         self.datacenter = None
         self.cluster = None
-        self.drs_vmotion_rate = [5, 4, 3, 2, 1][self.params.get('drs_vmotion_rate') -1]
+        self.drs_vmotion_rate = [5, 4, 3, 2, 1][self.params.get('drs_vmotion_rate') - 1]
 
         self.datacenter = find_datacenter_by_name(self.content, self.datacenter_name)
         if self.datacenter is None:

--- a/tests/integration/targets/vmware_cluster_drs/tasks/main.yml
+++ b/tests/integration/targets/vmware_cluster_drs/tasks/main.yml
@@ -95,6 +95,51 @@
     that:
       - not change_balance_vms_again.changed
 
+- name: Try to decativate already off predictive drs setting (check-mode)
+  vmware_cluster_drs: &change_predictive_drs
+    validate_certs: false
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter_name: "{{ dc1 }}"
+    cluster_name: test_cluster_drs
+    enable: true
+    predictive_drs: false
+  check_mode: true
+  register: change_balance_vms_check
+
+- assert:
+    that:
+      - not change_balance_vms_check.changed
+
+- name: Try to activate prdicteive drs setting (check-mode)
+  vmware_cluster_drs: *change_predictive_drs
+    predictive_drs: true
+  check_mode: true
+  register: change_balance_vms_check
+
+- assert:
+    that:
+      - change_balance_vms_check.changed
+
+- name: Try to decativate already off predictive drs setting
+  vmware_cluster_drs: *change_predictive_drs
+    predictive_drs: false
+  register: change_balance_vms_check
+
+- assert:
+    that:
+      - not change_balance_vms_check.changed
+
+- name: Try to acativate predictive drs setting 
+  vmware_cluster_drs: *change_predictive_drs
+    predictive_drs: true
+  register: change_balance_vms_check
+
+- assert:
+    that:
+      - change_balance_vms_check.changed
+
 # Delete test cluster
 - name: Delete test cluster
   vmware_cluster:

--- a/tests/integration/targets/vmware_cluster_drs/tasks/main.yml
+++ b/tests/integration/targets/vmware_cluster_drs/tasks/main.yml
@@ -121,7 +121,7 @@
     datacenter_name: "{{ dc1 }}"
     cluster_name: test_cluster_drs
     enable: true
-    predictive_drs: false
+    predictive_drs: true
   check_mode: true
   register: change_predictive_drs_check
 

--- a/tests/integration/targets/vmware_cluster_drs/tasks/main.yml
+++ b/tests/integration/targets/vmware_cluster_drs/tasks/main.yml
@@ -95,8 +95,8 @@
     that:
       - not change_balance_vms_again.changed
 
-- name: Try to decativate already off predictive drs setting (check-mode)
-  vmware_cluster_drs: &change_predictive_drs
+- name: Try to deactivate already off predictive drs setting (check-mode)
+  vmware_cluster_drs: &change_predictive_drs_deactivate
     validate_certs: false
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
@@ -106,39 +106,44 @@
     enable: true
     predictive_drs: false
   check_mode: true
-  register: change_balance_vms_check
+  register: change_predictive_drs_check
 
 - assert:
     that:
-      - not change_balance_vms_check.changed
+      - not change_predictive_drs_check.changed
 
-- name: Try to activate prdicteive drs setting (check-mode)
-  vmware_cluster_drs: *change_predictive_drs
-    predictive_drs: true
-  check_mode: true
-  register: change_balance_vms_check
-
-- assert:
-    that:
-      - change_balance_vms_check.changed
-
-- name: Try to decativate already off predictive drs setting
-  vmware_cluster_drs: *change_predictive_drs
+- name: Try to activate predictive drs setting (check-mode)
+  vmware_cluster_drs: &change_predictive_drs_activate
+    validate_certs: false
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter_name: "{{ dc1 }}"
+    cluster_name: test_cluster_drs
+    enable: true
     predictive_drs: false
-  register: change_balance_vms_check
+  check_mode: true
+  register: change_predictive_drs_check
 
 - assert:
     that:
-      - not change_balance_vms_check.changed
+      - change_predictive_drs_check.changed
 
-- name: Try to acativate predictive drs setting 
-  vmware_cluster_drs: *change_predictive_drs
-    predictive_drs: true
-  register: change_balance_vms_check
+- name: Try to deactivate already off predictive drs setting
+  vmware_cluster_drs: *change_predictive_drs_deactivate
+  register: change_predictive_drs_check
 
 - assert:
     that:
-      - change_balance_vms_check.changed
+      - not change_predictive_drs_check.changed
+
+- name: Try to activate predictive drs setting 
+  vmware_cluster_drs: *change_predictive_drs_activate
+  register: change_predictive_drs_check
+
+- assert:
+    that:
+      - change_predictive_drs_check.changed
 
 # Delete test cluster
 - name: Delete test cluster


### PR DESCRIPTION
##### SUMMARY
Add predictive DRS Setting
And invert drs_vmotion_rate => same like in the vCenter


##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_cluster_drs

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
