### PR TITLE
[BACKPORT] vmware_tools: Fix an issue with pyVmomi 8.0.0.1

### DIFF
--- a/changelogs/fragments/1578-vmware_tools-pyvmomi_8_0_0_1.yml
+++ b/changelogs/fragments/1578-vmware_tools-pyvmomi_8_0_0_1.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_tools - Fix an issue with pyVmomi 8.0.0.1 (https://github.com/ansible-collections/community.vmware/issues/1578).

--- a/plugins/connection/vmware_tools.py
+++ b/plugins/connection/vmware_tools.py
@@ -229,7 +229,7 @@ from ansible.plugins.connection import ConnectionBase
 from ansible.module_utils.basic import missing_required_lib
 
 try:
-    from pyVim.connect import Disconnect, SmartConnect, SmartConnectNoSSL
+    from pyVim.connect import Disconnect, SmartConnect
     from pyVmomi import vim, vmodl
 
     HAS_PYVMOMI = True
@@ -292,15 +292,13 @@ class Connection(ConnectionBase):
             "port": self.get_option("vmware_port"),
         }
 
-        if self.validate_certs:
-            connect = SmartConnect
-        else:
+        if not self.validate_certs:
             if HAS_URLLIB3:
                 urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-            connect = SmartConnectNoSSL
+            connection_kwargs['disableSslCertValidation'] = True
 
         try:
-            self._si = connect(**connection_kwargs)
+            self._si = SmartConnect(**connection_kwargs)
         except SSLError:
             raise AnsibleError("SSL Error: Certificate verification failed.")
         except (gaierror):


### PR DESCRIPTION
##### SUMMARY
[pyVmomi 8.0.0.1](https://github.com/vmware/pyvmomi/releases/tag/v8.0.0.1) removed `connect.SmartConnectNoSSL()` used in `plugins/connection/vmware_tools.py`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_tools

##### ADDITIONAL INFORMATION
Backport of #1584 to fix #1578 in the `stable-2.x` branch.
