### PR TITLE
vcenter_license: Disable integration tests

### DIFF
--- a/tests/integration/targets/vcenter_license/aliases
+++ b/tests/integration/targets/vcenter_license/aliases
@@ -1,2 +1,3 @@
 cloud/vcenter
 zuul/vmware/vcenter_only
+disabled


### PR DESCRIPTION
Temporarily disable integration tests for `vcenter_license`.