### PR TITLE
Use re.search for more flexibility in selecting a datastore

### DIFF
--- a/changelogs/fragments/0000-autoselect_datastore-use-regex.yaml
+++ b/changelogs/fragments/0000-autoselect_datastore-use-regex.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - autoselect_datastore-use-regex - when using autoselect_datastore, use re.search() to match the datastore instead of substring .find()

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -2758,7 +2758,7 @@ class PyVmomiHelper(PyVmomi):
 
                     if (ds.summary.freeSpace > datastore_freespace) or (ds.summary.freeSpace == datastore_freespace and not datastore):
                         # If datastore field is provided, filter destination datastores
-                        if self.params['disk'][0]['datastore'] and ds.name.find(self.params['disk'][0]['datastore']) < 0:
+                        if self.params['disk'][0]['datastore'] and not re.search(self.params['disk'][0]['datastore'],ds.name):
                             continue
 
                         datastore = ds


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

When finding the datastore(s) with autoselect_datastore, using re.search() provides more flexibility to match above what .find() substring matching can do.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_guest.py autoselect_datastore functionality

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Swapped call ds.name.find() over to using re.search() to provide regex searching ability.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
- name: Create a virtual machine on given ESXi hostname
  community.vmware.vmware_guest:
[...]
    disk:
    - size_gb: 10
      type: thin
      datastore: datastore1_SSD
      autoselect_datastore: True
[...]

- name: Create a virtual machine on given ESXi hostname
  community.vmware.vmware_guest:
[...]
    disk:
    - size_gb: 10
      type: thin
      datastore: '_SSD$'
      autoselect_datastore: True
[...]

```
