### PR TITLE
Support for nested resource pools

### DIFF
--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -2884,12 +2884,19 @@ class PyVmomiHelper(PyVmomi):
             cluster = None
 
         # get resource pools limiting search to cluster or datacenter
-        resource_pool = find_obj(self.content, [vim.ResourcePool], resource_pool_name, folder=cluster or datacenter)
-        if not resource_pool:
-            if resource_pool_name:
-                self.module.fail_json(msg='Unable to find resource_pool "%s"' % resource_pool_name)
+        resource_pool = find_obj(self.content, [vim.ResourcePool], None, folder=cluster or datacenter)
+        if not resource_pool:   
+            self.module.fail_json(msg='Unable to find resource pool, need esxi_hostname, resource_pool, or cluster')
+        resource_pool_path = resource_pool_name.split('/') if resource_pool_name else []
+        # filter path from empty items
+        rp_path_nodes = list(filter(None, resource_pool_path))
+        for i in range(len(rp_path_nodes)):
+            child = list(filter(lambda x: x.name == rp_path_nodes[i], resource_pool.resourcePool))
+            if len(child) != 1:
+                self.module.fail_json(msg='Unable to find node "%s" in resource pool path "%s"' % (rp_path_nodes[i], resource_pool_name))
+                break
             else:
-                self.module.fail_json(msg='Unable to find resource pool, need esxi_hostname, resource_pool, or cluster')
+                resource_pool = child[0]
         return resource_pool
 
     def deploy_vm(self):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I propose to change the logic of defining the target resource pool. In the current logic, nested resource pools cannot be defined, and the virtual machine is deployed in the first pool found by name, nesting is not considered.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #1360
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
I changed a part of `get_resource_pool()` function
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
I get an array of nodes from a string (resource_pool parameter, eg resource_pool:/prod/web/app) Then iterate over each node in a loop. I first take the `root resource pool` and look for the first element from the array among its children. I then search for the next element from the array among the children of the found node, and so on.
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
resource_pool parameter before:
```yaml
resource_pool: TST
```
resource_pool parameter after:
```yaml
resource_pool: DEVELOP/TST/DB
```
