### PR TITLE
vmware_host_service_manager: Enable integration tests again

### DIFF
--- a/tests/integration/targets/vmware_host_service_manager/aliases
+++ b/tests/integration/targets/vmware_host_service_manager/aliases
@@ -1,4 +1,3 @@
 cloud/vcenter
 needs/target/prepare_vmware_tests
 zuul/vmware/vcenter_1esxi
-disabled


### PR DESCRIPTION
##### SUMMARY
Enable integration tests for vmware_host_service_manager again.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_host_service_manager

##### ADDITIONAL INFORMATION
#945