### PR TITLE
vmware_host_lockdown_exceptions: Avoid unnecessary task

### DIFF
--- a/changelogs/fragments/1585-vmware_host_lockdown_exceptions-unnecessary_task.yml
+++ b/changelogs/fragments/1585-vmware_host_lockdown_exceptions-unnecessary_task.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - vmware_host_lockdown_exceptions - Avoid setting exception users to what they already are
+    (https://github.com/ansible-collections/community.vmware/pull/1585).

--- a/plugins/modules/vmware_host_lockdown_exceptions.py
+++ b/plugins/modules/vmware_host_lockdown_exceptions.py
@@ -139,7 +139,7 @@ class VmwareLockdownManager(PyVmomi):
             results['host_lockdown_exceptions'][host.name]['desired_exception_users'] = new_exception_users
             results['host_lockdown_exceptions'][host.name]['current_exception_users'] = new_exception_users
 
-            if not self.module.check_mode:
+            if changed and not self.module.check_mode:
                 try:
                     host.configManager.hostAccessManager.UpdateLockdownExceptions(new_exception_users)
 


### PR DESCRIPTION
##### SUMMARY
Currently, the module always updates the list of exception users even if they didn't change:

https://github.com/ansible-collections/community.vmware/blob/813d2b6781dd9de290c2ffe1e49869aa10a92004/plugins/modules/vmware_host_lockdown_exceptions.py#L142-L144

While I'm quite sure that the module is (basically) correct since it returns unchanged and doesn't break anything, this is an unnecessary task we should avoid.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_host_lockdown_exceptions

##### ADDITIONAL INFORMATION
https://github.com/ansible-collections/community.vmware/issues/529#issuecomment-1370911029