### PR TITLE
Implement encryption configuration for vm vmotion and ft

### DIFF
--- a/changelogs/fragments/1069_vmware_guest.yml
+++ b/changelogs/fragments/1069_vmware_guest.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_guest - add support for configuring vMotion and FT encryption (https://github.com/ansible-collections/community.vmware/issues/1069)

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -248,6 +248,7 @@ options:
     description:
     - Manage virtual machine encryption settings
     - All parameters case sensitive.
+    version_added: '3.8.0'
     suboptions:
         encrypted_vmotion:
             type: str

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -242,6 +242,21 @@ options:
         iommu:
             type: bool
             description: Flag to specify if I/O MMU is enabled for this virtual machine.
+  encryption:
+    type: dict
+    default: {}
+    description:
+    - Manage virtual machine encryption settings
+    - All parameters case sensitive.
+    suboptions:
+        encrypted_vmotion:
+            type: str
+            description: Controlls encryption for live migrations with vmotion
+            choices: [ 'disabled', 'opportunistic', 'required' ]
+        encrypted_ft:
+            type: str
+            description: Controlls encryption for fault tolerance replication
+            choices: [ 'disabled', 'opportunistic', 'required' ]
   guest_id:
     type: str
     description:
@@ -1709,6 +1724,27 @@ class PyVmomiHelper(PyVmomi):
                     self.configspec.flags = vim.vm.FlagInfo()
                 self.configspec.flags.vbsEnabled = virt_based_security
 
+    def configure_encryption_params(self, vm_obj):
+
+        encrypted_vmotion = self.params['encryption']['encrypted_vmotion']
+        if encrypted_vmotion is not None:
+            if vm_obj is None or encrypted_vmotion != vm_obj.config.migrateEncryption:
+                self.change_detected = True
+                self.configspec.migrateEncryption = encrypted_vmotion
+
+        encrypted_ft = self.params['encryption']['encrypted_ft']
+        if encrypted_ft is not None:
+            if encrypted_ft == "disabled":
+                encrypted_ft_cfg = "ftEncryptionDisabled"
+            elif encrypted_ft == "opportunistic":
+                encrypted_ft_cfg = "ftEncryptionOpportunistic"
+            elif encrypted_ft == "required":
+                encrypted_ft_cfg = "ftEncryptionRequired"
+            if vm_obj is None or encrypted_ft_cfg != vm_obj.config.ftEncryptionMode:
+                self.change_detected = True
+                self.configspec.ftEncryptionMode = encrypted_ft_cfg
+
+
     def get_device_by_type(self, vm=None, type=None):
         device_list = []
         if vm is None or type is None:
@@ -2981,6 +3017,7 @@ class PyVmomiHelper(PyVmomi):
         self.configure_guestid(vm_obj=vm_obj, vm_creation=True)
         self.configure_cpu_and_memory(vm_obj=vm_obj, vm_creation=True)
         self.configure_hardware_params(vm_obj=vm_obj)
+        self.configure_encryption_params(vm_obj=vm_obj)
         self.configure_resource_alloc_info(vm_obj=vm_obj)
         self.configure_vapp_properties(vm_obj=vm_obj)
         self.configure_disks(vm_obj=vm_obj)
@@ -3165,6 +3202,7 @@ class PyVmomiHelper(PyVmomi):
         self.configure_guestid(vm_obj=self.current_vm_obj)
         self.configure_cpu_and_memory(vm_obj=self.current_vm_obj)
         self.configure_hardware_params(vm_obj=self.current_vm_obj)
+        self.configure_encryption_params(vm_obj=self.current_vm_obj)
         self.configure_disks(vm_obj=self.current_vm_obj)
         self.configure_network(vm_obj=self.current_vm_obj)
         self.configure_cdrom(vm_obj=self.current_vm_obj)
@@ -3448,6 +3486,13 @@ def main():
                 version=dict(type='str'),
                 virt_based_security=dict(type='bool'),
                 iommu=dict(type='bool')
+            )),
+        encryption=dict(
+            type='dict',
+            default={},
+            options=dict(
+                encrypted_vmotion=dict(type='str', choices=[ 'disabled', 'opportunistic', 'required' ]),
+                encrypted_ft=dict(type='str', choices=[ 'disabled', 'opportunistic', 'required' ])
             )),
         force=dict(type='bool', default=False),
         datacenter=dict(type='str', default='ha-datacenter'),

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -252,11 +252,11 @@ options:
         encrypted_vmotion:
             type: str
             description: Controlls encryption for live migrations with vmotion
-            choices: [ 'disabled', 'opportunistic', 'required' ]
+            choices: ['disabled', 'opportunistic', 'required']
         encrypted_ft:
             type: str
             description: Controlls encryption for fault tolerance replication
-            choices: [ 'disabled', 'opportunistic', 'required' ]
+            choices: ['disabled', 'opportunistic', 'required']
   guest_id:
     type: str
     description:
@@ -1743,7 +1743,6 @@ class PyVmomiHelper(PyVmomi):
             if vm_obj is None or encrypted_ft_cfg != vm_obj.config.ftEncryptionMode:
                 self.change_detected = True
                 self.configspec.ftEncryptionMode = encrypted_ft_cfg
-
 
     def get_device_by_type(self, vm=None, type=None):
         device_list = []
@@ -3491,8 +3490,8 @@ def main():
             type='dict',
             default={},
             options=dict(
-                encrypted_vmotion=dict(type='str', choices=[ 'disabled', 'opportunistic', 'required' ]),
-                encrypted_ft=dict(type='str', choices=[ 'disabled', 'opportunistic', 'required' ])
+                encrypted_vmotion=dict(type='str', choices=['disabled', 'opportunistic', 'required']),
+                encrypted_ft=dict(type='str', choices=['disabled', 'opportunistic', 'required'])
             )),
         force=dict(type='bool', default=False),
         datacenter=dict(type='str', default='ha-datacenter'),

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -248,7 +248,7 @@ options:
     description:
     - Manage virtual machine encryption settings
     - All parameters case sensitive.
-    version_added: '3.8.0'
+    version_added: '3.9.0'
     suboptions:
         encrypted_vmotion:
             type: str


### PR DESCRIPTION
##### SUMMARY
Fixes #1069 

Implements the  ability to configured vm encryption settings for vmotion or fault tolerance

![image](https://github.com/ansible-collections/community.vmware/assets/6898158/00b520da-b3b5-4078-b2d0-8eae6f005210)

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
vmware_guest

##### ADDITIONAL INFORMATION
Fulfill  requirements of #1069