### PR TITLE
Use false instead of no in examples

### DIFF
--- a/changelogs/fragments/1660-false_instead_no_examples.yml
+++ b/changelogs/fragments/1660-false_instead_no_examples.yml
@@ -6,3 +6,4 @@ minor_changes:
   - vmware_guest_vgpu_info - Use false instead of no in examples (https://github.com/ansible-collections/community.vmware/issues/1660).
   - vmware_guest_vgpu - Use false instead of no in examples (https://github.com/ansible-collections/community.vmware/issues/1660).
   - vmware_host_datastore - Use false instead of no in examples (https://github.com/ansible-collections/community.vmware/issues/1660).
+  - vmware_recommended_datastore - Use false instead of no in examples (https://github.com/ansible-collections/community.vmware/issues/1660).

--- a/changelogs/fragments/1660-false_instead_no_examples.yml
+++ b/changelogs/fragments/1660-false_instead_no_examples.yml
@@ -1,0 +1,8 @@
+minor_changes:
+  - vmware_deploy_ovf - Use false instead of no in examples (https://github.com/ansible-collections/community.vmware/issues/1660).
+  - vmware_guest_disk - Use false instead of no in examples (https://github.com/ansible-collections/community.vmware/issues/1660).
+  - vmware_guest_file_operation - Use false instead of no in examples (https://github.com/ansible-collections/community.vmware/issues/1660).
+  - vmware_guest_storage_policy - Use false instead of no in examples (https://github.com/ansible-collections/community.vmware/issues/1660).
+  - vmware_guest_vgpu_info - Use false instead of no in examples (https://github.com/ansible-collections/community.vmware/issues/1660).
+  - vmware_guest_vgpu - Use false instead of no in examples (https://github.com/ansible-collections/community.vmware/issues/1660).
+  - vmware_host_datastore - Use false instead of no in examples (https://github.com/ansible-collections/community.vmware/issues/1660).

--- a/docs/community.vmware.vmware_deploy_ovf_module.rst
+++ b/docs/community.vmware.vmware_deploy_ovf_module.rst
@@ -525,7 +525,7 @@ Examples
         datastore: vsandatastore
         name: NewVM
         networks: "{u'VM Network':u'{{ ProvisioningNetworkLabel }}'}"
-        power_on: no
+        power_on: false
         ovf: /absolute/path/to/template/mytemplate.ova
       delegate_to: localhost
 

--- a/docs/community.vmware.vmware_guest_disk_module.rst
+++ b/docs/community.vmware.vmware_guest_disk_module.rst
@@ -975,7 +975,7 @@ Examples
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
         datacenter: "{{ datacenter_name }}"
-        validate_certs: no
+        validate_certs: false
         name: "Test_VM"
         disk:
           - type: rdm
@@ -991,7 +991,7 @@ Examples
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
         datacenter: "{{ datacenter_name }}"
-        validate_certs: no
+        validate_certs: false
         name: "Test_VM"
         disk:
           - type: rdm
@@ -1008,7 +1008,7 @@ Examples
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
         datacenter: "{{ datacenter_name }}"
-        validate_certs: no
+        validate_certs: false
         name: "Test_VM"
         disk:
           - type: rdm
@@ -1026,7 +1026,7 @@ Examples
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
         datacenter: "{{ datacenter_name }}"
-        validate_certs: no
+        validate_certs: false
         name: "Test_VM"
         disk:
           - type: rdm
@@ -1099,7 +1099,7 @@ Examples
           - state: absent
             scsi_controller: 1
             unit_number: 2
-            destroy: no
+            destroy: false
       delegate_to: localhost
       register: disk_facts
 
@@ -1109,7 +1109,7 @@ Examples
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
         datacenter: "{{ datacenter_name }}"
-        validate_certs: no
+        validate_certs: false
         uuid: 421e4592-c069-924d-ce20-7e7533fab926
         disk:
           - size_mb: 256
@@ -1136,7 +1136,7 @@ Examples
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
         datacenter: "{{ datacenter_name }}"
-        validate_certs: no
+        validate_certs: false
         name: VM_226
         disk:
           - type: vpmemdisk

--- a/docs/community.vmware.vmware_guest_file_operation_module.rst
+++ b/docs/community.vmware.vmware_guest_file_operation_module.rst
@@ -570,7 +570,7 @@ Examples
         directory:
           path: "/test"
           operation: create
-          recurse: no
+          recurse: false
       delegate_to: localhost
 
     - name: copy file to vm

--- a/docs/community.vmware.vmware_guest_storage_policy_module.rst
+++ b/docs/community.vmware.vmware_guest_storage_policy_module.rst
@@ -345,7 +345,7 @@ Examples
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
-        validate_certs: no
+        validate_certs: false
         uuid: cefd316c-fc19-45f3-a539-2cd03427a78d
         disk:
           - unit_number: 0
@@ -362,7 +362,7 @@ Examples
         hostname: "{{ vcenter_hostname }}"
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
-        validate_certs: no
+        validate_certs: false
         name: hostname1
         vm_home: storepol1
       delegate_to: localhost

--- a/docs/community.vmware.vmware_guest_vgpu_info_module.rst
+++ b/docs/community.vmware.vmware_guest_vgpu_info_module.rst
@@ -295,7 +295,7 @@ Examples
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
         datacenter: "{{ datacenter_name }}"
-        validate_certs: no
+        validate_certs: false
         name: UbuntuTest
       delegate_to: localhost
       register: vgpu_info

--- a/docs/community.vmware.vmware_guest_vgpu_module.rst
+++ b/docs/community.vmware.vmware_guest_vgpu_module.rst
@@ -381,7 +381,7 @@ Examples
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
         datacenter: "{{ datacenter_name }}"
-        validate_certs: no
+        validate_certs: false
         name: UbuntuTest
         vgpu: 'grid_m10-8q'
         state: present
@@ -394,7 +394,7 @@ Examples
         username: "{{ vcenter_username }}"
         password: "{{ vcenter_password }}"
         datacenter: "{{ datacenter_name }}"
-        validate_certs: no
+        validate_certs: false
         name: UbuntuTest
         vgpu: 'grid_m10-8q'
         state: absent

--- a/docs/community.vmware.vmware_host_datastore_module.rst
+++ b/docs/community.vmware.vmware_host_datastore_module.rst
@@ -380,7 +380,7 @@ Examples
           datastore_type: '{{ item.type }}'
           nfs_server: '{{ item.server }}'
           nfs_path: '{{ item.path }}'
-          nfs_ro: no
+          nfs_ro: false
           esxi_hostname: '{{ inventory_hostname }}'
           state: present
       delegate_to: localhost
@@ -397,7 +397,7 @@ Examples
           datastore_type: '{{ item.type }}'
           nfs_server: '{{ item.server }}'
           nfs_path: '{{ item.path }}'
-          nfs_ro: no
+          nfs_ro: false
           esxi_hostname: '{{ inventory_hostname }}'
           state: present
       delegate_to: localhost

--- a/docs/community.vmware.vmware_recommended_datastore_module.rst
+++ b/docs/community.vmware.vmware_recommended_datastore_module.rst
@@ -214,7 +214,7 @@ Examples
         hostname: '{{ vcenter_hostname }}'
         username: '{{ vcenter_username }}'
         password: '{{ vcenter_password }}'
-        validate_certs: no
+        validate_certs: false
         datastore_cluster: '{{ datastore_cluster_name }}'
         datacenter: '{{ datacenter }}'
       register: recommended_ds

--- a/plugins/modules/vmware_deploy_ovf.py
+++ b/plugins/modules/vmware_deploy_ovf.py
@@ -157,7 +157,7 @@ EXAMPLES = r'''
     datastore: vsandatastore
     name: NewVM
     networks: "{u'VM Network':u'{{ ProvisioningNetworkLabel }}'}"
-    power_on: no
+    power_on: false
     ovf: /absolute/path/to/template/mytemplate.ova
   delegate_to: localhost
 

--- a/plugins/modules/vmware_guest_disk.py
+++ b/plugins/modules/vmware_guest_disk.py
@@ -300,7 +300,7 @@ EXAMPLES = r'''
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     datacenter: "{{ datacenter_name }}"
-    validate_certs: no
+    validate_certs: false
     name: "Test_VM"
     disk:
       - type: rdm
@@ -316,7 +316,7 @@ EXAMPLES = r'''
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     datacenter: "{{ datacenter_name }}"
-    validate_certs: no
+    validate_certs: false
     name: "Test_VM"
     disk:
       - type: rdm
@@ -333,7 +333,7 @@ EXAMPLES = r'''
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     datacenter: "{{ datacenter_name }}"
-    validate_certs: no
+    validate_certs: false
     name: "Test_VM"
     disk:
       - type: rdm
@@ -351,7 +351,7 @@ EXAMPLES = r'''
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     datacenter: "{{ datacenter_name }}"
-    validate_certs: no
+    validate_certs: false
     name: "Test_VM"
     disk:
       - type: rdm
@@ -424,7 +424,7 @@ EXAMPLES = r'''
       - state: absent
         scsi_controller: 1
         unit_number: 2
-        destroy: no
+        destroy: false
   delegate_to: localhost
   register: disk_facts
 
@@ -434,7 +434,7 @@ EXAMPLES = r'''
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     datacenter: "{{ datacenter_name }}"
-    validate_certs: no
+    validate_certs: false
     uuid: 421e4592-c069-924d-ce20-7e7533fab926
     disk:
       - size_mb: 256
@@ -461,7 +461,7 @@ EXAMPLES = r'''
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     datacenter: "{{ datacenter_name }}"
-    validate_certs: no
+    validate_certs: false
     name: VM_226
     disk:
       - type: vpmemdisk

--- a/plugins/modules/vmware_guest_file_operation.py
+++ b/plugins/modules/vmware_guest_file_operation.py
@@ -172,7 +172,7 @@ EXAMPLES = r'''
     directory:
       path: "/test"
       operation: create
-      recurse: no
+      recurse: false
   delegate_to: localhost
 
 - name: copy file to vm

--- a/plugins/modules/vmware_guest_storage_policy.py
+++ b/plugins/modules/vmware_guest_storage_policy.py
@@ -109,7 +109,7 @@ EXAMPLES = r'''
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    validate_certs: no
+    validate_certs: false
     uuid: cefd316c-fc19-45f3-a539-2cd03427a78d
     disk:
       - unit_number: 0
@@ -126,7 +126,7 @@ EXAMPLES = r'''
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    validate_certs: no
+    validate_certs: false
     name: hostname1
     vm_home: storepol1
   delegate_to: localhost

--- a/plugins/modules/vmware_guest_vgpu.py
+++ b/plugins/modules/vmware_guest_vgpu.py
@@ -101,7 +101,7 @@ EXAMPLES = r"""
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     datacenter: "{{ datacenter_name }}"
-    validate_certs: no
+    validate_certs: false
     name: UbuntuTest
     vgpu: 'grid_m10-8q'
     state: present
@@ -114,7 +114,7 @@ EXAMPLES = r"""
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     datacenter: "{{ datacenter_name }}"
-    validate_certs: no
+    validate_certs: false
     name: UbuntuTest
     vgpu: 'grid_m10-8q'
     state: absent

--- a/plugins/modules/vmware_guest_vgpu_info.py
+++ b/plugins/modules/vmware_guest_vgpu_info.py
@@ -74,7 +74,7 @@ EXAMPLES = r"""
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     datacenter: "{{ datacenter_name }}"
-    validate_certs: no
+    validate_certs: false
     name: UbuntuTest
   delegate_to: localhost
   register: vgpu_info

--- a/plugins/modules/vmware_host_datastore.py
+++ b/plugins/modules/vmware_host_datastore.py
@@ -109,7 +109,7 @@ EXAMPLES = r'''
       datastore_type: '{{ item.type }}'
       nfs_server: '{{ item.server }}'
       nfs_path: '{{ item.path }}'
-      nfs_ro: no
+      nfs_ro: false
       esxi_hostname: '{{ inventory_hostname }}'
       state: present
   delegate_to: localhost
@@ -126,7 +126,7 @@ EXAMPLES = r'''
       datastore_type: '{{ item.type }}'
       nfs_server: '{{ item.server }}'
       nfs_path: '{{ item.path }}'
-      nfs_ro: no
+      nfs_ro: false
       esxi_hostname: '{{ inventory_hostname }}'
       state: present
   delegate_to: localhost

--- a/plugins/modules/vmware_recommended_datastore.py
+++ b/plugins/modules/vmware_recommended_datastore.py
@@ -44,7 +44,7 @@ EXAMPLES = r"""
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
-    validate_certs: no
+    validate_certs: false
     datastore_cluster: '{{ datastore_cluster_name }}'
     datacenter: '{{ datacenter }}'
   register: recommended_ds


### PR DESCRIPTION
##### SUMMARY
Use `false` instead of `no` in examples.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
vmware_deploy_ovf
vmware_guest_disk
vmware_guest_file_operation
vmware_guest_storage_policy
vmware_guest_vgpu_info
vmware_guest_vgpu
vmware_host_datastore
vmware_recommended_datastore

##### ADDITIONAL INFORMATION
#1660