### PR TITLE
Remove timeout parameter in wait_for_task

### DIFF
--- a/plugins/module_utils/vmware.py
+++ b/plugins/module_utils/vmware.py
@@ -117,19 +117,17 @@ def answer_question(vm, responses):
             raise TaskError("answer failed: %s" % to_text(e))
 
 
-def wait_for_task(task, max_backoff=64, timeout=3600, vm=None, answers=None):
+def wait_for_task(task, max_backoff=64, vm=None, answers=None):
     """Wait for given task using exponential back-off algorithm.
 
     Args:
         task: VMware task object
         max_backoff: Maximum amount of sleep time in seconds
-        timeout: Timeout for the given task in seconds
 
     Returns: Tuple with True and result for successful task
     Raises: TaskError on failure
     """
     failure_counter = 0
-    start_time = time.time()
 
     while True:
         if check_answer_question_status(vm):
@@ -138,8 +136,6 @@ def wait_for_task(task, max_backoff=64, timeout=3600, vm=None, answers=None):
                 answer_question(vm, responses)
             else:
                 raise TaskError("%s" % to_text(vm.runtime.question.text))
-        if time.time() - start_time >= timeout:
-            raise TaskError("Timeout")
         if task.info.state == vim.TaskInfo.State.success:
             return True, task.info.result
         if task.info.state == vim.TaskInfo.State.error:


### PR DESCRIPTION
##### SUMMARY

This was originally [added](https://github.com/ansible/ansible/pull/39596) for the Ansible 2.6 release, but in Ansible 2.10 a `timeout` property was [added](https://github.com/ansible/ansible/pull/69284) at the task level, which makes this functionality obsolete.

However, the presence of the `timeout` parameter to this function means that it effectively overrides the aforementioned task-level property. This means that all tasks that use `wait_for_task` effectively have a 1-hour timeout, regardless of what the user requests using the `timeout` property.

Having looked through this collection's source code, it does not seem that any callers to this function are overriding the `timeout` parameter, and no unit tests were added either. Thus, the only change necessary is to this function itself.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

- `module_utils/vmware.py`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Here's an example of how the previous code could be problematic:

```yaml
- name: Ensure VM is using the correct ESXi host and datastore
  delegate_to: localhost
  community.vmware.vmware_vmotion:
    hostname: "{{ vsphere_guest_vcenter_hostname }}"
    username: "{{ vsphere_guest_vcenter_user }}"
    password: "{{ vsphere_guest_vcenter_password }}"
    vm_name: "{{ inventory_hostname }}"
    destination_host: "{{ vsphere_guest_esxi_host }}"
    destination_datastore: "{{ vsphere_guest_disk_datastore }}"
  # Allow up to 2 hours for this task to complete, since datastore relocations can take a
  # long time for nodes with large hard disks.
  timeout: 7200
```

Unfortunately, the above task still fails after exactly 1 hour, in spite of the `timeout: 7200` property:

```
fatal: [build-node-15 -> localhost]: FAILED! => {"changed": false, "msg": "Timeout"}
fatal: [build-node-07 -> localhost]: FAILED! => {"changed": false, "msg": "Timeout"}
```