### PR TITLE
Issue 1606 Fix vmware_guest_custom_attributes failing on new VMs with KeyError 'value'

### DIFF
--- a/changelogs/fragments/1606-vmware_guest_custom_attributes.yml
+++ b/changelogs/fragments/1606-vmware_guest_custom_attributes.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_guest_custom_attributes - Fixes assigning attributes to new VMs (https://github.com/ansible-collections/community.vmware/issues/1606).

--- a/plugins/modules/vmware_guest_custom_attributes.py
+++ b/plugins/modules/vmware_guest_custom_attributes.py
@@ -254,15 +254,15 @@ class VmAttributeManager(PyVmomi):
             })
 
         # Gather the values of set the custom attribute.
-        for v in vm.customValue:
-            for e in existing_custom_attributes:
+        for e in existing_custom_attributes:
+            for v in vm.customValue:
                 if e['key'] == v.key:
                     e['value'] = v.value
 
-                # When add custom attribute as a new one, it has not the value key.
-                # Add the value key to avoid unintended behavior in the difference check.
-                if 'value' not in e:
-                    e['value'] = ''
+            # When add custom attribute as a new one, it has not the value key.
+            # Add the value key to avoid unintended behavior in the difference check.
+            if 'value' not in e:
+                e['value'] = ''
 
         # Select the custom attribute and value to update the configuration.
         _user_fields_for_diff = []

--- a/plugins/modules/vmware_guest_custom_attributes.py
+++ b/plugins/modules/vmware_guest_custom_attributes.py
@@ -253,6 +253,7 @@ class VmAttributeManager(PyVmomi):
                 "name": n
             })
 
+
         # Gather the values of set the custom attribute.
         for e in existing_custom_attributes:
             for v in vm.customValue:

--- a/plugins/modules/vmware_guest_custom_attributes.py
+++ b/plugins/modules/vmware_guest_custom_attributes.py
@@ -253,7 +253,6 @@ class VmAttributeManager(PyVmomi):
                 "name": n
             })
 
-
         # Gather the values of set the custom attribute.
         for e in existing_custom_attributes:
             for v in vm.customValue:


### PR DESCRIPTION
##### SUMMARY
Fixes #1606
Fixes #1568
Reversed the for loops in check_exists and bumped exception check into outer for loop for existing attributes. Tested against vSphere 7.0.3 and it set a list of attributes on a new VM without issue.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
vmware_guest_custom_attributes

##### ADDITIONAL INFORMATION
See Issue #1606 and Issue #1568 for details.
