### PR TITLE
Add resource pool of vm to vm_info output

### DIFF
--- a/changelogs/fragments/1511-vmware_vm_info.yml
+++ b/changelogs/fragments/1511-vmware_vm_info.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_vm_info - Adding resource pool of the VM to result (https://github.com/ansible-collections/community.vmware/pull/1551).

--- a/plugins/modules/vmware_vm_info.py
+++ b/plugins/modules/vmware_vm_info.py
@@ -323,6 +323,10 @@ class VmwareVmInfo(PyVmomi):
             if esxi_parent and isinstance(esxi_parent, vim.ClusterComputeResource):
                 cluster_name = summary.runtime.host.parent.name
 
+            resource_pool = None
+            if vm.resourcePool and vm.resourcePool != vm.resourcePool.owner.resourcePool:
+                resource_pool = vm.resourcePool.name
+
             vm_attributes = dict()
             if self.module.params.get('show_attribute'):
                 vm_attributes = self.get_vm_attributes(vm)
@@ -361,6 +365,7 @@ class VmwareVmInfo(PyVmomi):
                 "esxi_hostname": esxi_hostname,
                 "datacenter": datacenter.name,
                 "cluster": cluster_name,
+                "resource_pool": resource_pool,
                 "attributes": vm_attributes,
                 "tags": vm_tags,
                 "folder": vm_folder,


### PR DESCRIPTION
##### SUMMARY
Since the vm_info module does not get the resource pool of the virtual machines i have added that functionality.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
The vm_info module now additionally fetches the resource pool of  the virtual machine, if available.