### PR TITLE
vmware_vm_inventory: add example for groups parameter

### DIFF
--- a/plugins/inventory/vmware_vm_inventory.py
+++ b/plugins/inventory/vmware_vm_inventory.py
@@ -355,6 +355,23 @@ EXAMPLES = r'''
         | first
     properties:
       - guest.net
+
+# Group hosts using Jinja2 conditionals
+    plugin: community.vmware.vmware_vm_inventory
+    strict: False
+    hostname: 10.65.13.37
+    username: administrator@vsphere.local
+    password: Esxi@123$%
+    validate_certs: False
+    hostnames:
+    - config.name
+    properties:
+    - 'name'
+    - 'config.name'
+    - 'config.datastoreUrl'
+    groups:
+      slow_storage: "'Nas01' in config.datastoreUrl[0].name"
+      fast_storage: "'SSD' in config.datastoreUrl[0].name"
 '''
 
 from ansible.errors import AnsibleError, AnsibleParserError


### PR DESCRIPTION
##### SUMMARY
Add an example for using the groups parameter with Jinja2 conditionals.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
vmware_vm_inventory 

##### ADDITIONAL INFORMATION
 I found that it wasn't very intuitive for me to use the groups parameter with actual conditions (not just 'true') correctly and I thought this might help some people.

Also I kind of dislike the parameter description itself, but that's coming from here:
https://github.com/ansible/ansible/blob/devel/lib/ansible/plugins/doc_fragments/constructed.py#L25
I would like to append something along the lines of "[...] { group: condition }" - but whatever.. Even though I think that could be overwritten by this plugin, the example should suffice.