### PR TITLE
adds uuid support for vmware_tools connection plugin

### DIFF
--- a/changelogs/fragments/1647-uuid_vmware_tools_connections.yml
+++ b/changelogs/fragments/1647-uuid_vmware_tools_connections.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_tools - ansible_vmware_guest_uuid added for easier use of vmware_tools connection plugin with vmware_vm_inventory plugin


### PR DESCRIPTION
##### SUMMARY
Adding support for UUID to connect to a VM via vmware_tools plugin.
Why is it useful.
This way vmware_tools connection Plugin ist better usable in conjunction with vmware_vm_inventory, since there is no attribute for guest_path in the attributes of a VM. This way you can use the "config.uuid" attribute to connect to multiple VM's in different folders fetched via vmware_vm_inventory.

We are using vmware_tools connection plugin to easier connect to windows VM, instead of using winRM which is much more complex.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_tools connection plugin

##### ADDITIONAL INFORMATION
Implemented the way, that the path still can be used of course and the path is preffered of both is defined. However added a mutually exclusive hint to the doc.

Successfully tested against our vsphere 7 U3 environment.
