### PR TITLE
Temporarily disable 2.15 sanity tests

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -63,7 +63,7 @@ jobs:
           # - stable-2.12
           - stable-2.13
           - stable-2.14
-          - stable-2.15
+        # - stable-2.15
         # - devel
           - milestone
     # Ansible-test on various stable branches does not yet work well with cgroups v2.


### PR DESCRIPTION
Temporarily disable 2.15 sanity tests. At the moment, they fail with:

```
ERROR: Found 2 validate-modules issue(s) which need to be resolved:
ERROR: plugins/modules/vmware_portgroup.py:0:0: incompatible-choices: Argument 'load_balancing' in argument_spec found in teaming defines choices as (None) but this is incompatible with argument type 'str'
ERROR: plugins/modules/vmware_vswitch.py:0:0: incompatible-choices: Argument 'load_balancing' in argument_spec found in teaming defines choices as (None) but this is incompatible with argument type 'str'
See documentation for help: https://docs.ansible.com/ansible-core/devel/dev_guide/testing/sanity/validate-modules.html
Running sanity test "yamllint"
Run command with data: /root/.ansible/test/venv/sanity.yamllint/3.11/61ebfb13/bin/python /root/ansible/test/lib/ansible_test/_util/controller/sanity/yamllint/yamllinter.py
FATAL: The 1 sanity test(s) listed below (out of 46) failed. See error output above for details.
validate-modules
```

#1747