### PR TITLE
Module vmware_guest_cross_vc_clone - fix timeout and notauthenticated issue

### DIFF
--- a/changelogs/fragments/1223-cross_vc_clone_timeout.yml
+++ b/changelogs/fragments/1223-cross_vc_clone_timeout.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - vmware_cross_vc_clone - New parameter timeout in order to allow clone running longer than 1 hour
+  - vmware_cross_vc_clone - Fix vim.fault.NotAuthenticated issue
+    (https://github.com/ansible-collections/community.vmware/issues/1223).


### PR DESCRIPTION
##### SUMMARY
Fixes #1223
Add a parameter timeout to the vmware_guest_cross_vc_clone module in order to allow cross vc clone running longer than 1 hour.
Reconnect to destination vc after the clone to avoid the "vim.fault.NotAuthenticated" issue when the clone is long

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_guest_cross_vc_clone

##### ADDITIONAL INFORMATION
Improve the module to fix timeout and notauthenticated issues which happened when the clone take a lot of time.

Similar to #1629 