### PR TITLE
Update vmware_guest_custom_attributes.py

### DIFF
--- a/changelogs/fragments/1568-vmware_guest_custom_attributes-fix-key-error-on-new-vms.yml
+++ b/changelogs/fragments/1568-vmware_guest_custom_attributes-fix-key-error-on-new-vms.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_guest_custom_attributes  - Fix an issue when setting the custom fields on a newly created VM (https://github.com/ansible-collections/community.vmware/issues/1568).

--- a/plugins/modules/vmware_guest_custom_attributes.py
+++ b/plugins/modules/vmware_guest_custom_attributes.py
@@ -250,7 +250,8 @@ class VmAttributeManager(PyVmomi):
         for k, n in [(x.key, x.name) for x in self.custom_field_mgr for v in user_fields if x.name == v['name']]:
             existing_custom_attributes.append({
                 "key": k,
-                "name": n
+                "name": n,
+                "value": ""
             })
 
         # Gather the values of set the custom attribute.
@@ -258,11 +259,6 @@ class VmAttributeManager(PyVmomi):
             for e in existing_custom_attributes:
                 if e['key'] == v.key:
                     e['value'] = v.value
-
-                # When add custom attribute as a new one, it has not the value key.
-                # Add the value key to avoid unintended behavior in the difference check.
-                if 'value' not in e:
-                    e['value'] = ''
 
         # Select the custom attribute and value to update the configuration.
         _user_fields_for_diff = []


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When setting the custom fields on a newly created VM, I get a key error in the *check_exists* function. This is because the *vm.customValue* field is empty and so the elements in the *existing_custom_attributes* list don't have the field *value*. Adding the field *value* during creation of the *existing_custom_attributes* and eventually overwriting it later fixes the problem for me.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #1568

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
*vmware_guest_custom_attributes*

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
- Create a VM without custom attributes
- Try to update the attributes for the VM running e.g.
```
- name: Configure custom attributes
  community.vmware.vmware_guest_custom_attributes:
    hostname: "{{ hostname }}"
    username: "{{ username }}"
    password: "{{ password }}"
    name: "{{ host }}"
    folder: "{{ vm_folder }}"
    state: present
    attributes: 
      - name: foo
        value: bar
       
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: KeyError: 'value'
fatal: [localhost]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/home/_/.ansible/tmp/ansible-tmp-1670252175.1850512-14501-53110338757278/AnsiballZ_vmware_guest_custom_attributes.py\", line 100, in <module>\n    _ansiballz_main()\n  File \"/home/_/.ansible/tmp/ansible-tmp-1670252175.1850512-14501-53110338757278/AnsiballZ_vmware_guest_custom_attributes.py\", line 92, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/home/_/.ansible/tmp/ansible-tmp-1670252175.1850512-14501-53110338757278/AnsiballZ_vmware_guest_custom_attributes.py\", line 40, in invoke_module\n    runpy.run_module(mod_name='ansible_collections.community.vmware.plugins.modules.vmware_guest_custom_attributes', init_globals=dict(_module_fqn='ansible_collections.community.vmware.plugins.modules.vmware_guest_custom_attributes', _modlib_path=modlib_path),\n  File \"/usr/lib/python3.9/runpy.py\", line 210, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/usr/lib/python3.9/runpy.py\", line 97, in _run_module_code\n    _run_code(code, mod_globals, init_globals,\n  File \"/usr/lib/python3.9/runpy.py\", line 87, in _run_code\n    exec(code, run_globals)\n  File \"/tmp/ansible_community.vmware.vmware_guest_custom_attributes_payload_62z6z4_f/ansible_community.vmware.vmware_guest_custom_attributes_payload.zip/ansible_collections/community/vmware/plugins/modules/vmware_guest_custom_attributes.py\", line 358, in <module>\n  File \"/tmp/ansible_community.vmware.vmware_guest_custom_attributes_payload_62z6z4_f/ansible_community.vmware.vmware_guest_custom_attributes_payload.zip/ansible_collections/community/vmware/plugins/modules/vmware_guest_custom_attributes.py\", line 346, in main\n  File \"/tmp/ansible_community.vmware.vmware_guest_custom_attributes_payload_62z6z4_f/ansible_community.vmware.vmware_guest_custom_attributes_payload.zip/ansible_collections/community/vmware/plugins/modules/vmware_guest_custom_attributes.py\", line 189, in set_custom_field\n  File \"/tmp/ansible_community.vmware.vmware_guest_custom_attributes_payload_62z6z4_f/ansible_community.vmware.vmware_guest_custom_attributes_payload.zip/ansible_collections/community/vmware/plugins/modules/vmware_guest_custom_attributes.py\", line 271, in check_exists\nKeyError: 'value'\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
```
