### PR TITLE
2.x: Pin vsphere-automation-sdk to v8.0.0.0

### DIFF
--- a/changelogs/fragments/1715-requirements.yml
+++ b/changelogs/fragments/1715-requirements.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Pin vsphere-automation-sdk to v8.0.0.0 (https://github.com/ansible-collections/community.vmware/issues/1715).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pyVmomi>=6.7
-git+https://github.com/vmware/vsphere-automation-sdk-python.git ; python_version >= '2.7'  # Python 2.6 is not supported
+git+https://github.com/vmware/vsphere-automation-sdk-python.git@v8.0.0.0 ; python_version >= '2.7'  # Python 2.6 is not supported


### PR DESCRIPTION
##### SUMMARY
Pin `vsphere-automation-sdk` to v8.0.0.0 since newer releases require a pyOpenssl version that is incompatible with ansible-core 2.12.

Fixes #1715

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
requirements.txt

##### ADDITIONAL INFORMATION
