### PR TITLE
backport 1757: Fix 2.15 integration test

### DIFF
--- a/tests/integration/targets/vmware_vm_info/tasks/main.yml
+++ b/tests/integration/targets/vmware_vm_info/tasks/main.yml
@@ -6,6 +6,7 @@
 - import_role:
     name: prepare_vmware_tests
   vars:
+    setup_attach_host: true
     setup_datastore: true
     setup_virtualmachines: true
 
@@ -15,13 +16,6 @@
     hostname: '{{ esxi1 }}'
     username: '{{ esxi_user }}'
     password: '{{ esxi_password }}'
-
-- import_role:
-    name: prepare_vmware_tests
-  vars:
-    setup_attach_host: true
-    setup_datastore: true
-    setup_virtualmachines: true
 
 - &vm_data
   name: Get info about available vms


### PR DESCRIPTION
##### SUMMARY
Backport #1757: The integration tests fail for vmware_vm_info when run in Zuul with ansible-core 2.15.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_vm_info

##### ADDITIONAL INFORMATION
