### PR TITLE
issue_1682_vmware_vm_info_more_show_parameters

### DIFF
--- a/changelogs/fragments/1682_vmware_vm_info
+++ b/changelogs/fragments/1682_vmware_vm_info
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_vm_info - Add several parameters to skip discovering some information (https://github.com/ansible-collections/community.vmware/issues/1682)


### PR DESCRIPTION
##### SUMMARY
Fixes #1682

add parameters for faster run:
* show_cluster=dict(type='bool', default=True),
* show_datacenter=dict(type='bool', default=True),
* show_datastore=dict(type='bool', default=True),
* show_esxi_hostname=dict(type='bool', default=True),
* show_mac_address=dict(type='bool', default=True),
* show_net=dict(type='bool', default=True),
* show_resource_pool=dict(type='bool', default=True),

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE

- Feature Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
community.vmware.vmware_vm_info

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
