### PR TITLE
Add vVols management

### DIFF
--- a/changelogs/fragments/1725-vmware_guest-register_in_inventory.yaml
+++ b/changelogs/fragments/1725-vmware_guest-register_in_inventory.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+  - vmware_host_datastore - added new parameter 'register_in_inventory' for registering in the inventory a VM that already exists on a given datastore.
+                          - added new parameter 'vmx_file_path' to specify the virtuale machine vmx file name to register in inventory.

--- a/changelogs/fragments/1725-vmware_host_datastore-resignature.yaml
+++ b/changelogs/fragments/1725-vmware_host_datastore-resignature.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_host_datastore - added new parameter resignature for supporting resignaturing an existing VMFS datastore on an imported/cloned LUN.

--- a/plugins/module_utils/vmware_sms.py
+++ b/plugins/module_utils/vmware_sms.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2023, Ansible Project
+# Copyright: (c) 2023, Pure Storage, Inc.
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+try:
+    from pyVmomi import sms
+    from pyVim.connect import SoapStubAdapter
+except ImportError:
+    pass
+
+from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi
+from random import randint
+import time
+
+
+class TaskError(Exception):
+    def __init__(self, *args, **kwargs):
+        super(TaskError, self).__init__(*args, **kwargs)
+
+
+class SMS(PyVmomi):
+    def __init__(self, module):
+        super(SMS, self).__init__(module)
+        self.sms_si = None
+        self.version = "sms.version.v7_0_0_1"
+
+    def get_sms_connection(self):
+        """
+        Creates a Service instance for VMware SMS
+        """
+        client_stub = self.si._GetStub()
+        try:
+            session_cookie = client_stub.cookie.split('"')[1]
+        except IndexError:
+            self.module.fail_json(msg="Failed to get session cookie")
+        ssl_context = client_stub.schemeArgs.get('context')
+        additional_headers = {'vcSessionCookie': session_cookie}
+        hostname = self.module.params['hostname']
+        if not hostname:
+            self.module.fail_json(msg="Please specify required parameter - hostname")
+        stub = SoapStubAdapter(host=hostname, path="/sms/sdk", version=self.version,
+                               sslContext=ssl_context, requestContext=additional_headers)
+
+        self.sms_si = sms.ServiceInstance("ServiceInstance", stub)
+
+
+def wait_for_sms_task(task, max_backoff=64, timeout=3600):
+    """Wait for given task using exponential back-off algorithm.
+
+    Args:
+        task: VMware SMS task object
+        max_backoff: Maximum amount of sleep time in seconds
+        timeout: Timeout for the given task in seconds
+
+    Returns: Tuple with True and result for successful task
+    Raises: TaskError on failure
+    """
+    failure_counter = 0
+    start_time = time.time()
+
+    while True:
+        task_info = task.QuerySmsTaskInfo()
+        if time.time() - start_time >= timeout:
+            raise TaskError("Timeout")
+        if task_info.state == sms.TaskInfo.State.success:
+            return True, task_info.result
+        if task_info.state == sms.TaskInfo.State.error:
+            return False, task_info.error
+        if task_info.state in [sms.TaskInfo.State.running, sms.TaskInfo.State.queued]:
+            sleep_time = min(2 ** failure_counter + randint(1, 1000) / 1000, max_backoff)
+            time.sleep(sleep_time)
+            failure_counter += 1

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -17,11 +17,12 @@ description: >
    This module can be used to create new virtual machines from templates or other virtual machines,
    manage power state of virtual machine such as power on, power off, suspend, shutdown, reboot, restart etc.,
    modify various virtual machine components like network, disk, customization etc.,
-   rename a virtual machine and remove a virtual machine with associated components.
+   rename a virtual machine, register, unregister and remove a virtual machine with associated components.
 author:
 - Loic Blot (@nerzhul) <loic.blot@unix-experience.fr>
 - Philippe Dellaert (@pdellaert) <philippe@dellaert.org>
 - Abhijeet Kasurde (@Akasurde) <akasurde@redhat.com>
+- Eugenio Grosso <egrosso@purestorage.com>
 notes:
     - Please make sure that the user used for M(community.vmware.vmware_guest) has the correct level of privileges.
     - For example, following is the list of minimum privileges required by users to create virtual machines.
@@ -781,6 +782,17 @@ options:
     - Specify convert disk type while cloning template or virtual machine.
     choices: [ 'thin', 'thick', 'eagerzeroedthick' ]
     type: str
+  register_in_inventory:
+    description:
+    - Specify whether virtual machine should be registered in the inventory.
+    type: bool
+    default: false
+  vmx_file_path:
+    description:
+    - Specify the path of the vmx file to register in the inventory an existing
+      virtual machine on the given C(datastore).
+      Only used when C(register_in_inventory) is set to true.
+    type: str
 extends_documentation_fragment:
 - community.vmware.vmware.documentation
 
@@ -951,6 +963,23 @@ EXAMPLES = r'''
     name: vm_name
     delete_from_inventory: true
     state: absent
+  delegate_to: localhost
+
+- name: Register a virtual machine in the inventory on given ESXi cluster
+  community.vmware.vmware_guest:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter: "{{ datacenter }}"
+    cluster: "{{ cluster }}"
+    folder: "{{ vm_folder }}"
+    name: vm_name
+    state: poweredon
+    wait_for_ip_address: yes
+    register_in_inventory: yes
+    datastore: "{{ datastore }}"
+    # Note: the path must not have any leading / char
+    vmx_file_path: "{{ vmx_file }}"
   delegate_to: localhost
 
 - name: Manipulate vApp properties
@@ -3147,6 +3176,101 @@ class PyVmomiHelper(PyVmomi):
             vm_facts = self.gather_facts(vm)
             return {'changed': self.change_applied, 'failed': False, 'instance': vm_facts}
 
+    def register_vm(self):
+        datastore_name = self.params.get('datastore', None)
+        if datastore_name is None:
+            self.module.fail_json(msg="Datastore is required parameter while registering a virtual machine")
+        vmx_file_path = self.params.get('vmx_file_path', None)
+        if vmx_file_path is None:
+            self.module.fail_json(msg="vmx file path is required parameter while registering a virtual machine")
+        vmx_file_path = "[" + datastore_name + "] " + vmx_file_path
+        self.folder = self.params.get('folder', None)
+        if self.folder is None:
+            self.module.fail_json(msg="Folder is required parameter while registering a virtual machine")
+
+        # Prepend / if it was missing from the folder path, also strip trailing slashes
+        if not self.folder.startswith('/'):
+            self.folder = '/%(folder)s' % self.params
+        self.folder = self.folder.rstrip('/')
+
+        datacenter = self.cache.find_obj(self.content, [vim.Datacenter], self.params['datacenter'])
+        if datacenter is None:
+            self.module.fail_json(msg='No datacenter named %(datacenter)s was found' % self.params)
+
+        dcpath = compile_folder_path_for_object(datacenter)
+
+        # Nested folder does not have trailing /
+        if not dcpath.endswith('/'):
+            dcpath += '/'
+
+        # Check for full path first in case it was already supplied
+        if self.folder.startswith(
+            dcpath + self.params["datacenter"] + "/vm"
+        ) or self.folder.startswith(dcpath + "/" + self.params["datacenter"] + "/vm"):
+            fullpath = self.folder
+        elif self.folder.startswith("/vm/") or self.folder == "/vm":
+            fullpath = "%s%s%s" % (dcpath, self.params["datacenter"], self.folder)
+        elif self.folder.startswith("/"):
+            fullpath = "%s%s/vm%s" % (dcpath, self.params["datacenter"], self.folder)
+        else:
+            fullpath = "%s%s/vm/%s" % (dcpath, self.params["datacenter"], self.folder)
+
+        f_obj = self.content.searchIndex.FindByInventoryPath(fullpath)
+
+        # abort if no strategy was successful
+        if f_obj is None:
+            # Add some debugging values in failure.
+            details = {
+                'datacenter': datacenter.name,
+                'datacenter_path': dcpath,
+                'folder': self.folder,
+                'full_search_path': fullpath,
+            }
+            self.module.fail_json(msg='No folder %s matched in the search path : %s' % (self.folder, fullpath),
+                                  details=details)
+
+        destfolder = f_obj
+
+        # always get a resource_pool
+        resource_pool = self.get_resource_pool()
+
+        esx_host = None
+        # Only select specific host when ESXi hostname is provided
+        if self.params['esxi_hostname']:
+            esx_host = self.select_host()
+
+        try:
+            task = destfolder.RegisterVM_Task(path=vmx_file_path,
+                                              asTemplate=self.params['is_template'],
+                                              pool=resource_pool,
+                                              host=esx_host)
+        except vmodl.fault.InvalidRequest as e:
+            self.module.fail_json(msg="Failed to register virtual machine due to invalid configuration "
+                                      "parameter %s" % to_native(e.msg))
+        except vim.fault.RestrictedVersion as e:
+            self.module.fail_json(msg="Failed to register virtual machine due to "
+                                      "product versioning restrictions: %s" % to_native(e.msg))
+        self.change_detected = True
+        self.wait_for_task(task)
+        if task.info.state == 'error':
+            configspec_json = serialize_spec(self.configspec)
+            kwargs = {
+                'changed': self.change_applied,
+                'failed': True,
+                'msg': task.info.error.msg,
+                'configspec': configspec_json,
+                'clone_method': 'RegisterVM_Task'
+            }
+            return kwargs
+        vm = task.info.result
+        if self.params['wait_for_ip_address'] or self.params['state'] in ['poweredon', 'powered-on', 'restarted']:
+            set_vm_power_state(self.content, vm, 'poweredon', force=False)
+
+            if self.params['wait_for_ip_address']:
+                wait_for_vm_ip(self.content, vm, self.params['wait_for_ip_address_timeout'])
+        vm_facts = self.gather_facts(vm)
+        return {'changed': self.change_applied, 'failed': False, 'instance': vm_facts}
+
     def get_snapshots_by_name_recursively(self, snapshots, snapname):
         snap_obj = []
         for snapshot in snapshots:
@@ -3491,6 +3615,8 @@ def main():
         datastore=dict(type='str'),
         convert=dict(type='str', choices=['thin', 'thick', 'eagerzeroedthick']),
         delete_from_inventory=dict(type='bool', default=False),
+        register_in_inventory=dict(type='bool', default=False),
+        vmx_file_path=dict(type='str'),
     )
 
     module = AnsibleModule(argument_spec=argument_spec,
@@ -3500,6 +3626,11 @@ def main():
                            ],
                            required_one_of=[
                                ['name', 'uuid'],
+                           ],
+                           required_if=[
+                               ['register_in_inventory', True, ['datastore',
+                                                                'vmx_file_path',
+                                                                'folder']],
                            ],
                            )
     result = {'failed': False, 'changed': False}
@@ -3587,7 +3718,10 @@ def main():
                     desired_operation='deploy_vm',
                 )
                 module.exit_json(**result)
-            result = pyv.deploy_vm()
+            if module.params['register_in_inventory']:
+                result = pyv.register_vm()
+            else:
+                result = pyv.deploy_vm()
             if result['failed']:
                 module.fail_json(msg='Failed to create a virtual machine : %s' % result['msg'])
 

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -22,7 +22,7 @@ author:
 - Loic Blot (@nerzhul) <loic.blot@unix-experience.fr>
 - Philippe Dellaert (@pdellaert) <philippe@dellaert.org>
 - Abhijeet Kasurde (@Akasurde) <akasurde@redhat.com>
-- Eugenio Grosso <egrosso@purestorage.com>
+- Eugenio Grosso (@genegr) <egrosso@purestorage.com>
 notes:
     - Please make sure that the user used for M(community.vmware.vmware_guest) has the correct level of privileges.
     - For example, following is the list of minimum privileges required by users to create virtual machines.

--- a/plugins/modules/vmware_host_datastore.py
+++ b/plugins/modules/vmware_host_datastore.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright: (c) 2018, Ansible Project
+# Copyright: (c) 2023, Pure Storage, Inc.
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -21,6 +22,7 @@ description:
 author:
 - Ludovic Rivallain (@lrivallain) <ludovic.rivallain@gmail.com>
 - Christian Kotte (@ckotte) <christian.kotte@gmx.de>
+- Eugenio Grosso (@genegr) <eugenio.grosso@purestorage.com>
 notes:
 - Kerberos authentication with NFS v4.1 isn't implemented
 options:
@@ -32,7 +34,7 @@ options:
   datastore_type:
     description:
     - Type of the datastore to configure (nfs/nfs41/vmfs).
-    choices: [ 'nfs', 'nfs41', 'vmfs' ]
+    choices: [ 'nfs', 'nfs41', 'vmfs', 'vvol' ]
     type: str
   nfs_server:
     description:
@@ -51,6 +53,12 @@ options:
     - Unused if datastore type is not set to C(nfs)/C(nfs41) and state is not set to C(present).
     default: false
     type: bool
+  resignature:
+    description:
+    - Allows forcing resignature of unresolved VMFS datastore that already exists on the specified disk device.
+    - Unused if datastore type is not set to C(vmfs) and state is not set to C(present).
+    default: false
+    type: bool
   vmfs_device_name:
     description:
     - Name of the device to be used as VMFS datastore.
@@ -61,6 +69,11 @@ options:
     - VMFS version to use for datastore creation.
     - Unused if datastore type is not set to C(vmfs) and state is not set to C(present).
     type: int
+  vasa_provider:
+    description:
+    - hostname or ipaddress of the VASA provider to use for vVols provisioning
+    type: str
+    required: false
   esxi_hostname:
     description:
     - ESXi hostname to manage the datastore.
@@ -134,6 +147,31 @@ EXAMPLES = r'''
       - { 'name': 'NasDS_vol03', 'server': 'nas01,nas02', 'path': '/mnt/vol01', 'type': 'nfs41'}
       - { 'name': 'NasDS_vol04', 'server': 'nas01,nas02', 'path': '/mnt/vol02', 'type': 'nfs41'}
 
+- name: Mount vVols datastore to ESXi
+  community.vmware.vmware_host_datastore:
+      hostname: '{{ vcenter_hostname }}'
+      username: '{{ vcenter_username }}'
+      password: '{{ vcenter_password }}'
+      datastore_name: myvvolds
+      datastore_type: vvol
+      vasa_provider: pure-X90a
+      esxi_hostname: esxi-1
+      state: absent
+  delegate_to: localhost
+
+- name: Mount unresolved VMFS datastores to ESXi
+  community.vmware.vmware_host_datastore:
+      hostname: '{{ vcenter_hostname }}'
+      username: '{{ vcenter_username }}'
+      password: '{{ vcenter_password }}'
+      datastore_name: mydatastore01
+      vmfs_device_name: 'naa.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+      vmfs_version: 6
+      esxi_hostname:  esxi01
+      resignature: true
+      state: present
+  delegate_to: localhost
+
 - name: Remove/Umount Datastores from a ESXi
   community.vmware.vmware_host_datastore:
       hostname: '{{ esxi_hostname }}'
@@ -153,11 +191,12 @@ except ImportError:
     pass
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.community.vmware.plugins.module_utils.vmware import vmware_argument_spec, PyVmomi, find_datastore_by_name, find_obj
+from ansible_collections.community.vmware.plugins.module_utils.vmware import vmware_argument_spec, find_datastore_by_name, find_obj, wait_for_task
+from ansible_collections.community.vmware.plugins.module_utils.vmware_sms import SMS
 from ansible.module_utils._text import to_native
 
 
-class VMwareHostDatastore(PyVmomi):
+class VMwareHostDatastore(SMS):
     def __init__(self, module):
         super(VMwareHostDatastore, self).__init__(module)
 
@@ -167,7 +206,9 @@ class VMwareHostDatastore(PyVmomi):
         self.nfs_path = module.params['nfs_path']
         self.nfs_ro = module.params['nfs_ro']
         self.vmfs_device_name = module.params['vmfs_device_name']
+        self.vasa_provider_name = module.params['vasa_provider']
         self.vmfs_version = module.params['vmfs_version']
+        self.resignature = module.params['resignature']
         self.esxi_hostname = module.params['esxi_hostname']
         self.auto_expand = module.params['auto_expand']
         self.state = module.params['state']
@@ -264,6 +305,8 @@ class VMwareHostDatastore(PyVmomi):
             self.mount_nfs_datastore_host()
         if self.datastore_type == 'vmfs':
             self.mount_vmfs_datastore_host()
+        if self.datastore_type == 'vvol':
+            self.mount_vvol_datastore_host()
 
     def mount_nfs_datastore_host(self):
         if self.module.check_mode is False:
@@ -308,16 +351,62 @@ class VMwareHostDatastore(PyVmomi):
                 self.module.fail_json(msg="%s" % error_message_used_disk)
             error_message_mount = "Cannot mount datastore %s on host %s" % (self.datastore_name, self.esxi.name)
             try:
-                vmfs_ds_options = ds_system.QueryVmfsDatastoreCreateOptions(host_ds_system,
-                                                                            ds_path,
-                                                                            self.vmfs_version)
-                vmfs_ds_options[0].spec.vmfs.volumeName = self.datastore_name
-                ds_system.CreateVmfsDatastore(
-                    host_ds_system,
-                    vmfs_ds_options[0].spec)
+                if self.resignature:
+                    storage_system = self.esxi.configManager.storageSystem
+                    host_unres_volumes = storage_system.QueryUnresolvedVmfsVolume()
+                    unres_vol_extents = {}
+                    for unres_vol in host_unres_volumes:
+                        for ext in unres_vol.extent:
+                            unres_vol_extents[ext.device.diskName] = ext
+                    if self.vmfs_device_name in unres_vol_extents:
+                        spec = vim.host.UnresolvedVmfsResignatureSpec()
+                        spec.extentDevicePath = unres_vol_extents[self.vmfs_device_name].devicePath
+                        task = host_ds_system.ResignatureUnresolvedVmfsVolume_Task(spec)
+                        wait_for_task(task=task)
+                        task.info.result.result.RenameDatastore(self.datastore_name)
+                else:
+                    vmfs_ds_options = ds_system.QueryVmfsDatastoreCreateOptions(host_ds_system,
+                                                                                ds_path,
+                                                                                self.vmfs_version)
+                    vmfs_ds_options[0].spec.vmfs.volumeName = self.datastore_name
+                    ds_system.CreateVmfsDatastore(
+                        host_ds_system,
+                        vmfs_ds_options[0].spec)
             except (vim.fault.NotFound, vim.fault.DuplicateName,
                     vim.fault.HostConfigFault, vmodl.fault.InvalidArgument) as fault:
                 self.module.fail_json(msg="%s : %s" % (error_message_mount, to_native(fault.msg)))
+            except Exception as e:
+                self.module.fail_json(msg="%s : %s" % (error_message_mount, to_native(e)))
+        self.module.exit_json(changed=True, result="Datastore %s on host %s" % (self.datastore_name, self.esxi.name))
+
+    def mount_vvol_datastore_host(self):
+        if self.module.check_mode is False:
+            self.get_sms_connection()
+            storage_manager = self.sms_si.QueryStorageManager()
+            container_result = storage_manager.QueryStorageContainer()
+            provider = None
+            for p in container_result.providerInfo:
+                if p.name == self.vasa_provider_name:
+                    provider = p
+                    break
+            if provider is None:
+                error_message_provider = "VASA provider %s not found" % self.vasa_provider_name
+                self.module.fail_json(msg="%s" % error_message_provider)
+
+            container = None
+            for sc in container_result.storageContainer:
+                if sc.providerId[0] == provider.uid:
+                    container = sc
+                    break
+            if container is None:
+                error_message_container = "vVol container for provider %s not found" % provider.uid
+                self.module.fail_json(msg="%s" % error_message_container)
+
+            vvol_spec = vim.HostDatastoreSystem.VvolDatastoreSpec(name=self.datastore_name, scId=container.uuid)
+            host_ds_system = self.esxi.configManager.datastoreSystem
+            error_message_mount = "Cannot mount datastore %s on host %s" % (self.datastore_name, self.esxi.name)
+            try:
+                host_ds_system.CreateVvolDatastore(vvol_spec)
             except Exception as e:
                 self.module.fail_json(msg="%s : %s" % (error_message_mount, to_native(e)))
         self.module.exit_json(changed=True, result="Datastore %s on host %s" % (self.datastore_name, self.esxi.name))
@@ -327,14 +416,16 @@ def main():
     argument_spec = vmware_argument_spec()
     argument_spec.update(
         datastore_name=dict(type='str', required=True),
-        datastore_type=dict(type='str', choices=['nfs', 'nfs41', 'vmfs']),
+        datastore_type=dict(type='str', choices=['nfs', 'nfs41', 'vmfs', 'vvol']),
         nfs_server=dict(type='str'),
         nfs_path=dict(type='str'),
         nfs_ro=dict(type='bool', default=False),
         vmfs_device_name=dict(type='str'),
         vmfs_version=dict(type='int'),
+        resignature=dict(type='bool', default=False),
         esxi_hostname=dict(type='str', required=False),
         auto_expand=dict(type='bool', default=True),
+        vasa_provider=dict(type='str'),
         state=dict(type='str', default='present', choices=['absent', 'present'])
     )
 
@@ -346,6 +437,7 @@ def main():
             ['datastore_type', 'vmfs', ['vmfs_device_name']],
             ['datastore_type', 'nfs', ['nfs_server', 'nfs_path']],
             ['datastore_type', 'nfs41', ['nfs_server', 'nfs_path']],
+            ['datastore_type', 'vvol', ['vasa_provider']],
         ]
     )
 

--- a/plugins/modules/vmware_vasa.py
+++ b/plugins/modules/vmware_vasa.py
@@ -1,0 +1,259 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2023, Pure Storage, Inc.
+# Author(s): Eugenio Grosso, <eugenio.grosso@purestorage.com>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = r'''
+module: vmware_vasa
+short_description: Manage VMware Virtual Volumes storage provider
+author:
+  - Eugenio Grosso (@genegr) <eugenio.grosso@purestorage.com>
+description:
+  - This module can be used to register and unregister a VASA provider
+options:
+  vasa_name:
+    description:
+    - The name of the VASA provider to be managed.
+    type: str
+    required: True
+  vasa_url:
+    description:
+    - The url  of the VASA provider to be managed.
+    - This parameter is required if I(state=present)
+    type: str
+    required: True
+  vasa_username:
+    description:
+    - The user account to connect to the VASA provider.
+    - This parameter is required if I(state=present)
+    type: str
+  vasa_password:
+    description:
+    - The password of the user account to connect to the VASA provider.
+    - This parameter is required if I(state=present)
+    type: str
+  vasa_certificate:
+    description:
+    - The SSL certificate of the VASA provider.
+    - This parameter is required if I(state=present)
+    type: str
+  state:
+    description:
+    - Create C(present) or remove C(absent) a VASA provider.
+    choices: [ absent, present ]
+    default: present
+    type: str
+seealso:
+- module: community.vmware.vmware_vasa_info
+extends_documentation_fragment:
+- community.vmware.vmware.documentation
+'''
+
+EXAMPLES = r'''
+- name: Create Cluster
+  community.vmware.vmware_cluster:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    vasa_name: "{{ vasa_name }}"
+    vasa_url: "{{ vasa_url }}"
+    vasa_username: "{{ vasa_username }}"
+    vasa_password: "{{ vasa_password }}"
+    vasa_certificate: "{{ vasa_certificate }}"
+    state: present
+  delegate_to: localhost
+
+- name: Unregister VASA provider
+  community.vmware.vmware_vasa:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    vasa_name: "{{ vasa_name }}"
+    state: absent
+  delegate_to: localhost
+'''
+
+RETURN = r'''
+'''
+try:
+    from pyVmomi import sms
+except ImportError:
+    pass
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.community.vmware.plugins.module_utils.vmware_sms import (
+    SMS,
+    TaskError,
+    wait_for_sms_task)
+from ansible_collections.community.vmware.plugins.module_utils.vmware import vmware_argument_spec
+from ansible.module_utils._text import to_native
+
+
+class VMwareVASA(SMS):
+    def __init__(self, module):
+        super(VMwareVASA, self).__init__(module)
+        self.vasa_name = module.params['vasa_name']
+        self.vasa_url = module.params['vasa_url']
+        self.vasa_username = module.params['vasa_username']
+        self.vasa_password = module.params['vasa_password']
+        self.vasa_certificate = module.params['vasa_certificate']
+        self.desired_state = module.params['state']
+        self.storage_manager = None
+
+    def process_state(self):
+        """
+        Manage internal states of VASA provider
+        """
+        vasa_states = {
+            'absent': {
+                'present': self.state_unregister_vasa,
+                'absent': self.state_exit_unchanged,
+            },
+            'present': {
+                'present': self.state_exit_unchanged,
+                'absent': self.state_register_vasa,
+            }
+        }
+        # Initialize connection to SMS manager
+        self.get_sms_connection()
+        current_state = self.check_vasa_configuration()
+        # Based on the desired_state and the current_state call
+        # the appropriate method from the dictionary
+        vasa_states[self.desired_state][current_state]()
+
+    def state_register_vasa(self):
+        """
+        Register VASA provider with vcenter
+        """
+        changed, result = True, None
+        vasa_provider_spec = sms.provider.VasaProviderSpec()
+        vasa_provider_spec.name = self.vasa_name
+        vasa_provider_spec.username = self.vasa_username
+        vasa_provider_spec.password = self.vasa_password
+        vasa_provider_spec.url = self.vasa_url
+        vasa_provider_spec.certificate = self.vasa_certificate
+        try:
+            if not self.module.check_mode:
+                task = self.storage_manager.RegisterProvider_Task(vasa_provider_spec)
+                changed, result = wait_for_sms_task(task)
+                # This second step is required to register self-signed certs,
+                # since the previous task returns the certificate back waiting
+                # for confirmation
+                if isinstance(result, sms.fault.CertificateNotTrusted):
+                    vasa_provider_spec.certificate = result.certificate
+                    task = self.storage_manager.RegisterProvider_Task(vasa_provider_spec)
+                    changed, result = wait_for_sms_task(task)
+                if isinstance(result, sms.provider.VasaProvider):
+                    provider_info = result.QueryProviderInfo()
+                    temp_provider_info = {
+                        'name': provider_info.name,
+                        'uid': provider_info.uid,
+                        'description': provider_info.description,
+                        'version': provider_info.version,
+                        'certificate_status': provider_info.certificateStatus,
+                        'url': provider_info.url,
+                        'status': provider_info.status,
+                        'related_storage_array': []
+                    }
+                    for a in provider_info.relatedStorageArray:
+                        temp_storage_array = {
+                            'active': str(a.active),
+                            'array_id': a.arrayId,
+                            'manageable': str(a.manageable),
+                            'priority': str(a.priority)
+                        }
+                        temp_provider_info['related_storage_array'].append(temp_storage_array)
+                    result = temp_provider_info
+
+            self.module.exit_json(changed=changed, result=result)
+        except TaskError as task_err:
+            self.module.fail_json(msg="Failed to register VASA provider"
+                                      " due to task exception %s" % to_native(task_err))
+        except Exception as generic_exc:
+            self.module.fail_json(msg="Failed to register VASA"
+                                      " due to generic exception %s" % to_native(generic_exc))
+
+    def state_unregister_vasa(self):
+        """
+        Unregister VASA provider
+        """
+        changed, result = True, None
+
+        try:
+            if not self.module.check_mode:
+                uid = self.vasa_provider_info.uid
+                task = self.storage_manager.UnregisterProvider_Task(uid)
+                changed, result = wait_for_sms_task(task)
+            self.module.exit_json(changed=changed, result=result)
+        except Exception as generic_exc:
+            self.module.fail_json(msg="Failed to unregister VASA"
+                                      " due to generic exception %s" % to_native(generic_exc))
+
+    def state_exit_unchanged(self):
+        """
+        Exit without any change
+        """
+        self.module.exit_json(changed=False)
+
+    def check_vasa_configuration(self):
+        """
+        Check VASA configuration
+        Returns: 'Present' if VASA provider exists, else 'absent'
+
+        """
+        self.vasa_provider_info = None
+        self.storage_manager = self.sms_si.QueryStorageManager()
+        storage_providers = self.storage_manager.QueryProvider()
+
+        try:
+            for provider in storage_providers:
+                provider_info = provider.QueryProviderInfo()
+                if provider_info.name == self.vasa_name:
+                    if provider_info.url != self.vasa_url:
+                        raise Exception("VASA provider '%s' URL '%s' "
+                                        "is inconsistent  with task parameter '%s'"
+                                        % (self.vasa_name, provider_info.url, self.vasa_url))
+                    self.vasa_provider_info = provider_info
+                    break
+            if self.vasa_provider_info is None:
+                return 'absent'
+            return 'present'
+        except Exception as generic_exc:
+            self.module.fail_json(msg="Failed to check configuration"
+                                      " due to generic exception %s" % to_native(generic_exc))
+
+
+def main():
+    argument_spec = vmware_argument_spec()
+    argument_spec.update(dict(
+        vasa_name=dict(type='str', required=True),
+        vasa_url=dict(type='str', required=True),
+        vasa_username=dict(type='str'),
+        vasa_password=dict(type='str', no_log=True),
+        vasa_certificate=dict(type='str'),
+        state=dict(type='str',
+                   default='present',
+                   choices=['absent', 'present']),
+    ))
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        required_if=[
+            ['state', 'present', ['vasa_username', 'vasa_password', 'vasa_certificate']]
+        ]
+    )
+
+    vmware_vasa = VMwareVASA(module)
+    vmware_vasa.process_state()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/vmware_vasa_info.py
+++ b/plugins/modules/vmware_vasa_info.py
@@ -1,0 +1,115 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2023, Pure Storage, Inc.
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = r'''
+---
+module: vmware_vasa_info
+short_description: Gather information about vSphere VASA providers.
+description:
+- Returns basic information on the vSphere VASA providers registered in the
+  vcenter.
+author:
+- Eugenio Grosso (@genegr) <eugenio.grosso@purestorage.com>
+extends_documentation_fragment:
+- community.vmware.vmware.documentation
+
+'''
+
+EXAMPLES = r'''
+- name: Get VASA providers info
+  community.vmware.vmware__info:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+  delegate_to: localhost
+  register: providers
+'''
+
+RETURN = r'''
+vasa_providers:
+  description: list of dictionary of VASA info
+  returned: success
+  type: list
+  sample: [
+            {
+                "certificate_status": "valid",
+                "description": "IOFILTER VASA Provider on host host01.domain.local",
+                "name": "IOFILTER Provider host01.domain.local",
+                "related_storage_array": [
+                    {
+                        "active": "True",
+                        "array_id": "IOFILTERS:616d4715-7de2-7be2-997a-10f920c5fdbe",
+                        "manageable": "True",
+                        "priority": "1"
+                    }
+                ],
+                "status": "online",
+                "uid": "02e10bc5-dd77-4ce4-9100-5aee44e7abaa",
+                "url": "https://host01.domain.local:9080/version.xml",
+                "version": "1.0"
+            },
+    ]
+'''
+
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.community.vmware.plugins.module_utils.vmware_sms import SMS
+from ansible_collections.community.vmware.plugins.module_utils.vmware import vmware_argument_spec
+
+
+class SMSClient(SMS):
+    def __init__(self, module):
+        super(SMSClient, self).__init__(module)
+
+    def get_vasa_provider_info(self):
+        self.get_sms_connection()
+
+        results = dict(changed=False, vasa_providers=[])
+        storage_manager = self.sms_si.QueryStorageManager()
+        storage_providers = storage_manager.QueryProvider()
+
+        for provider in storage_providers:
+            provider_info = provider.QueryProviderInfo()
+            temp_provider_info = {
+                'name': provider_info.name,
+                'uid': provider_info.uid,
+                'description': provider_info.description,
+                'version': provider_info.version,
+                'certificate_status': provider_info.certificateStatus,
+                'url': provider_info.url,
+                'status': provider_info.status,
+                'related_storage_array': []
+            }
+            for a in provider_info.relatedStorageArray:
+                temp_storage_array = {
+                    'active': str(a.active),
+                    'array_id': a.arrayId,
+                    'manageable': str(a.manageable),
+                    'priority': str(a.priority)
+                }
+                temp_provider_info['related_storage_array'].append(temp_storage_array)
+
+            results['vasa_providers'].append(temp_provider_info)
+
+        self.module.exit_json(**results)
+
+
+def main():
+    argument_spec = vmware_argument_spec()
+
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+
+    sms_client = SMSClient(module)
+    sms_client.get_vasa_provider_info()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
##### SUMMARY
Added new module <kbd>vmware_vasa</kbd> and extended <kbd>vmware_host_datastore</kbd> to allow vVols datastore creation/deletion.
Also included new utility module <kbd>vmware_vasa_info</kbd>

##### COMPONENT NAME
vmware_vasa
vmware_vasa_info
vmware_host_datastore

##### ADDITIONAL INFORMATION
The  <kbd>vmware_vasa</kbd> can be used to register/unregister a VASA provider with a vcenter.
The <kbd>vmware_vasa_info</kbd> shows the configuration of the registered VASA providers.
The <kbd>vmware_host_datastore</kbd> module is able to register/remove also vVols datastores. In addition it is possible by specifying the <kbd>resignature</kbd> parameter to import/reconnect unresolved VMFS datastores.