### PR TITLE
Do not fail when state is absent and disk is not found

### DIFF
--- a/changelogs/fragments/1765_vmware_guest_disk.yaml
+++ b/changelogs/fragments/1765_vmware_guest_disk.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_guest_disk - Fix idempotency for `absent` disks (https://github.com/ansible-collections/community.vmware/issues/1765).

--- a/plugins/modules/vmware_guest_disk.py
+++ b/plugins/modules/vmware_guest_disk.py
@@ -810,10 +810,6 @@ class PyVmomiHelper(PyVmomi):
                         disk_change_list.append(disk_change)
                         results['disk_changes'][disk['disk_index']] = "Disk created."
                         break
-                    if not disk_found and disk['state'] == 'absent':
-                        self.module.fail_json(msg="Not found disk with 'controller_type': '%s',"
-                                                  " 'controller_number': '%s', 'unit_number': '%s' to remove."
-                                                  % (disk['controller_type'], disk['controller_number'], disk['disk_unit_number']))
             if disk_change:
                 # Adding multiple disks in a single attempt raises weird errors
                 # So adding single disk at a time.

--- a/tests/integration/targets/vmware_guest_disk/tasks/main.yml
+++ b/tests/integration/targets/vmware_guest_disk/tasks/main.yml
@@ -608,3 +608,27 @@
   assert:
     that:
       - test_remove_ide_disk is changed
+
+- name: Try to remove non-existing SCSI disk
+  vmware_guest_disk:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter: "{{ dc1 }}"
+    validate_certs: false
+    name: test_vm1
+    disk:
+      - state: "absent"
+        controller_type: 'paravirtual'
+        controller_number: 0
+        unit_number: 15
+  register: test_remove_non_existing_disk
+  ignore_errors: true
+
+- debug:
+    msg: "{{ test_remove_non_existing_disk }}"
+
+- name: assert that removing non existing disk does not fail
+  assert:
+    that:
+      - test_remove_non_existing_disk is not failed


### PR DESCRIPTION
##### SUMMARY
Fixes #1765. Do not faill when state is absent and disk is not present

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_guest_disk

##### ADDITIONAL INFORMATION

```paste below


PLAY [localhost] ***********************************************************************************************************************************************************************************************************************

 

TASK [Remove VM disk] ******************************************************************************************************************************************************************************************************************

ok: [localhost]

 

PLAY RECAP *****************************************************************************************************************************************************************************************************************************

localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```
