### PR TITLE
fix(vmware_vsan_health_info): Return dict instead of JSON string

### DIFF
--- a/changelogs/fragments/1706-vmware_vsan_health_info.yml
+++ b/changelogs/fragments/1706-vmware_vsan_health_info.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  -  vmware_vsan_health_info - Fix return value (https://github.com/ansible-collections/community.vmware/pull/1706).

--- a/plugins/modules/vmware_vsan_health_info.py
+++ b/plugins/modules/vmware_vsan_health_info.py
@@ -167,7 +167,7 @@ class VSANInfoManager(PyVmomi):
 
         health = json.dumps(cluster_health, cls=VmomiSupport.VmomiJSONEncoder, sort_keys=True, strip_dynamic=True)
 
-        self.module.exit_json(changed=False, vsan_health_info=health)
+        self.module.exit_json(changed=False, vsan_health_info=json.loads(health))
 
 
 def main():


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #1648

While the module description says that the return type should be a dict, it actually returns a JSON string

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_vsan_health_info
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
