### PR TITLE
Add example using four networks to map

### DIFF
--- a/docs/community.vmware.vmware_deploy_ovf_module.rst
+++ b/docs/community.vmware.vmware_deploy_ovf_module.rst
@@ -539,6 +539,24 @@ Examples
         ovf: /path/to/ubuntu-16.04-amd64.ovf
       delegate_to: localhost
 
+    # Deploy an OVA template, with network mapping of four source networks (Internal, External, Management, and HA) to target networks (VM_NET_1, VM_NET_2, VM_NET_3, and VM_NET_4)
+    - community.vmware.vmware_deploy_ovf:
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        datacenter: Datacenter1
+        cluster: Cluster1
+        datastore: vsandatastore
+        name: NewVM
+        networks:
+          Internal: 'VM_NET_1'
+          External: 'VM_NET_2'
+          Management: 'VM_NET_3'
+          HA: 'VM_NET_4'
+        power_on: false
+        ovf: files/mytemplate.ova
+      delegate_to: localhost
+
 
 
 Return Values


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added an example that shows how networks mapping is done with an OVA template that contains four source networks.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- vmware_deploy_ovf

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Lines added:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
    # Deploy an OVA template, with network mapping of four source networks (Internal, External, Management, and HA) to target networks (VM_NET_1, VM_NET_2, VM_NET_3, and VM_NET_4)
    - community.vmware.vmware_deploy_ovf:
        hostname: '{{ vcenter_hostname }}'
        username: '{{ vcenter_username }}'
        password: '{{ vcenter_password }}'
        datacenter: Datacenter1
        cluster: Cluster1
        datastore: vsandatastore
        name: NewVM
        networks:
          Internal: 'VM_NET_1'
          External: 'VM_NET_2'
          Management: 'VM_NET_3'
          HA: 'VM_NET_4'
        power_on: false
        ovf: files/mytemplate.ova
      delegate_to: localhost

```
