### PR TITLE
Add mac address fix to vmware_guest.py

### DIFF
--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -1950,6 +1950,9 @@ class PyVmomiHelper(PyVmomi):
                 if 'mac' in network_devices[key] and nic.device.macAddress != current_net_devices[key].macAddress:
                     self.module.fail_json(msg="Changing MAC address has not effect when interface is already present. "
                                               "The failing new MAC address is %s" % nic.device.macAddress)
+                if network_devices[key].get('mac') != nic.device.macAddress:
+                    nic.device.macAddress = network_devices[key].get('mac')
+                    nic_change_detected = True
 
             else:
                 # Default device type is vmxnet3, VMware best practice


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This change seeks to fix a problem encountered when building multiple VM's from a template, using customisation to apply new IP details, where the mac addresses are not properly handled by the customiser script.

Original change from https://github.com/ansible/ansible/issues/64774#issuecomment-554390558

This looks to fix #1391 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_guest

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

