### PR TITLE
Use antsibull-docs to create documentation

### DIFF
--- a/tools/antsibull-docs-wrapper.sh
+++ b/tools/antsibull-docs-wrapper.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+TMPDIR=`mktemp -d`
+export ANSIBLE_COLLECTIONS_PATH="$TMPDIR"
+ansible-galaxy collection install "$1"
+antsibull-docs collection-plugins community.vmware --dest-dir docs/ --use-current --output-format simplified-rst --fqcn-plugin-names
+rm -rf $TMPDIR

--- a/tools/create_documentation_tasks.yml
+++ b/tools/create_documentation_tasks.yml
@@ -2,5 +2,12 @@
   ansible.builtin.pip:
     name: tox
 
+- name: Install antsibull-docs
+  ansible.builtin.pip:
+    name: antsibull-docs
+
 - name: Refresh module documentation and README.md
   ansible.builtin.shell: tox -e add_docs
+
+- name: Update documentation with antsibull-docs
+  ansible.builtin.shell: "{{ playbook_dir }}/antsibull-docs-wrapper.sh"

--- a/tox.ini
+++ b/tox.ini
@@ -18,8 +18,14 @@ commands =
   yamllint -c .yamllint.yaml tests
 
 [testenv:add_docs]
-deps = git+https://github.com/ansible-network/collection_prep
-commands = collection_prep_add_docs -p .
+setenv =
+  LC_ALL=en_US.UTF-8
+deps =
+  git+https://github.com/ansible-network/collection_prep
+  antsibull-docs
+commands =
+  collection_prep_add_docs -p .
+  antsibull-docs collection-plugins community.vmware --dest-dir docs/ --use-current --output-format simplified-rst --fqcn-plugin-names
 
 [testenv:antsibull-changelog]
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -18,14 +18,8 @@ commands =
   yamllint -c .yamllint.yaml tests
 
 [testenv:add_docs]
-setenv =
-  LC_ALL=en_US.UTF-8
-deps =
-  git+https://github.com/ansible-network/collection_prep
-  antsibull-docs
-commands =
-  collection_prep_add_docs -p .
-  antsibull-docs collection-plugins community.vmware --dest-dir docs/ --use-current --output-format simplified-rst --fqcn-plugin-names
+deps = git+https://github.com/ansible-network/collection_prep
+commands = collection_prep_add_docs -p .
 
 [testenv:antsibull-changelog]
 setenv =


### PR DESCRIPTION
##### SUMMARY
This is just a first test trying to use [antsibull-docs](https://github.com/ansible-community/antsibull-docs) instead of [collection_prep](https://github.com/ansible-network/collection_prep) in order to generate the documentation. If I'm lucky, it works and I don't have to change it soon.

##### ISSUE TYPE
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
tools/create_documentation_tasks.yml

##### ADDITIONAL INFORMATION
Follow-up to #1788

#1770

cc @felixfontein 