### PR TITLE
Backport Fix wrong key in the documentation of the return values

### DIFF
--- a/changelogs/fragments/1615-wrong_key_for_return_value.yml
+++ b/changelogs/fragments/1615-wrong_key_for_return_value.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_guest_disk - Fix wrong key in the documentation of the return values (https://github.com/ansible-collections/community.vmware/issues/1615)

--- a/docs/community.vmware.vmware_guest_disk_module.rst
+++ b/docs/community.vmware.vmware_guest_disk_module.rst
@@ -1164,7 +1164,7 @@ Common return values are documented `here <https://docs.ansible.com/ansible/late
             <tr>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="return-"></div>
-                    <b>disk_status</b>
+                    <b>disk_data</b>
                     <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
                     <div style="font-size: small">
                       <span style="color: purple">dictionary</span>

--- a/plugins/modules/vmware_guest_disk.py
+++ b/plugins/modules/vmware_guest_disk.py
@@ -474,7 +474,7 @@ EXAMPLES = r'''
 '''
 
 RETURN = r'''
-disk_status:
+disk_data:
     description: metadata about the virtual machine's disks after managing them
     returned: always
     type: dict


### PR DESCRIPTION
##### SUMMARY
Update the documentation of vmware_guest_disk to show the correct key of the return values.

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
vmware_guest_disk

##### ADDITIONAL INFORMATION
Backport #1623 
