### PR TITLE
Also look at NFS mounted datastores, not just VMFS

### DIFF
--- a/changelogs/fragments/1751-autoselect_datastore-also-use-NFS-mounts.yml
+++ b/changelogs/fragments/1751-autoselect_datastore-also-use-NFS-mounts.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - autoselect_datastore - add support to also look at NFS mounted filesystems (previously was just VMFS)

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -2739,13 +2739,13 @@ class PyVmomiHelper(PyVmomi):
 
                     for host in cluster.host:
                         for mi in host.configManager.storageSystem.fileSystemVolumeInfo.mountInfo:
-                            if mi.volume.type == "VMFS":
+                            if mi.volume.type == "VMFS" or mi.volume.type == "NFS":
                                 datastores.append(self.cache.find_obj(self.content, [vim.Datastore], mi.volume.name))
                 elif self.params['esxi_hostname']:
                     host = self.find_hostsystem_by_name(self.params['esxi_hostname'])
 
                     for mi in host.configManager.storageSystem.fileSystemVolumeInfo.mountInfo:
-                        if mi.volume.type == "VMFS":
+                        if mi.volume.type == "VMFS" or mi.volume.type == "NFS":
                             datastores.append(self.cache.find_obj(self.content, [vim.Datastore], mi.volume.name))
                 else:
                     datastores = self.cache.get_all_objs(self.content, [vim.Datastore])


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
VMware allows datastores to be NFS hosted. Currently the autoselect_datastore logic only considers VMFS filesystems. NFS mounted filesystems show up as "NFS", so adjusting logic to also check and consider those filesystems.


##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Make autoselect_datastore consider NFS mounted filesystems.

##### ADDITIONAL INFORMATION
Code change does an "or" test on the volume type looking for things that are "NFS" volume types.

Validation requires setting up NFS datastores in your ESXi environment, then calling vmware_guest as below:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
  community.vmware.vmware_guest:
    hostname: "{{ vmware_vcenter }}"
    username: "{{ vmware_account_name }}"
    password: "{{ vmware_password }}"
    validate_certs: False
    name: "{{ vmware_create_vm_name }}"
    datacenter: "{{ vmware_datacenter }}"
    cluster: "{{ vmware_cluster }}"
    folder: "{{ vmware_folder }}"
    hardware:
      num_cpus: "{{ vmware_create_vm_num_cpus }}"
      memory_mb: "{{ vmware_create_vm_memory_mb }}"
    disk:
      - size_gb: "{{ vmware_create_vm_disk_size_gb }}"
        type: "thick"
        datastore: "{{ vmware_create_vm_disk_datastore }}"
        autoselect_datastore: "{{ vmware_create_vm_disk_autoselect_datastore }}"
    networks:
      - connected: yes
        start_connected: yes
        name: "{{ vmware_create_vm_networks_name }}"
    cdrom:
      - type: "iso"
        controller_number: 0
        unit_number: 0
        iso_path: "{{ vmware_create_vm_cdrom_iso_path }}"
  delegate_to: 127.0.0.1

```
