### PR TITLE
vmware_guest_boot_manager: Add a new parameter 'boot_hdd_name' to specify the boot disk name

### DIFF
--- a/changelogs/fragments/1543-vmware_guest_boot_manager.yml
+++ b/changelogs/fragments/1543-vmware_guest_boot_manager.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_guest_boot_manager - Add a new parameter boot_hdd_name to specify the boot disk name(https://github.com/ansible-collections/community.vmware/pull/1543).

--- a/changelogs/fragments/vmware_guest_boot_manager.yml
+++ b/changelogs/fragments/vmware_guest_boot_manager.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - vmware_guest_boot_manager - Add a new parameter boot_hdd_name to specify the boot disk name(https://github.com/ansible-collections/community.vmware/pull/).

--- a/changelogs/fragments/vmware_guest_boot_manager.yml
+++ b/changelogs/fragments/vmware_guest_boot_manager.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_guest_boot_manager - Add a new parameter boot_hdd_name to specify the boot disk name(https://github.com/ansible-collections/community.vmware/pull/).

--- a/plugins/modules/vmware_guest_boot_manager.py
+++ b/plugins/modules/vmware_guest_boot_manager.py
@@ -39,40 +39,41 @@ options:
      - Whether to use the VMware instance UUID rather than the BIOS UUID.
      default: false
      type: bool
-   boot_order:
-     description:
-     - List of the boot devices.
-     default: []
-     type: list
-     elements: str
    name_match:
      description:
      - If multiple virtual machines matching the name, use the first or last found.
      default: 'first'
      choices: ['first', 'last']
      type: str
+   boot_order:
+     description:
+     - List of the boot devices.
+     default: []
+     type: list
+     elements: str
+   boot_hdd_name:
+     description:
+     - Name of disk to be set as boot disk, which is case sensitive, e.g., 'Hard disk 1'.
+     - This parameter is optional, if not set, will use the first virtual disk found in VM device list.
+     type: str
    boot_delay:
      description:
      - Delay in milliseconds before starting the boot sequence.
-     default: 0
      type: int
    enter_bios_setup:
      description:
      - If set to C(True), the virtual machine automatically enters BIOS setup the next time it boots.
      - The virtual machine resets this flag, so that the machine boots proceeds normally.
      type: 'bool'
-     default: False
    boot_retry_enabled:
      description:
      - If set to C(True), the virtual machine that fails to boot, will try to boot again after C(boot_retry_delay) is expired.
      - If set to C(False), the virtual machine waits indefinitely for user intervention.
      type: 'bool'
-     default: False
    boot_retry_delay:
      description:
      - Specify the time in milliseconds between virtual machine boot failure and subsequent attempt to boot again.
      - If set, will automatically set C(boot_retry_enabled) to C(True) as this parameter is required.
-     default: 0
      type: int
    boot_firmware:
      description:
@@ -229,11 +230,14 @@ class VmBootManager(PyVmomi):
         return results
 
     def ensure(self):
-        self._get_vm()
-
+        boot_order_list = []
+        change_needed = False
+        kwargs = dict()
+        previous_boot_disk = None
         valid_device_strings = ['cdrom', 'disk', 'ethernet', 'floppy']
 
-        boot_order_list = []
+        self._get_vm()
+
         for device_order in self.params.get('boot_order'):
             if device_order not in valid_device_strings:
                 self.module.fail_json(msg="Invalid device found [%s], please specify device from ['%s']" % (device_order,
@@ -243,7 +247,13 @@ class VmBootManager(PyVmomi):
                 if first_cdrom:
                     boot_order_list.append(vim.vm.BootOptions.BootableCdromDevice())
             elif device_order == 'disk':
-                first_hdd = [device for device in self.vm.config.hardware.device if isinstance(device, vim.vm.device.VirtualDisk)]
+                if not self.params.get('boot_hdd_name'):
+                    first_hdd = [device for device in self.vm.config.hardware.device if isinstance(device, vim.vm.device.VirtualDisk)]
+                else:
+                    first_hdd = [device for device in self.vm.config.hardware.device if isinstance(device, vim.vm.device.VirtualDisk)
+                                 and device.deviceInfo.label == self.params.get('boot_hdd_name')]
+                    if not first_hdd:
+                        self.module.fail_json(msg="Not found virtual disk with disk label '%d'" % (self.params.get('boot_hdd_name')))
                 if first_hdd:
                     boot_order_list.append(vim.vm.BootOptions.BootableDiskDevice(deviceKey=first_hdd[0].key))
             elif device_order == 'ethernet':
@@ -255,8 +265,16 @@ class VmBootManager(PyVmomi):
                 if first_floppy:
                     boot_order_list.append(vim.vm.BootOptions.BootableFloppyDevice())
 
-        change_needed = False
-        kwargs = dict()
+        # Get previous boot disk name when boot_hdd_name is set
+        if self.params.get('boot_hdd_name'):
+            for i in range(0, len(self.vm.config.bootOptions.bootOrder)):
+                if type(self.vm.config.bootOptions.bootOrder[i]) is vim.vm.BootOptions.BootableDiskDevice:
+                    if self.vm.config.bootOptions.bootOrder[i].deviceKey:
+                        for dev in self.vm.config.hardware.device:
+                            if isinstance(dev, vim.vm.device.VirtualDisk) and \
+                                    dev.key == self.vm.config.bootOptions.bootOrder[i].deviceKey:
+                                previous_boot_disk = dev.deviceInfo.label
+
         if len(boot_order_list) != len(self.vm.config.bootOptions.bootOrder):
             kwargs.update({'bootOrder': boot_order_list})
             change_needed = True
@@ -267,27 +285,36 @@ class VmBootManager(PyVmomi):
                 if boot_device_type != vm_boot_device_type:
                     kwargs.update({'bootOrder': boot_order_list})
                     change_needed = True
+                else:
+                    if vm_boot_device_type is vim.vm.BootOptions.BootableDiskDevice and \
+                            boot_order_list[i].deviceKey != self.vm.config.bootOptions.bootOrder[i].deviceKey:
+                        kwargs.update({'bootOrder': boot_order_list})
+                        change_needed = True
 
-        if self.vm.config.bootOptions.bootDelay != self.params.get('boot_delay'):
+        if self.params.get('boot_delay') is not None and \
+                self.vm.config.bootOptions.bootDelay != self.params.get('boot_delay'):
             kwargs.update({'bootDelay': self.params.get('boot_delay')})
             change_needed = True
 
-        if self.vm.config.bootOptions.enterBIOSSetup != self.params.get('enter_bios_setup'):
+        if self.params.get('enter_bios_setup') is not None and \
+                self.vm.config.bootOptions.enterBIOSSetup != self.params.get('enter_bios_setup'):
             kwargs.update({'enterBIOSSetup': self.params.get('enter_bios_setup')})
             change_needed = True
 
-        if self.vm.config.bootOptions.bootRetryEnabled != self.params.get('boot_retry_enabled'):
+        if self.params.get('boot_retry_enabled') is not None and \
+                self.vm.config.bootOptions.bootRetryEnabled != self.params.get('boot_retry_enabled'):
             kwargs.update({'bootRetryEnabled': self.params.get('boot_retry_enabled')})
             change_needed = True
 
-        if self.vm.config.bootOptions.bootRetryDelay != self.params.get('boot_retry_delay'):
+        if self.params.get('boot_retry_delay') is not None and \
+                self.vm.config.bootOptions.bootRetryDelay != self.params.get('boot_retry_delay'):
             if not self.vm.config.bootOptions.bootRetryEnabled:
                 kwargs.update({'bootRetryEnabled': True})
             kwargs.update({'bootRetryDelay': self.params.get('boot_retry_delay')})
             change_needed = True
 
         boot_firmware_required = False
-        if self.vm.config.firmware != self.params.get('boot_firmware'):
+        if self.params.get('boot_firmware') is not None and self.vm.config.firmware != self.params.get('boot_firmware'):
             change_needed = True
             boot_firmware_required = True
 
@@ -311,8 +338,10 @@ class VmBootManager(PyVmomi):
             previous_boot_retry_delay=self.vm.config.bootOptions.bootRetryDelay,
             previous_boot_firmware=self.vm.config.firmware,
             previous_secure_boot_enabled=self.vm.config.bootOptions.efiSecureBootEnabled,
-            current_boot_order=[],
+            current_boot_order=[]
         )
+        if previous_boot_disk:
+            results.update({'previous_boot_disk': previous_boot_disk})
 
         if change_needed:
             vm_conf = vim.vm.ConfigSpec()
@@ -336,9 +365,11 @@ class VmBootManager(PyVmomi):
                 'current_boot_retry_enabled': self.vm.config.bootOptions.bootRetryEnabled,
                 'current_boot_retry_delay': self.vm.config.bootOptions.bootRetryDelay,
                 'current_boot_firmware': self.vm.config.firmware,
-                'current_secure_boot_enabled': self.vm.config.bootOptions.efiSecureBootEnabled,
+                'current_secure_boot_enabled': self.vm.config.bootOptions.efiSecureBootEnabled
             }
         )
+        if self.params.get('boot_hdd_name'):
+            results.update({'current_boot_disk': self.params.get('boot_hdd_name')})
 
         self.module.exit_json(changed=changed, vm_boot_status=results)
 
@@ -350,37 +381,24 @@ def main():
         uuid=dict(type='str'),
         moid=dict(type='str'),
         use_instance_uuid=dict(type='bool', default=False),
-        boot_order=dict(
-            type='list',
-            default=[],
-            elements='str',
-        ),
         name_match=dict(
             choices=['first', 'last'],
             default='first'
         ),
-        boot_delay=dict(
-            type='int',
-            default=0,
+        boot_order=dict(
+            type='list',
+            default=[],
+            elements='str'
         ),
-        enter_bios_setup=dict(
-            type='bool',
-            default=False,
-        ),
-        boot_retry_enabled=dict(
-            type='bool',
-            default=False,
-        ),
-        boot_retry_delay=dict(
-            type='int',
-            default=0,
-        ),
-        secure_boot_enabled=dict(
-            type='bool',
-        ),
+        boot_hdd_name=dict(type='str'),
+        boot_delay=dict(type='int'),
+        enter_bios_setup=dict(type='bool'),
+        boot_retry_enabled=dict(type='bool'),
+        boot_retry_delay=dict(type='int'),
+        secure_boot_enabled=dict(type='bool'),
         boot_firmware=dict(
             type='str',
-            choices=['efi', 'bios'],
+            choices=['efi', 'bios']
         )
     )
 

--- a/plugins/modules/vmware_guest_boot_manager.py
+++ b/plugins/modules/vmware_guest_boot_manager.py
@@ -56,6 +56,7 @@ options:
      - Name of disk to be set as boot disk, which is case sensitive, e.g., 'Hard disk 1'.
      - This parameter is optional, if not set, will use the first virtual disk found in VM device list.
      type: str
+     version_added: '3.2.0'
    boot_delay:
      description:
      - Delay in milliseconds before starting the boot sequence.
@@ -253,7 +254,7 @@ class VmBootManager(PyVmomi):
                     first_hdd = [device for device in self.vm.config.hardware.device if isinstance(device, vim.vm.device.VirtualDisk)
                                  and device.deviceInfo.label == self.params.get('boot_hdd_name')]
                     if not first_hdd:
-                        self.module.fail_json(msg="Not found virtual disk with disk label '%d'" % (self.params.get('boot_hdd_name')))
+                        self.module.fail_json(msg="Not found virtual disk with disk label '%s'" % (self.params.get('boot_hdd_name')))
                 if first_hdd:
                     boot_order_list.append(vim.vm.BootOptions.BootableDiskDevice(deviceKey=first_hdd[0].key))
             elif device_order == 'ethernet':
@@ -268,7 +269,7 @@ class VmBootManager(PyVmomi):
         # Get previous boot disk name when boot_hdd_name is set
         if self.params.get('boot_hdd_name'):
             for i in range(0, len(self.vm.config.bootOptions.bootOrder)):
-                if type(self.vm.config.bootOptions.bootOrder[i]) is vim.vm.BootOptions.BootableDiskDevice:
+                if isinstance(self.vm.config.bootOptions.bootOrder[i], vim.vm.BootOptions.BootableDiskDevice):
                     if self.vm.config.bootOptions.bootOrder[i].deviceKey:
                         for dev in self.vm.config.hardware.device:
                             if isinstance(dev, vim.vm.device.VirtualDisk) and \

--- a/tests/integration/targets/vmware_guest_boot_manager/tasks/main.yml
+++ b/tests/integration/targets/vmware_guest_boot_manager/tasks/main.yml
@@ -74,3 +74,114 @@
       assert:
         that:
         - boot_info2.vm_boot_info.current_secure_boot_enabled is true
+
+- name: Get VM disk info 1
+  community.vmware.vmware_guest_disk_info:
+    validate_certs: false
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    name: "{{ virtual_machines[0].name }}"
+  register: disk_info1
+
+- ansible.builtin.debug: var=disk_info1
+
+- name: Add a new disk for boot disk config test
+  block:
+    - name: Add a new disk to VM
+      community.vmware.vmware_guest_disk:
+        validate_certs: false
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        name: "{{ virtual_machines[0].name }}"
+        disk:
+          - size_mb: 10
+            type: thin
+            datastore: "{{ rw_datastore }}"
+            state: present
+            controller_number: "{{ disk_info1.guest_disk_info['0'].controller_bus_number }}"
+            unit_number: "{{ disk_info1.guest_disk_info['0'].unit_number | int + 1 }}"
+            controller_type: "{{ disk_info1.guest_disk_info['0'].controller_type }}"
+      register: add_disk_result
+
+    - ansible.builtin.debug: var=add_disk_result
+
+    - name: assert that new disk is added
+      assert:
+        that:
+          - add_disk_result.changed
+          - add_disk_result.disk_data | length == 2
+  when:
+    - disk_info1 is defined
+    - disk_info1.guest_disk_info is defined
+    - disk_info1.guest_disk_info | length == 1
+
+- name: Get VM disk info 2
+  community.vmware.vmware_guest_disk_info:
+    validate_certs: false
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    name: "{{ virtual_machines[0].name }}"
+  register: disk_info2
+
+- ansible.builtin.debug: var=disk_info2
+
+- name: Get disk with label 'Hard disk 2'
+  ansible.builtin.set_fact:
+    get_hard_disk_2: "{{ item }}"
+  when: item.value.label == 'Hard disk 2'
+  with_dict: "{{ disk_info2.guest_disk_info }}"
+
+- name: assert that 'Hard disk 2' found in disk info
+  assert:
+    that:
+      - get_hard_disk_2 is defined
+
+- ansible.builtin.debug: var=get_hard_disk_2
+
+- name: Set boot disk to 'Hard disk 2'
+  community.vmware.vmware_guest_boot_manager:
+    validate_certs: false
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    name: "{{ virtual_machines[0].name }}"
+    boot_order:
+      - disk
+      - cdrom
+      - ethernet
+    boot_hdd_name: 'Hard disk 2'
+  register: set_boot_hdd_result1
+
+- ansible.builtin.debug: var=set_boot_hdd_result1
+
+- name: assert that boot disk is set to 'Hard disk 2'
+  assert:
+    that:
+      - set_boot_hdd_result1.changed
+      - set_boot_hdd_result1.vm_boot_status.current_boot_disk == 'Hard disk 2'
+
+- name: Set boot disk to 'Hard disk 2' again to test idempotency
+  community.vmware.vmware_guest_boot_manager:
+    validate_certs: false
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    name: "{{ virtual_machines[0].name }}"
+    boot_order:
+      - disk
+      - cdrom
+      - ethernet
+    boot_hdd_name: 'Hard disk 2'
+  register: set_boot_hdd_result2
+
+- ansible.builtin.debug: var=set_boot_hdd_result2
+
+- name: assert that task is not changed
+  assert:
+    that:
+      - not set_boot_hdd_result2.changed
+      - set_boot_hdd_result2.vm_boot_status.current_boot_disk == 'Hard disk 2'
+      - set_boot_hdd_result2.vm_boot_status.previous_boot_disk == 'Hard disk 2'

--- a/tests/integration/targets/vmware_guest_boot_manager/tasks/main.yml
+++ b/tests/integration/targets/vmware_guest_boot_manager/tasks/main.yml
@@ -81,6 +81,7 @@
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
+    datacenter: "{{ dc1 }}"
     name: "{{ virtual_machines[0].name }}"
   register: disk_info1
 
@@ -94,6 +95,7 @@
         hostname: '{{ vcenter_hostname }}'
         username: '{{ vcenter_username }}'
         password: '{{ vcenter_password }}'
+        datacenter: "{{ dc1 }}"
         name: "{{ virtual_machines[0].name }}"
         disk:
           - size_mb: 10
@@ -124,6 +126,7 @@
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
     name: "{{ virtual_machines[0].name }}"
+    datacenter: "{{ dc1 }}"
   register: disk_info2
 
 - ansible.builtin.debug: var=disk_info2
@@ -147,6 +150,7 @@
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
+    datacenter: "{{ dc1 }}"
     name: "{{ virtual_machines[0].name }}"
     boot_order:
       - disk
@@ -169,6 +173,7 @@
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
+    datacenter: "{{ dc1 }}"
     name: "{{ virtual_machines[0].name }}"
     boot_order:
       - disk

--- a/tests/integration/targets/vmware_guest_boot_manager/tasks/main.yml
+++ b/tests/integration/targets/vmware_guest_boot_manager/tasks/main.yml
@@ -150,7 +150,6 @@
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
-    datacenter: "{{ dc1 }}"
     name: "{{ virtual_machines[0].name }}"
     boot_order:
       - disk
@@ -173,7 +172,6 @@
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
-    datacenter: "{{ dc1 }}"
     name: "{{ virtual_machines[0].name }}"
     boot_order:
       - disk


### PR DESCRIPTION
Signed-off-by: Diane Wang <dianew@vmware.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
1. For BIOS firmware VM, when add new hard disk to SATA controller, restart VM will result VM disk order changed and VM can not boot up automatically. So in this module, add a new parameter `boot_hdd_name` to specify boot from which hard disk.
2. Remove the default values of some parameters, if these parameters are not set in the task and previous VM config is not the same as the default value, then these VM config will be changed,  which is not expected.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_guest_boot_manager

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
- community.vmware.vmware_guest_boot_manager:
        hostname: xx.xx.xx.xx
        username: xxxxx
        password: xxxxx
        validate_certs: false
        name: test_vm
        boot_delay: 20000
        enter_bios_setup: false
        boot_retry_enabled: false
        boot_retry_delay: 2200
        boot_firmware: bios
        secure_boot_enabled: false
        boot_order:
          - disk
          - cdrom
          - ethernet
        boot_hdd_name: 'Hard disk 1'
```
Return results:
```
ok: [localhost] => {
    "vm_boot_order": {
        "changed": true,
        "failed": false,
        "vm_boot_status": {
            "current_boot_delay": 20000,
            "current_boot_disk": "Hard disk 1",
            "current_boot_firmware": "bios",
            "current_boot_order": [
                "disk",
                "cdrom",
                "ethernet"
            ],
            "current_boot_retry_delay": 2200,
            "current_boot_retry_enabled": true,
            "current_enter_bios_setup": false,
            "current_secure_boot_enabled": false,
            "previous_boot_delay": 0,
            "previous_boot_firmware": "bios",
            "previous_boot_order": [],
            "previous_boot_retry_delay": 10000,
            "previous_boot_retry_enabled": false,
            "previous_enter_bios_setup": false,
            "previous_secure_boot_enabled": false
        }
    }
}
```