### PR TITLE
fixing ssl validation behaviour

### DIFF
--- a/changelogs/fragments/1653-cross_vc_clone_ssl_thumbprint.yml
+++ b/changelogs/fragments/1653-cross_vc_clone_ssl_thumbprint.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_cross_vc_clone - Fix SSL Thumbprint validation to ignore if destination_vcenter_validate_certs is false

--- a/changelogs/fragments/1653-cross_vc_clone_ssl_thumbprint.yml
+++ b/changelogs/fragments/1653-cross_vc_clone_ssl_thumbprint.yml
@@ -1,2 +1,3 @@
 bugfixes:
   - vmware_cross_vc_clone - Fix SSL Thumbprint validation to ignore if destination_vcenter_validate_certs is false
+    (https://github.com/ansible-collections/community.vmware/issues/1433).

--- a/plugins/modules/vmware_guest_cross_vc_clone.py
+++ b/plugins/modules/vmware_guest_cross_vc_clone.py
@@ -306,7 +306,7 @@ class CrossVCCloneManager(PyVmomi):
         if not self.destination_vcenter_validate_certs:
             self.service_locator.sslThumbprint = self.get_cert_fingerprint(
                 self.destination_vcenter,
-                self.params['port'],
+                self.destination_vcenter_port,
                 self.module.params['proxy_host'],
                 self.module.params['proxy_port'])
         creds = vim.ServiceLocatorNamePassword()

--- a/plugins/modules/vmware_guest_cross_vc_clone.py
+++ b/plugins/modules/vmware_guest_cross_vc_clone.py
@@ -302,6 +302,13 @@ class CrossVCCloneManager(PyVmomi):
         # populate service locator
         self.service_locator.instanceUuid = self.destination_content.about.instanceUuid
         self.service_locator.url = "https://" + self.destination_vcenter + ":" + str(self.params['port']) + "/sdk"
+        # If ssl verify is false, we ignore it also in the clone task by fetching thumbprint automatically
+        if not self.destination_vcenter_validate_certs:
+            self.service_locator.sslThumbprint = self.get_cert_fingerprint(
+                self.destination_vcenter,
+                self.params['port'],
+                self.module.params['proxy_host'],
+                self.module.params['proxy_port'])
         creds = vim.ServiceLocatorNamePassword()
         creds.username = self.destination_vcenter_username
         creds.password = self.destination_vcenter_password


### PR DESCRIPTION
##### SUMMARY

Fixes #1433 

Fixing behaviour of SSL Validation at destination host in cross_vc_clone module. Since it is possible to define to not perform ssl validation at destination VC, there is still an error, because serviceLocatorSpec wants a thumbprint, if this is not set, it throws and ssl validation error.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
vmware_guest_cross_vc_clone

##### ADDITIONAL INFORMATION
What I am doing to work around the limits of the serviceLocatorSpec, is to check if ssl should be validated, if not, I just fetch the thumbprint from the destination VC and inject it to the serviceLocatorSpec.

There is also another PR currently open (https://github.com/ansible-collections/community.vmware/pull/1608) which adds a thumbprint option, this is also a really good addition. May we should bring my change and the change of @ironbishop and me together, what to you think @mariolenz ?
