### PR TITLE
vmware_host_tcpip_stacks: Enable integration tests again

### DIFF
--- a/tests/integration/targets/vmware_host_tcpip_stacks/aliases
+++ b/tests/integration/targets/vmware_host_tcpip_stacks/aliases
@@ -1,4 +1,3 @@
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
-disabled

--- a/tests/integration/targets/vmware_host_tcpip_stacks/tasks/main.yml
+++ b/tests/integration/targets/vmware_host_tcpip_stacks/tasks/main.yml
@@ -14,4 +14,4 @@
 - block:
   - include_tasks: vmware_host_tcpip_stacks_tests.yml
   always:
-  - include_tasks: destroy.yml
+  - include_tasks: post.yml

--- a/tests/integration/targets/vmware_host_tcpip_stacks/tasks/post.yml
+++ b/tests/integration/targets/vmware_host_tcpip_stacks/tasks/post.yml
@@ -52,3 +52,27 @@
   loop:
     - provisioning
     - vmotion
+
+- name: Restore original configuration
+  vmware_host_tcpip_stacks:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: "{{ esxi_hosts[0] }}"
+    default:
+      hostname: "{{ default_stack_backup.dnsConfig.hostName }}"
+      domain: "{{ default_stack_backup.dnsConfig.domainName }}"
+      #preferred_dns: "{{ default_stack_backup.dnsConfig.address }}"
+      search_domains: "{{ default_stack_backup.dnsConfig.searchDomain }}"
+      gateway: "{{ default_stack_backup.ipRouteConfig.defaultGateway }}"
+      congestion_algorithm: "{{ default_stack_backup.congestionControlAlgorithm }}"
+      max_num_connections: "{{ default_stack_backup.requestedMaxNumberOfConnections }}"
+    provisioning:
+      gateway: "{{ provisioning_stack_backup.ipRouteConfig.defaultGateway }}"
+      congestion_algorithm: "{{ provisioning_stack_backup.congestionControlAlgorithm }}"
+      max_num_connections: "{{ provisioning_stack_backup.requestedMaxNumberOfConnections }}"
+    vmotion:
+      gateway: "{{ vmotion_stack_backup.ipRouteConfig.defaultGateway }}"
+      congestion_algorithm: "{{ vmotion_stack_backup.congestionControlAlgorithm }}"
+      max_num_connections: "{{ vmotion_stack_backup.requestedMaxNumberOfConnections }}"

--- a/tests/integration/targets/vmware_host_tcpip_stacks/tasks/pre.yml
+++ b/tests/integration/targets/vmware_host_tcpip_stacks/tasks/pre.yml
@@ -66,21 +66,19 @@
     that:
       - vmkernel_vmotion_result.changed is sameas true
 
-- name: Gather vmk info
-  vmware_vmkernel_info:
+- name: Gather host facts
+  vmware_host_facts:
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     validate_certs: false
     esxi_hostname: "{{ esxi_hosts[0] }}"
-  register: vmk0_info_result
+    schema: vsphere
+  register: gather_host_facts_result
 
-- name: set the variable of vmk0 ipaddr
+- name: set the variable of original gw
   set_fact:
-    vmk0_ipaddr: "{{ item.ipv4_address }}"
-  loop: "{{ vmk0_info_result.host_vmk_info[esxi_hosts[0]] }}"
-  when:
-    - item.device == "vmk0"
+    original_gw: "{{ gather_host_facts_result.ansible_facts.config.network.ipRouteConfig.defaultGateway }}"
 
 - name: set the variable for each vmk
   set_fact:
@@ -90,6 +88,6 @@
 - name: Make sure if defined the variables
   assert:
     that:
-      - vmk0_ipaddr is defined
+      - original_gw is defined
       - provisioning_vmk is defined
       - vmotion_vmk is defined

--- a/tests/integration/targets/vmware_host_tcpip_stacks/tasks/pre.yml
+++ b/tests/integration/targets/vmware_host_tcpip_stacks/tasks/pre.yml
@@ -74,11 +74,28 @@
     validate_certs: false
     esxi_hostname: "{{ esxi_hosts[0] }}"
     schema: vsphere
-  register: gather_host_facts_result
+  register: gather_host_facts_from_vcenter_result
 
-- name: set the variable of original gw
+- name: Backup default stack
   set_fact:
-    original_gw: "{{ gather_host_facts_result.ansible_facts.config.network.ipRouteConfig.defaultGateway }}"
+    default_stack_backup: "{{ item }}"
+  loop: "{{ gather_host_facts_from_vcenter_result.ansible_facts.config.network.netStackInstance }}"
+  when:
+    - item.key == "defaultTcpipStack"
+
+- name: Backup provisioning stack
+  set_fact:
+    provisioning_stack_backup: "{{ item }}"
+  loop: "{{ gather_host_facts_from_vcenter_result.ansible_facts.config.network.netStackInstance }}"
+  when:
+    - item.key == "vSphereProvisioning"
+
+- name: Backup vmotion stack
+  set_fact:
+    vmotion_stack_backup: "{{ item }}"
+  loop: "{{ gather_host_facts_from_vcenter_result.ansible_facts.config.network.netStackInstance }}"
+  when:
+    - item.key == "vmotion"
 
 - name: set the variable for each vmk
   set_fact:
@@ -88,6 +105,8 @@
 - name: Make sure if defined the variables
   assert:
     that:
-      - original_gw is defined
+      - default_stack_backup is defined
+      - provisioning_stack_backup is defined
+      - vmotion_stack_backup is defined
       - provisioning_vmk is defined
       - vmotion_vmk is defined

--- a/tests/integration/targets/vmware_host_tcpip_stacks/tasks/vmware_host_tcpip_stacks_tests.yml
+++ b/tests/integration/targets/vmware_host_tcpip_stacks/tasks/vmware_host_tcpip_stacks_tests.yml
@@ -16,7 +16,7 @@
       alternate_dns: 9.9.9.9
       search_domains:
         - example.com
-      gateway: "{{ vmk0_ipaddr }}"
+      gateway: "{{ original_gw }}"
       congestion_algorithm: cubic
       max_num_connections: 12000
   check_mode: true
@@ -43,7 +43,7 @@
       alternate_dns: 9.9.9.9
       search_domains:
         - example.com
-      gateway: "{{ vmk0_ipaddr }}"
+      gateway: "{{ original_gw }}"
       congestion_algorithm: cubic
       max_num_connections: 12000
   register: update_default_config_result
@@ -58,7 +58,7 @@
       - update_default_config_result.default.preferred_dns == "8.8.8.8"
       - update_default_config_result.default.alternate_dns == "9.9.9.9"
       - update_default_config_result.default.search_domains.0 == "example.com"
-      - update_default_config_result.default.gateway == vmk0_ipaddr
+      - update_default_config_result.default.gateway == original_gw
       - update_default_config_result.default.congestion_algorithm == "cubic"
       - update_default_config_result.default.max_num_connections == 12000
 
@@ -76,7 +76,7 @@
       alternate_dns: 9.9.9.9
       search_domains:
         - example.com
-      gateway: "{{ vmk0_ipaddr }}"
+      gateway: "{{ original_gw }}"
       congestion_algorithm: cubic
       max_num_connections: 12000
   register: update_default_config_idempotency_result
@@ -223,7 +223,7 @@
       search_domains:
         - example.com
         - hoge.com
-      gateway: "{{ vmk0_ipaddr }}"
+      gateway: "{{ original_gw }}"
       congestion_algorithm: newreno
       max_num_connections: 11000
     provisioning:
@@ -259,7 +259,7 @@
       search_domains:
         - example.com
         - hoge.com
-      gateway: "{{ vmk0_ipaddr }}"
+      gateway: "{{ original_gw }}"
       congestion_algorithm: newreno
       max_num_connections: 11000
     provisioning:
@@ -283,7 +283,7 @@
       - update_all_config_result.default.alternate_dns == "8.8.8.8"
       - update_all_config_result.default.search_domains.0 == "example.com"
       - update_all_config_result.default.search_domains.1 == "hoge.com"
-      - update_all_config_result.default.gateway == vmk0_ipaddr
+      - update_all_config_result.default.gateway == original_gw
       - update_all_config_result.default.congestion_algorithm == "newreno"
       - update_all_config_result.default.max_num_connections == 11000
       - update_all_config_result.provisioning.gateway == "100.64.0.2"
@@ -308,7 +308,7 @@
       search_domains:
         - example.com
         - hoge.com
-      gateway: "{{ vmk0_ipaddr }}"
+      gateway: "{{ original_gw }}"
       congestion_algorithm: newreno
       max_num_connections: 11000
     provisioning:

--- a/tests/integration/targets/vmware_host_tcpip_stacks/tasks/vmware_host_tcpip_stacks_tests.yml
+++ b/tests/integration/targets/vmware_host_tcpip_stacks/tasks/vmware_host_tcpip_stacks_tests.yml
@@ -16,7 +16,7 @@
       alternate_dns: 9.9.9.9
       search_domains:
         - example.com
-      gateway: "{{ original_gw }}"
+      gateway: "{{ default_stack_backup.ipRouteConfig.defaultGateway }}"
       congestion_algorithm: cubic
       max_num_connections: 12000
   check_mode: true
@@ -43,7 +43,7 @@
       alternate_dns: 9.9.9.9
       search_domains:
         - example.com
-      gateway: "{{ original_gw }}"
+      gateway: "{{ default_stack_backup.ipRouteConfig.defaultGateway }}"
       congestion_algorithm: cubic
       max_num_connections: 12000
   register: update_default_config_result
@@ -58,7 +58,7 @@
       - update_default_config_result.default.preferred_dns == "8.8.8.8"
       - update_default_config_result.default.alternate_dns == "9.9.9.9"
       - update_default_config_result.default.search_domains.0 == "example.com"
-      - update_default_config_result.default.gateway == original_gw
+      - update_default_config_result.default.gateway == default_stack_backup.ipRouteConfig.defaultGateway
       - update_default_config_result.default.congestion_algorithm == "cubic"
       - update_default_config_result.default.max_num_connections == 12000
 
@@ -76,7 +76,7 @@
       alternate_dns: 9.9.9.9
       search_domains:
         - example.com
-      gateway: "{{ original_gw }}"
+      gateway: "{{ default_stack_backup.ipRouteConfig.defaultGateway }}"
       congestion_algorithm: cubic
       max_num_connections: 12000
   register: update_default_config_idempotency_result
@@ -223,7 +223,7 @@
       search_domains:
         - example.com
         - hoge.com
-      gateway: "{{ original_gw }}"
+      gateway: "{{ default_stack_backup.ipRouteConfig.defaultGateway }}"
       congestion_algorithm: newreno
       max_num_connections: 11000
     provisioning:
@@ -259,7 +259,7 @@
       search_domains:
         - example.com
         - hoge.com
-      gateway: "{{ original_gw }}"
+      gateway: "{{ default_stack_backup.ipRouteConfig.defaultGateway }}"
       congestion_algorithm: newreno
       max_num_connections: 11000
     provisioning:
@@ -283,7 +283,7 @@
       - update_all_config_result.default.alternate_dns == "8.8.8.8"
       - update_all_config_result.default.search_domains.0 == "example.com"
       - update_all_config_result.default.search_domains.1 == "hoge.com"
-      - update_all_config_result.default.gateway == original_gw
+      - update_all_config_result.default.gateway == default_stack_backup.ipRouteConfig.defaultGateway
       - update_all_config_result.default.congestion_algorithm == "newreno"
       - update_all_config_result.default.max_num_connections == 11000
       - update_all_config_result.provisioning.gateway == "100.64.0.2"
@@ -308,7 +308,7 @@
       search_domains:
         - example.com
         - hoge.com
-      gateway: "{{ original_gw }}"
+      gateway: "{{ default_stack_backup.ipRouteConfig.defaultGateway }}"
       congestion_algorithm: newreno
       max_num_connections: 11000
     provisioning:


### PR DESCRIPTION
##### SUMMARY
Fixes #1120

Enable integration tests for vmware_host_tcpip_stacks again.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_host_tcpip_stacks

##### ADDITIONAL INFORMATION
#1121