### PR TITLE
vmware_guest - set custom attributes on VM create

### DIFF
--- a/changelogs/1713-vmware_guest-custom_attributes_on_create.yaml
+++ b/changelogs/1713-vmware_guest-custom_attributes_on_create.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - vmware_guest - Fixed issue where custom attributes were not getting set on VM creation (https://github.com/ansible-collections/community.vmware/pull/1713)

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -3126,6 +3126,9 @@ class PyVmomiHelper(PyVmomi):
                 if task.info.state == 'error':
                     return {'changed': self.change_applied, 'failed': True, 'msg': task.info.error.msg, 'op': 'advanced_settings'}
 
+            if self.params['customvalues']:
+                self.customize_customvalues(vm_obj=vm)
+
             if self.params['wait_for_ip_address'] or self.params['wait_for_customization'] or self.params['state'] in ['poweredon', 'powered-on', 'restarted']:
                 set_vm_power_state(self.content, vm, 'poweredon', force=False)
 

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -3124,7 +3124,7 @@ class PyVmomiHelper(PyVmomi):
                 task = vm.ReconfigVM_Task(vm_custom_spec)
                 self.wait_for_task(task)
                 if task.info.state == 'error':
-                    return {'changed': self.change_applied, 'failed': True, 'msg': task.info.error.msg, 'op': 'customvalues'}
+                    return {'changed': self.change_applied, 'failed': True, 'msg': task.info.error.msg, 'op': 'advanced_settings'}
 
             if self.params['wait_for_ip_address'] or self.params['wait_for_customization'] or self.params['state'] in ['poweredon', 'powered-on', 'restarted']:
                 set_vm_power_state(self.content, vm, 'poweredon', force=False)


### PR DESCRIPTION
##### SUMMARY
Fixes issue where custom attributes were not getting set on VM creation.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- `plugins/modules/vmware_guest.py`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
