### PR TITLE
Backport vmware_portgroup_info fix

### DIFF
--- a/changelogs/fragments/1544-vmware_portgroup_info.yml
+++ b/changelogs/fragments/1544-vmware_portgroup_info.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - vmware_portgroup_info - Fix an issue that can fail the module after manually updating a portgroup through vCenter
+    (https://github.com/ansible-collections/community.vmware/issues/1544).

--- a/plugins/modules/vmware_portgroup_info.py
+++ b/plugins/modules/vmware_portgroup_info.py
@@ -162,7 +162,7 @@ class PortgroupInfoManager(PyVmomi):
                 else:
                     pg_info_dict['failover_active'] = spec.policy.nicTeaming.nicOrder.activeNic
                     pg_info_dict['failover_standby'] = spec.policy.nicTeaming.nicOrder.standbyNic
-                if spec.policy.nicTeaming.failureCriteria and spec.policy.nicTeaming.failureCriteria.checkBeacon is None:
+                if spec.policy.nicTeaming.failureCriteria is None:
                     pg_info_dict['failure_detection'] = "No override"
                 else:
                     if spec.policy.nicTeaming.failureCriteria.checkBeacon:


### PR DESCRIPTION
##### SUMMARY
Backport #1546

In some cases, a portgroup might have `spec.policy.nicTeaming.failureCriteria` set, but without `checkBeacon`. This crashes the module.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_portgroup_info

##### ADDITIONAL INFORMATION
See #1544 for more information.