### PR TITLE
2.x: vmware_object_custom_attributes_info: Global custom attributes

### DIFF
--- a/changelogs/fragments/1477-vmware_object_custom_attributes_info.yml
+++ b/changelogs/fragments/1477-vmware_object_custom_attributes_info.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - vmware_object_custom_attributes_info - Fixed an issue that has occurred an error if a custom attribute is the global type
+    (https://github.com/ansible-collections/community.vmware/issues/1477).

--- a/plugins/modules/vmware_object_custom_attributes_info.py
+++ b/plugins/modules/vmware_object_custom_attributes_info.py
@@ -157,7 +157,7 @@ class VmwareCustomAttributesInfo(PyVmomi):
         for key, value in available_fields.items():
             attribute_result = {
                 'attribute': value['name'],
-                'type': self.to_json(value['type']).replace('vim.', ''),
+                'type': self.to_json(value['type']).replace('vim.', '') if value['type'] is not None else 'Global',
                 'key': key,
                 'value': None
             }


### PR DESCRIPTION
##### SUMMARY
Backport #1541

Fix the bug that occurs the error if the custom attribute is the global type.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_object_custom_attributes_info

##### ADDITIONAL INFORMATION
#1477