### PR TITLE
CI: Remove unnecessary prepare step

### DIFF
--- a/plugins/modules/vmware_vswitch.py
+++ b/plugins/modules/vmware_vswitch.py
@@ -257,8 +257,6 @@ from ansible_collections.community.vmware.plugins.module_utils.vmware import PyV
 from ansible.module_utils._text import to_native
 
 
-# Meaningless diff with no code changes to trigger CI
-
 class VMwareHostVirtualSwitch(PyVmomi):
     def __init__(self, module):
         super(VMwareHostVirtualSwitch, self).__init__(module)

--- a/plugins/modules/vmware_vswitch.py
+++ b/plugins/modules/vmware_vswitch.py
@@ -257,6 +257,8 @@ from ansible_collections.community.vmware.plugins.module_utils.vmware import PyV
 from ansible.module_utils._text import to_native
 
 
+# Meaningless diff with no code changes to trigger CI
+
 class VMwareHostVirtualSwitch(PyVmomi):
     def __init__(self, module):
         super(VMwareHostVirtualSwitch, self).__init__(module)

--- a/tests/integration/targets/prepare_vmware_tests/tasks/setup_datastore.yml
+++ b/tests/integration/targets/prepare_vmware_tests/tasks/setup_datastore.yml
@@ -27,10 +27,6 @@
     validate_certs: false
   with_items: "{{ esxi_hosts }}"
 
-- vmware_host_scanhba:
-    refresh_storage: true
-    cluster_name: '{{ ccr1 }}'
-
 - name: The vcenter needs a bit of time to refresh the DS list
   vmware_datastore_info:
     validate_certs: false


### PR DESCRIPTION
I think this task is not really necessary:

https://github.com/ansible-collections/community.vmware/blob/f476a072745c7ab9e76a5db1b2b48fc0f2dc5f7e/tests/integration/targets/prepare_vmware_tests/tasks/setup_datastore.yml#L30-L32