### PR TITLE
docs(vmware_object_role_permission): Clarify vCenter compatibility

### DIFF
--- a/plugins/modules/vmware_object_role_permission.py
+++ b/plugins/modules/vmware_object_role_permission.py
@@ -14,13 +14,13 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 ---
 module: vmware_object_role_permission
-short_description: Manage local roles on an ESXi host
-description: This module can be used to manage object permissions on the given host.
+short_description: Manage local roles on an ESXi host or vCenter
+description: This module can be used to manage object permissions on the given host or vCenter.
 author:
 - Derek Rushing (@kryptsi)
 - Joseph Andreatta (@vmwjoseph)
 notes:
-    - The ESXi login user must have the appropriate rights to administer permissions.
+    - The login user must have the appropriate rights to administer permissions.
     - Permissions for a distributed switch must be defined and managed on either the datacenter or a folder containing the switch.
 options:
   role:
@@ -86,9 +86,9 @@ EXAMPLES = r'''
 
 - name: Remove user from VM folder
   community.vmware.vmware_object_role_permission:
-    hostname: '{{ esxi_hostname }}'
-    username: '{{ esxi_username }}'
-    password: '{{ esxi_password }}'
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
     role: Admin
     principal: user_bob
     object_name: services

--- a/plugins/modules/vmware_object_role_permission_info.py
+++ b/plugins/modules/vmware_object_role_permission_info.py
@@ -21,7 +21,7 @@ description: This module can be used to gather object permissions on the given V
 author:
 - Abhijeet Kasurde (@Akasurde)
 notes:
-    - The ESXi login user must have the appropriate rights to administer permissions.
+    - The ESXi or vCenter login user must have the appropriate rights to administer permissions.
     - Supports check mode.
 options:
   principal:


### PR DESCRIPTION
##### SUMMARY
This update to the documentation should clarify that the module is compatible with ESXi and vCenter which previously wasn't clear by reading through the module description.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
vmware_object_role_permission
vmware_object_role_permission_info

##### ADDITIONAL INFORMATION
This PR is similar to #1678 

This is the same as #1705 which keeps failing in the CI pipeline.