### PR TITLE
2.x: vmware_guest_instant_clone: Fix an issue with pyVmomi 8.0.0.1

### DIFF
--- a/changelogs/fragments/1555-vmware_guest_instant_clone-pyvmomi_8_0_0_1.yml
+++ b/changelogs/fragments/1555-vmware_guest_instant_clone-pyvmomi_8_0_0_1.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_guest_instant_clone - Fix an issue with pyVmomi 8.0.0.1 (https://github.com/ansible-collections/community.vmware/issues/1555).

--- a/plugins/module_utils/vmware.py
+++ b/plugins/module_utils/vmware.py
@@ -289,7 +289,7 @@ def find_folder_by_fqpn(content, folder_name, datacenter_name=None, folder_type=
         for part in folder_parts:
             folder_obj = None
             for part_obj in parent_obj.childEntity:
-                if part_obj.name == part and 'Folder' in part_obj.childType:
+                if part_obj.name == part and ('Folder' in part_obj.childType or vim.Folder in part_obj.childType):
                     folder_obj = part_obj
                     parent_obj = part_obj
                     break


### PR DESCRIPTION
##### SUMMARY
Backport #1557

pyVmomi 8.0.0.1 breaks `find_folder_by_fqpn` and, therefor, `vmware_guest_instant_clone`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_guest_instant_clone

##### ADDITIONAL INFORMATION
#1555