### PR TITLE
Add vVols management

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,15 @@ community.vmware Release Notes
 .. contents:: Topics
 
 
+v3.5.1
+======
+
+Bugfixes
+--------
+
+- vmware_guest - Fixed issue where custom attributes were not getting set on VM creation (https://github.com/ansible-collections/community.vmware/pull/1713)
+- vmware_vsan_health_info - Fix return value (https://github.com/ansible-collections/community.vmware/pull/1706).
+
 v3.5.0
 ======
 

--- a/README.md
+++ b/README.md
@@ -221,6 +221,8 @@ Name | Description
 [community.vmware.vmware_tag_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_tag_info_module.rst)|Manage VMware tag info
 [community.vmware.vmware_tag_manager](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_tag_manager_module.rst)|Manage association of VMware tags with VMware objects
 [community.vmware.vmware_target_canonical_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_target_canonical_info_module.rst)|Return canonical (NAA) from an ESXi host system
+[community.vmware.vmware_vasa](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_vasa_module.rst)|Manage VMware Virtual Volumes storage provider
+[community.vmware.vmware_vasa_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_vasa_info_module.rst)|Gather information about vSphere VASA providers.
 [community.vmware.vmware_vc_infraprofile_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_vc_infraprofile_info_module.rst)|List and Export VMware vCenter infra profile configs.
 [community.vmware.vmware_vcenter_settings](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_vcenter_settings_module.rst)|Configures general settings on a vCenter server
 [community.vmware.vmware_vcenter_settings_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_vcenter_settings_info_module.rst)|Gather info vCenter settings
@@ -242,6 +244,7 @@ Name | Description
 [community.vmware.vmware_vspan_session](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_vspan_session_module.rst)|Create or remove a Port Mirroring session.
 [community.vmware.vmware_vswitch](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_vswitch_module.rst)|Manage a VMware Standard Switch to an ESXi host.
 [community.vmware.vmware_vswitch_info](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vmware_vswitch_info_module.rst)|Gathers info about an ESXi host's vswitch configurations
+[community.vmware.vsan_health_silent_checks](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vsan_health_silent_checks_module.rst)|Silence vSAN health checks
 [community.vmware.vsphere_copy](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vsphere_copy_module.rst)|Copy a file to a VMware datastore
 [community.vmware.vsphere_file](https://github.com/ansible-collections/community.vmware/blob/main/docs/community.vmware.vsphere_file_module.rst)|Manage files on a vCenter datastore
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -1552,3 +1552,13 @@ releases:
       name: vmware_vsan_hcl_db
       namespace: ''
     release_date: '2023-03-26'
+  3.5.1:
+    changes:
+      bugfixes:
+      - vmware_guest - Fixed issue where custom attributes were not getting set on
+        VM creation (https://github.com/ansible-collections/community.vmware/pull/1713)
+      - vmware_vsan_health_info - Fix return value (https://github.com/ansible-collections/community.vmware/pull/1706).
+    fragments:
+    - 1706-vmware_vsan_health_info.yml
+    - 1713-vmware_guest-custom_attributes_on_create.yaml
+    release_date: '2023-05-07'

--- a/changelogs/fragments/1706-vmware_vsan_health_info.yml
+++ b/changelogs/fragments/1706-vmware_vsan_health_info.yml
@@ -1,2 +1,0 @@
-bugfixes:
-  -  vmware_vsan_health_info - Fix return value (https://github.com/ansible-collections/community.vmware/pull/1706).

--- a/changelogs/fragments/1713-vmware_guest-custom_attributes_on_create.yaml
+++ b/changelogs/fragments/1713-vmware_guest-custom_attributes_on_create.yaml
@@ -1,3 +1,0 @@
----
-bugfixes:
-  - vmware_guest - Fixed issue where custom attributes were not getting set on VM creation (https://github.com/ansible-collections/community.vmware/pull/1713)

--- a/docs/community.vmware.vmware_host_datastore_module.rst
+++ b/docs/community.vmware.vmware_host_datastore_module.rst
@@ -86,6 +86,7 @@ Parameters
                                     <li>nfs</li>
                                     <li>nfs41</li>
                                     <li>vmfs</li>
+                                    <li>vvol</li>
                         </ul>
                 </td>
                 <td>
@@ -311,6 +312,21 @@ Parameters
             <tr>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>vasa_provider</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>hostname or ipaddress of the VASA providere to use for vVols provisioning</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>vmfs_device_name</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
@@ -404,6 +420,30 @@ Examples
       loop:
           - { 'name': 'NasDS_vol03', 'server': 'nas01,nas02', 'path': '/mnt/vol01', 'type': 'nfs41'}
           - { 'name': 'NasDS_vol04', 'server': 'nas01,nas02', 'path': '/mnt/vol02', 'type': 'nfs41'}
+
+    - name: Mount vVols datastore to ESXi
+      community.vmware.vmware_host_datastore:
+          hostname: '{{ vcenter_hostname }}'
+          username: '{{ vcenter_username }}'
+          password: '{{ vcenter_password }}'
+          datastore_name: myvvolds
+          datastore_type: vvol
+          vasa_provider: pure-X90a
+          esxi_hostname: esxi-1
+          state: absent
+      delegate_to: localhost
+
+    - name: Mount unresolved VMFS datastores to ESXi
+      community.vmware.vmware_host_datastore:
+          hostname: '{{ vcenter_hostname }}'
+          username: '{{ vcenter_username }}'
+          password: '{{ vcenter_password }}'
+          datastore_name: mydatastore01
+          vmfs_device_name: 'naa.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+          vmfs_version: 6
+          esxi_hostname:  esxi01
+          state: present
+      delegate_to: localhost
 
     - name: Remove/Umount Datastores from a ESXi
       community.vmware.vmware_host_datastore:

--- a/docs/community.vmware.vmware_vasa_info_module.rst
+++ b/docs/community.vmware.vmware_vasa_info_module.rst
@@ -1,0 +1,229 @@
+.. _community.vmware.vmware_vasa_info_module:
+
+
+*********************************
+community.vmware.vmware_vasa_info
+*********************************
+
+**Gather information about vSphere VASA providers.**
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Returns basic information on the vSphere VASA providers registered in the vcenter.
+
+
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+            <th width="100%">Comments</th>
+        </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>hostname</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The hostname or IP address of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_HOST</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The password of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PASSWORD</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: pass, pwd</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">443</div>
+                </td>
+                <td>
+                        <div>The port number of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PORT</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>proxy_host</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Address of a proxy that will receive all HTTPS requests and relay them.</div>
+                        <div>The format is a hostname or a IP.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PROXY_HOST</code> will be used instead.</div>
+                        <div>This feature depends on a version of pyvmomi greater than v6.7.1.2018.12</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>proxy_port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Port of the HTTP proxy that will receive all HTTPS requests and relay them.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PROXY_PORT</code> will be used instead.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>username</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The username of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_USER</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: admin, user</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>validate_certs</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>no</li>
+                                    <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Allows connection when SSL certificates are not valid. Set to <code>false</code> when certificates are not trusted.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_VALIDATE_CERTS</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                        <div>If set to <code>true</code>, please make sure Python &gt;= 2.7.9 is installed on the given machine.</div>
+                </td>
+            </tr>
+    </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - All modules requires API write access and hence is not supported on a free ESXi license.
+
+
+
+Examples
+--------
+
+.. code-block:: yaml
+
+    - name: Get VASA providers info
+      community.vmware.vmware__info:
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+      delegate_to: localhost
+      register: providers
+
+
+
+Return Values
+-------------
+Common return values are documented `here <https://docs.ansible.com/ansible/latest/reference_appendices/common_return_values.html#common-return-values>`_, the following are the fields unique to this module:
+
+.. raw:: html
+
+    <table border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Key</th>
+            <th>Returned</th>
+            <th width="100%">Description</th>
+        </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>vasa_providers</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">list</span>
+                    </div>
+                </td>
+                <td>success</td>
+                <td>
+                            <div>list of dictionary of VASA info</div>
+                    <br/>
+                        <div style="font-size: smaller"><b>Sample:</b></div>
+                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">[{&#x27;certificate_status&#x27;: &#x27;valid&#x27;, &#x27;description&#x27;: &#x27;IOFILTER VASA Provider on host host01.domain.local&#x27;, &#x27;name&#x27;: &#x27;IOFILTER Provider host01.domain.local&#x27;, &#x27;related_storage_array&#x27;: [{&#x27;active&#x27;: &#x27;True&#x27;, &#x27;array_id&#x27;: &#x27;IOFILTERS:616d4715-7de2-7be2-997a-10f920c5fdbe&#x27;, &#x27;manageable&#x27;: &#x27;True&#x27;, &#x27;priority&#x27;: &#x27;1&#x27;}], &#x27;status&#x27;: &#x27;online&#x27;, &#x27;uid&#x27;: &#x27;02e10bc5-dd77-4ce4-9100-5aee44e7abaa&#x27;, &#x27;url&#x27;: &#x27;https://host01.domain.local:9080/version.xml&#x27;, &#x27;version&#x27;: &#x27;1.0&#x27;}]</div>
+                </td>
+            </tr>
+    </table>
+    <br/><br/>
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Eugenio Grosso

--- a/docs/community.vmware.vmware_vasa_module.rst
+++ b/docs/community.vmware.vmware_vasa_module.rst
@@ -1,0 +1,318 @@
+.. _community.vmware.vmware_vasa_module:
+
+
+****************************
+community.vmware.vmware_vasa
+****************************
+
+**Manage VMware Virtual Volumes storage provider**
+
+
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- This module can be used to register and unregister a VASA provider
+
+
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+            <th width="100%">Comments</th>
+        </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>hostname</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The hostname or IP address of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_HOST</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The password of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PASSWORD</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: pass, pwd</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">443</div>
+                </td>
+                <td>
+                        <div>The port number of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PORT</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>proxy_host</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Address of a proxy that will receive all HTTPS requests and relay them.</div>
+                        <div>The format is a hostname or a IP.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PROXY_HOST</code> will be used instead.</div>
+                        <div>This feature depends on a version of pyvmomi greater than v6.7.1.2018.12</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>proxy_port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Port of the HTTP proxy that will receive all HTTPS requests and relay them.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PROXY_PORT</code> will be used instead.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>absent</li>
+                                    <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Create <code>present</code> or remove <code>absent</code> a VASA provider.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>username</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The username of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_USER</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: admin, user</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>validate_certs</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>no</li>
+                                    <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Allows connection when SSL certificates are not valid. Set to <code>false</code> when certificates are not trusted.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_VALIDATE_CERTS</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                        <div>If set to <code>true</code>, please make sure Python &gt;= 2.7.9 is installed on the given machine.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>vasa_certificate</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The SSL certificate of the VASA provider.</div>
+                        <div>This parameter is required if <em>state=present</em></div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>vasa_name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The name of the VASA provider to be managed.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>vasa_password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The password of the user account to connect to the VASA provider.</div>
+                        <div>This parameter is required if <em>state=present</em></div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>vasa_url</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The url  of the VASA provider to be managed.</div>
+                        <div>This parameter is required if <em>state=present</em></div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>vasa_username</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The user account to connect to the VASA provider.</div>
+                        <div>This parameter is required if <em>state=present</em></div>
+                </td>
+            </tr>
+    </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - All modules requires API write access and hence is not supported on a free ESXi license.
+
+
+See Also
+--------
+
+.. seealso::
+
+   :ref:`community.vmware.vmware_vasa_info_module`
+      The official documentation on the **community.vmware.vmware_vasa_info** module.
+
+
+Examples
+--------
+
+.. code-block:: yaml
+
+    - name: Create Cluster
+      community.vmware.vmware_cluster:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        vasa_name: "{{ vasa_name }}"
+        vasa_url: "{{ vasa_url }}"
+        vasa_username: "{{ vasa_username }}"
+        vasa_password: "{{ vasa_password }}"
+        vasa_certificate: "{{ vasa_certificate }}"
+        state: present
+      delegate_to: localhost
+
+    - name: Unregister VASA provider
+      community.vmware.vmware_vasa:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        vasa_name: "{{ vasa_name }}"
+        state: absent
+      delegate_to: localhost
+
+
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Eugenio Grosso (egrosso@purestorage.com)

--- a/docs/community.vmware.vsan_health_silent_checks_module.rst
+++ b/docs/community.vmware.vsan_health_silent_checks_module.rst
@@ -1,0 +1,271 @@
+.. _community.vmware.vsan_health_silent_checks_module:
+
+
+******************************************
+community.vmware.vsan_health_silent_checks
+******************************************
+
+**Silence vSAN health checks**
+
+
+Version added: 3.6.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+- Take a list of vSAN health checks and silence them
+- Re-enable alerts for previously silenced health checks
+
+
+
+Requirements
+------------
+The below requirements are needed on the host that executes this module.
+
+- vSAN Management SDK, which needs to be downloaded from VMware and installed manually.
+
+
+Parameters
+----------
+
+.. raw:: html
+
+    <table  border=0 cellpadding=0 class="documentation-table">
+        <tr>
+            <th colspan="1">Parameter</th>
+            <th>Choices/<font color="blue">Defaults</font></th>
+            <th width="100%">Comments</th>
+        </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>checks</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">list</span>
+                         / <span style="color: purple">elements=string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The checks to silence.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>cluster_name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                         / <span style="color: red">required</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Name of the vSAN cluster.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>hostname</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The hostname or IP address of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_HOST</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>password</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The password of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PASSWORD</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: pass, pwd</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>
+                        <b>Default:</b><br/><div style="color: blue">443</div>
+                </td>
+                <td>
+                        <div>The port number of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PORT</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>proxy_host</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Address of a proxy that will receive all HTTPS requests and relay them.</div>
+                        <div>The format is a hostname or a IP.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PROXY_HOST</code> will be used instead.</div>
+                        <div>This feature depends on a version of pyvmomi greater than v6.7.1.2018.12</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>proxy_port</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Port of the HTTP proxy that will receive all HTTPS requests and relay them.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_PROXY_PORT</code> will be used instead.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>state</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li><div style="color: blue"><b>present</b>&nbsp;&larr;</div></li>
+                                    <li>absent</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>The state of the health checks.</div>
+                        <div>If set to <code>present</code>, all given health checks will be silenced.</div>
+                        <div>If set to <code>absent</code>, all given health checks will be removed from the list of silent checks.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>username</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The username of the vSphere vCenter or ESXi server.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_USER</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                        <div style="font-size: small; color: darkgreen"><br/>aliases: admin, user</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>validate_certs</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>no</li>
+                                    <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Allows connection when SSL certificates are not valid. Set to <code>false</code> when certificates are not trusted.</div>
+                        <div>If the value is not specified in the task, the value of environment variable <code>VMWARE_VALIDATE_CERTS</code> will be used instead.</div>
+                        <div>Environment variable support added in Ansible 2.6.</div>
+                        <div>If set to <code>true</code>, please make sure Python &gt;= 2.7.9 is installed on the given machine.</div>
+                </td>
+            </tr>
+    </table>
+    <br/>
+
+
+Notes
+-----
+
+.. note::
+   - All modules requires API write access and hence is not supported on a free ESXi license.
+
+
+
+Examples
+--------
+
+.. code-block:: yaml
+
+    - name: Disable the vSAN Support Insight health check
+      community.vmware.vsan_health_silent_checks:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        checks: vsanenablesupportinsight
+        cluster_name: 'vSAN01'
+      delegate_to: localhost
+
+    - name: Re-enable health check alerts for release catalog and HCL DB
+      community.vmware.vsan_health_silent_checks:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        checks:
+          - releasecataloguptodate
+          - autohclupdate
+        state: absent
+        cluster_name: 'vSAN01'
+      delegate_to: localhost
+
+
+
+
+Status
+------
+
+
+Authors
+~~~~~~~
+
+- Philipp Fruck (@p-fruck)

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -5,7 +5,7 @@ name: vmware
 # https://github.com/ansible-network/releases/tree/master/ansible_releases/cmd
 # A script based on https://pypi.org/project/pbr/ will generate the version
 # key. The version value depends on the tag or the last git tag.
-version: null
+version: 3.5.1
 readme: README.md
 authors:
   - Ansible (https://github.com/ansible)

--- a/plugins/module_utils/vmware_sms.py
+++ b/plugins/module_utils/vmware_sms.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2023, Ansible Project
+# Copyright: (c) 2023, Pure Storage, Inc.
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+try:
+    from pyVmomi import sms
+    from pyVim.connect import SoapStubAdapter
+except ImportError:
+    pass
+
+from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi
+from random import randint
+import time
+
+class TaskError(Exception):
+    def __init__(self, *args, **kwargs):
+        super(TaskError, self).__init__(*args, **kwargs)
+
+class SMS(PyVmomi):
+    def __init__(self, module):
+        super(SMS, self).__init__(module)
+        self.sms_si = None
+        self.version = "sms.version.v7_0_0_1"
+
+    def get_sms_connection(self):
+        """
+        Creates a Service instance for VMware SMS
+        """
+        client_stub = self.si._GetStub()
+        try:
+            session_cookie = client_stub.cookie.split('"')[1]
+        except IndexError:
+            self.module.fail_json(msg="Failed to get session cookie")
+        ssl_context = client_stub.schemeArgs.get('context')
+        additional_headers = {'vcSessionCookie': session_cookie}
+        hostname = self.module.params['hostname']
+        if not hostname:
+            self.module.fail_json(msg="Please specify required parameter - hostname")
+        stub = SoapStubAdapter(host=hostname, path="/sms/sdk", version=self.version,
+                               sslContext=ssl_context, requestContext=additional_headers)
+
+        self.sms_si = sms.ServiceInstance("ServiceInstance", stub)
+
+
+
+def wait_for_sms_task(task, max_backoff=64, timeout=3600):
+    """Wait for given task using exponential back-off algorithm.
+
+    Args:
+        task: VMware SMS task object
+        max_backoff: Maximum amount of sleep time in seconds
+        timeout: Timeout for the given task in seconds
+
+    Returns: Tuple with True and result for successful task
+    Raises: TaskError on failure
+    """
+    failure_counter = 0
+    start_time = time.time()
+
+    while True:
+        task_info = task.QuerySmsTaskInfo()
+        if time.time() - start_time >= timeout:
+            raise TaskError("Timeout")
+        if task_info.state == sms.TaskInfo.State.success:
+            return True, task_info.result
+        if task_info.state == sms.TaskInfo.State.error:
+            return False, task_info.error
+        if task_info.state in [sms.TaskInfo.State.running, sms.TaskInfo.State.queued]:
+            sleep_time = min(2 ** failure_counter + randint(1, 1000) / 1000, max_backoff)
+            time.sleep(sleep_time)
+            failure_counter += 1

--- a/plugins/module_utils/vmware_sms.py
+++ b/plugins/module_utils/vmware_sms.py
@@ -16,9 +16,11 @@ from ansible_collections.community.vmware.plugins.module_utils.vmware import PyV
 from random import randint
 import time
 
+
 class TaskError(Exception):
     def __init__(self, *args, **kwargs):
         super(TaskError, self).__init__(*args, **kwargs)
+
 
 class SMS(PyVmomi):
     def __init__(self, module):
@@ -44,7 +46,6 @@ class SMS(PyVmomi):
                                sslContext=ssl_context, requestContext=additional_headers)
 
         self.sms_si = sms.ServiceInstance("ServiceInstance", stub)
-
 
 
 def wait_for_sms_task(task, max_backoff=64, timeout=3600):

--- a/plugins/modules/vmware_host_datastore.py
+++ b/plugins/modules/vmware_host_datastore.py
@@ -22,6 +22,7 @@ description:
 author:
 - Ludovic Rivallain (@lrivallain) <ludovic.rivallain@gmail.com>
 - Christian Kotte (@ckotte) <christian.kotte@gmx.de>
+- Eugenio Grosso <eugenio.grosso@purestorage.com>
 notes:
 - Kerberos authentication with NFS v4.1 isn't implemented
 options:
@@ -64,7 +65,7 @@ options:
     type: int
   vasa_provider:
     description:
-    - hostname or ipaddress of the VASA providere to use for vVols provisioning
+    - hostname or ipaddress of the VASA provider to use for vVols provisioning
     type: str
     required: false
   esxi_hostname:
@@ -350,14 +351,13 @@ class VMwareHostDatastore(SMS):
                     for unres_vol in host_unres_volumes:
                         for ext in unres_vol.extent:
                             unres_vol_extents[ext.device.diskName] = ext
-                    ds_name = None
                     if self.vmfs_device_name in unres_vol_extents:
                         spec = vim.host.UnresolvedVmfsResignatureSpec()
                         spec.extentDevicePath = unres_vol_extents[self.vmfs_device_name].devicePath
                         task = host_ds_system.ResignatureUnresolvedVmfsVolume_Task(spec)
                         wait_for_task(task=task)
                         task.info.result.result.RenameDatastore(self.datastore_name)
-                else:    
+                else:
                     vmfs_ds_options = ds_system.QueryVmfsDatastoreCreateOptions(host_ds_system,
                                                                                 ds_path,
                                                                                 self.vmfs_version)
@@ -399,7 +399,7 @@ class VMwareHostDatastore(SMS):
             host_ds_system = self.esxi.configManager.datastoreSystem
             error_message_mount = "Cannot mount datastore %s on host %s" % (self.datastore_name, self.esxi.name)
             try:
-                vvols_datastore = host_ds_system.CreateVvolDatastore(vvol_spec)
+                host_ds_system.CreateVvolDatastore(vvol_spec)
             except Exception as e:
                 self.module.fail_json(msg="%s : %s" % (error_message_mount, to_native(e)))
         self.module.exit_json(changed=True, result="Datastore %s on host %s" % (self.datastore_name, self.esxi.name))

--- a/plugins/modules/vmware_host_datastore.py
+++ b/plugins/modules/vmware_host_datastore.py
@@ -404,6 +404,7 @@ class VMwareHostDatastore(SMS):
                 self.module.fail_json(msg="%s : %s" % (error_message_mount, to_native(e)))
         self.module.exit_json(changed=True, result="Datastore %s on host %s" % (self.datastore_name, self.esxi.name))
 
+
 def main():
     argument_spec = vmware_argument_spec()
     argument_spec.update(

--- a/plugins/modules/vmware_vasa.py
+++ b/plugins/modules/vmware_vasa.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright: (c) 2023, Pure Storage, Inc. 
+# Copyright: (c) 2023, Pure Storage, Inc.
 # Author(s): Eugenio Grosso, <egrosso@purestorage.com>
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
@@ -14,7 +14,7 @@ DOCUMENTATION = r'''
 module: vmware_vasa
 short_description: Manage VMware Virtual Volumes storage provider
 author:
-  - Eugenio Grosso (egrosso@purestorage.com)
+  - Eugenio Grosso <eugenio.grosso@purestorage.com>
 description:
   - This module can be used to register and unregister a VASA provider
 options:
@@ -82,7 +82,7 @@ EXAMPLES = r'''
 RETURN = r'''
 '''
 try:
-    from pyVmomi import sms, vmodl
+    from pyVmomi import sms
 except ImportError:
     pass
 
@@ -145,37 +145,36 @@ class VMwareVASA(SMS):
                 # This second step is required to register self-signed certs,
                 # since the previous task returns the certificate back waiting
                 # for confirmation
-                if isinstance(result, sms.fault.CertificateNotTrusted): 
+                if isinstance(result, sms.fault.CertificateNotTrusted):
                     vasa_provider_spec.certificate = result.certificate
                     task = self.storage_manager.RegisterProvider_Task(vasa_provider_spec)
                     changed, result = wait_for_sms_task(task)
                 if isinstance(result, sms.provider.VasaProvider):
                     provider_info = result.QueryProviderInfo()
                     temp_provider_info = {
-                         'name': provider_info.name,
-                         'uid': provider_info.uid,
-                         'description': provider_info.description,
-                         'version': provider_info.version,
-                         'certificate_status': provider_info.certificateStatus,
-                         'url': provider_info.url,
-                         'status': provider_info.status,
-                         'related_storage_array': []
+                        'name': provider_info.name,
+                        'uid': provider_info.uid,
+                        'description': provider_info.description,
+                        'version': provider_info.version,
+                        'certificate_status': provider_info.certificateStatus,
+                        'url': provider_info.url,
+                        'status': provider_info.status,
+                        'related_storage_array': []
                     }
                     for a in provider_info.relatedStorageArray:
                         temp_storage_array = {
-                             'active': str(a.active),
-                             'array_id': a.arrayId,
-                             'manageable': str(a.manageable),
-                             'priority': str(a.priority)
+                            'active': str(a.active),
+                            'array_id': a.arrayId,
+                            'manageable': str(a.manageable),
+                            'priority': str(a.priority)
                         }
                         temp_provider_info['related_storage_array'].append(temp_storage_array)
                     result = temp_provider_info
 
             self.module.exit_json(changed=changed, result=result)
         except TaskError as task_err:
-            self.module.fail_json(
-                      msg="Failed to register VASA provider"
-                          " due to task exception %s" % to_native(task_err))
+            self.module.fail_json(msg="Failed to register VASA provider"
+                                      " due to task exception %s" % to_native(task_err))
         except Exception as generic_exc:
             self.module.fail_json(msg="Failed to register VASA"
                                       " due to generic exception %s" % to_native(generic_exc))
@@ -220,7 +219,6 @@ class VMwareVASA(SMS):
                         raise Exception("VASA provider '%s' URL '%s' is inconsistent  with task parameter '%s'" % (self.vasa_name, provider_info.url, self.vasa_url))
                     self.vasa_provider_info = provider_info
                     break
-                
             if self.vasa_provider_info is None:
                 return 'absent'
             return 'present'

--- a/plugins/modules/vmware_vasa.py
+++ b/plugins/modules/vmware_vasa.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright: (c) 2023, Pure Storage, Inc.
-# Author(s): Eugenio Grosso, <egrosso@purestorage.com>
+# Author(s): Eugenio Grosso, <eugenio.grosso@purestorage.com>
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/plugins/modules/vmware_vasa.py
+++ b/plugins/modules/vmware_vasa.py
@@ -1,0 +1,258 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2023, Pure Storage, Inc. 
+# Author(s): Eugenio Grosso, <egrosso@purestorage.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = r'''
+module: vmware_vasa
+short_description: Manage VMware Virtual Volumes storage provider
+author:
+  - Eugenio Grosso (egrosso@purestorage.com)
+description:
+  - This module can be used to register and unregister a VASA provider
+options:
+  vasa_name:
+    description:
+    - The name of the VASA provider to be managed.
+    type: str
+    required: True
+  vasa_url:
+    description:
+    - The url  of the VASA provider to be managed.
+    - This parameter is required if I(state=present)
+    type: str
+  vasa_username:
+    description:
+    - The user account to connect to the VASA provider.
+    - This parameter is required if I(state=present)
+    type: str
+  vasa_password:
+    description:
+    - The password of the user account to connect to the VASA provider.
+    - This parameter is required if I(state=present)
+    type: str
+  vasa_certificate:
+    description:
+    - The SSL certificate of the VASA provider.
+    - This parameter is required if I(state=present)
+    type: str
+  state:
+    description:
+    - Create C(present) or remove C(absent) a VASA provider.
+    choices: [ absent, present ]
+    default: present
+    type: str
+seealso:
+- module: community.vmware.vmware_vasa_info
+extends_documentation_fragment:
+- community.vmware.vmware.documentation
+'''
+
+EXAMPLES = r'''
+- name: Create Cluster
+  community.vmware.vmware_cluster:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    vasa_name: "{{ vasa_name }}"
+    vasa_url: "{{ vasa_url }}"
+    vasa_username: "{{ vasa_username }}"
+    vasa_password: "{{ vasa_password }}"
+    vasa_certificate: "{{ vasa_certificate }}"
+    state: present
+  delegate_to: localhost
+
+- name: Unregister VASA provider
+  community.vmware.vmware_vasa:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    vasa_name: "{{ vasa_name }}"
+    state: absent
+  delegate_to: localhost
+'''
+
+RETURN = r'''
+'''
+try:
+    from pyVmomi import sms, vmodl
+except ImportError:
+    pass
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.community.vmware.plugins.module_utils.vmware_sms import (
+    SMS,
+    TaskError,
+    wait_for_sms_task)
+from ansible_collections.community.vmware.plugins.module_utils.vmware import vmware_argument_spec
+from ansible.module_utils._text import to_native
+
+
+class VMwareVASA(SMS):
+    def __init__(self, module):
+        super(VMwareVASA, self).__init__(module)
+        self.vasa_name = module.params['vasa_name']
+        self.vasa_url = module.params['vasa_url']
+        self.vasa_username = module.params['vasa_username']
+        self.vasa_password = module.params['vasa_password']
+        self.vasa_certificate = module.params['vasa_certificate']
+        self.desired_state = module.params['state']
+        self.storage_manager = None
+
+    def process_state(self):
+        """
+        Manage internal states of VASA provider
+        """
+        vasa_states = {
+            'absent': {
+                'present': self.state_unregister_vasa,
+                'absent': self.state_exit_unchanged,
+            },
+            'present': {
+                'present': self.state_exit_unchanged,
+                'absent': self.state_register_vasa,
+            }
+        }
+        # Initialize connection to SMS manager
+        self.get_sms_connection()
+        current_state = self.check_vasa_configuration()
+        # Based on the desired_state and the current_state call
+        # the appropriate method from the dictionary
+        vasa_states[self.desired_state][current_state]()
+
+    def state_register_vasa(self):
+        """
+        Register VASA provider with vcenter
+        """
+        changed, result = True, None
+        vasa_provider_spec = sms.provider.VasaProviderSpec()
+        vasa_provider_spec.name = self.vasa_name
+        vasa_provider_spec.username = self.vasa_username
+        vasa_provider_spec.password = self.vasa_password
+        vasa_provider_spec.url = self.vasa_url
+        vasa_provider_spec.certificate = self.vasa_certificate
+        try:
+            if not self.module.check_mode:
+                task = self.storage_manager.RegisterProvider_Task(vasa_provider_spec)
+                changed, result = wait_for_sms_task(task)
+                # This second step is required to register self-signed certs,
+                # since the previous task returns the certificate back waiting
+                # for confirmation
+                if isinstance(result, sms.fault.CertificateNotTrusted): 
+                    vasa_provider_spec.certificate = result.certificate
+                    task = self.storage_manager.RegisterProvider_Task(vasa_provider_spec)
+                    changed, result = wait_for_sms_task(task)
+                if isinstance(result, sms.provider.VasaProvider):
+                    provider_info = result.QueryProviderInfo()
+                    temp_provider_info = {
+                         'name': provider_info.name,
+                         'uid': provider_info.uid,
+                         'description': provider_info.description,
+                         'version': provider_info.version,
+                         'certificate_status': provider_info.certificateStatus,
+                         'url': provider_info.url,
+                         'status': provider_info.status,
+                         'related_storage_array': []
+                    }
+                    for a in provider_info.relatedStorageArray:
+                        temp_storage_array = {
+                             'active': str(a.active),
+                             'array_id': a.arrayId,
+                             'manageable': str(a.manageable),
+                             'priority': str(a.priority)
+                        }
+                        temp_provider_info['related_storage_array'].append(temp_storage_array)
+                    result = temp_provider_info
+
+            self.module.exit_json(changed=changed, result=result)
+        except TaskError as task_err:
+            self.module.fail_json(
+                      msg="Failed to register VASA provider"
+                          " due to task exception %s" % to_native(task_err))
+        except Exception as generic_exc:
+            self.module.fail_json(msg="Failed to register VASA"
+                                      " due to generic exception %s" % to_native(generic_exc))
+
+    def state_unregister_vasa(self):
+        """
+        Unregister VASA provider
+        """
+        changed, result = True, None
+
+        try:
+            if not self.module.check_mode:
+                uid = self.vasa_provider_info.uid
+                task = self.storage_manager.UnregisterProvider_Task(uid)
+                changed, result = wait_for_sms_task(task)
+            self.module.exit_json(changed=changed, result=result)
+        except Exception as generic_exc:
+            self.module.fail_json(msg="Failed to unregister VASA"
+                                      " due to generic exception %s" % to_native(generic_exc))
+
+    def state_exit_unchanged(self):
+        """
+        Exit without any change
+        """
+        self.module.exit_json(changed=False)
+
+    def check_vasa_configuration(self):
+        """
+        Check VASA configuration
+        Returns: 'Present' if VASA provider exists, else 'absent'
+
+        """
+        self.vasa_provider_info = None
+        self.storage_manager = self.sms_si.QueryStorageManager()
+        storage_providers = self.storage_manager.QueryProvider()
+
+        try:
+            for provider in storage_providers:
+                provider_info = provider.QueryProviderInfo()
+                if provider_info.name == self.vasa_name:
+                    if provider_info.url != self.vasa_url:
+                        raise Exception("VASA provider '%s' URL '%s' is inconsistent  with task parameter '%s'" % (self.vasa_name, provider_info.url, self.vasa_url))
+                    self.vasa_provider_info = provider_info
+                    break
+                
+            if self.vasa_provider_info is None:
+                return 'absent'
+            return 'present'
+        except Exception as generic_exc:
+            self.module.fail_json(msg="Failed to check configuration"
+                                      " due to generic exception %s" % to_native(generic_exc))
+
+
+def main():
+    argument_spec = vmware_argument_spec()
+    argument_spec.update(dict(
+        vasa_name=dict(type='str', required=True),
+        vasa_url=dict(type='str', required=True),
+        vasa_username=dict(type='str'),
+        vasa_password=dict(type='str', no_log=True),
+        vasa_certificate=dict(type='str'),
+        state=dict(type='str',
+                   default='present',
+                   choices=['absent', 'present']),
+    ))
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        required_if=[
+            ['state', 'present', ['vasa_username', 'vasa_password', 'vasa_certificate']]
+        ]
+    )
+
+    vmware_vasa = VMwareVASA(module)
+    vmware_vasa.process_state()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/vmware_vasa_info.py
+++ b/plugins/modules/vmware_vasa_info.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright: (c) 2023, Eugenio Grosso <eugenio.grosso@purestorage.com>
+# Copyright: (c) 2023, Pure Storage, Inc.
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/plugins/modules/vmware_vasa_info.py
+++ b/plugins/modules/vmware_vasa_info.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright: (c) 2023, Eugenio Grosso <egrosso@purestorage.com>
+# Copyright: (c) 2023, Eugenio Grosso <eugenio.grosso@purestorage.com>
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -17,7 +17,7 @@ description:
 - Returns basic information on the vSphere VASA providers registered in the
   vcenter.
 author:
-- Eugenio Grosso
+- Eugenio Grosso <eugenio.grosso@purestorage.com>
 extends_documentation_fragment:
 - community.vmware.vmware.documentation
 
@@ -59,10 +59,6 @@ vasa_providers:
     ]
 '''
 
-try:
-    from pyVmomi import sms
-except ImportError:
-    pass
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.vmware.plugins.module_utils.vmware_sms import SMS

--- a/plugins/modules/vmware_vasa_info.py
+++ b/plugins/modules/vmware_vasa_info.py
@@ -1,0 +1,119 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2023, Eugenio Grosso <egrosso@purestorage.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = r'''
+---
+module: vmware_vasa_info
+short_description: Gather information about vSphere VASA providers.
+description:
+- Returns basic information on the vSphere VASA providers registered in the
+  vcenter.
+author:
+- Eugenio Grosso
+extends_documentation_fragment:
+- community.vmware.vmware.documentation
+
+'''
+
+EXAMPLES = r'''
+- name: Get VASA providers info
+  community.vmware.vmware__info:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+  delegate_to: localhost
+  register: providers
+'''
+
+RETURN = r'''
+vasa_providers:
+  description: list of dictionary of VASA info
+  returned: success
+  type: list
+  sample: [
+            {
+                "certificate_status": "valid",
+                "description": "IOFILTER VASA Provider on host host01.domain.local",
+                "name": "IOFILTER Provider host01.domain.local",
+                "related_storage_array": [
+                    {
+                        "active": "True",
+                        "array_id": "IOFILTERS:616d4715-7de2-7be2-997a-10f920c5fdbe",
+                        "manageable": "True",
+                        "priority": "1"
+                    }
+                ],
+                "status": "online",
+                "uid": "02e10bc5-dd77-4ce4-9100-5aee44e7abaa",
+                "url": "https://host01.domain.local:9080/version.xml",
+                "version": "1.0"
+            },
+    ]
+'''
+
+try:
+    from pyVmomi import sms
+except ImportError:
+    pass
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.community.vmware.plugins.module_utils.vmware_sms import SMS
+from ansible_collections.community.vmware.plugins.module_utils.vmware import vmware_argument_spec
+
+
+class SMSClient(SMS):
+    def __init__(self, module):
+        super(SMSClient, self).__init__(module)
+
+    def get_vasa_provider_info(self):
+        self.get_sms_connection()
+
+        results = dict(changed=False, vasa_providers=[])
+        storage_manager = self.sms_si.QueryStorageManager()
+        storage_providers = storage_manager.QueryProvider()
+
+        for provider in storage_providers:
+            provider_info = provider.QueryProviderInfo()
+            temp_provider_info = {
+                'name': provider_info.name,
+                'uid': provider_info.uid,
+                'description': provider_info.description,
+                'version': provider_info.version,
+                'certificate_status': provider_info.certificateStatus,
+                'url': provider_info.url,
+                'status': provider_info.status,
+                'related_storage_array': []
+            }
+            for a in provider_info.relatedStorageArray:
+                temp_storage_array = {
+                    'active': str(a.active),
+                    'array_id': a.arrayId,
+                    'manageable': str(a.manageable),
+                    'priority': str(a.priority)
+                }
+                temp_provider_info['related_storage_array'].append(temp_storage_array)
+
+            results['vasa_providers'].append(temp_provider_info)
+
+        self.module.exit_json(**results)
+
+
+def main():
+    argument_spec = vmware_argument_spec()
+
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+
+    sms_client = SMSClient(module)
+    sms_client.get_vasa_provider_info()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
##### SUMMARY
Added two additional modules to manage VASA provider registration/removal. Those are fundamental for automating vVols
management. Also extended the <kbd>vmware_host_datastore</kbd> to include vVols datastores creation/deletion.

##### COMPONENT NAME
vmware_vasa
vmware_vasa_info
vmware_host_datastore

##### ADDITIONAL INFORMATION

The <kbd>vmware_vasa</kbd> module can be used to register/unregister a VASA provider, while the <kbd>vmware_vasa_info</kbd> queries the target vcenter for the registered VASA providers and returns their list.
Both modules are subclass of the additional SMS class, which implements the wrapper to the storage management service.

The  <kbd>vmware_host_datastore</kbd> includes now the code to create and remove vVols datastores.
All the codes have been tested using Pure Storage VASA providers on FlashArray //X series storage array.
