### PR TITLE
vmware_vm_info: Add instance_uuid

### DIFF
--- a/changelogs/fragments/1805_vmware_vm_info.yml
+++ b/changelogs/fragments/1805_vmware_vm_info.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_vm_info -  Add `instance_uuid` to the result (https://github.com/ansible-collections/community.vmware/issues/1805)

--- a/plugins/modules/vmware_cluster_info.py
+++ b/plugins/modules/vmware_cluster_info.py
@@ -184,7 +184,7 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six.moves.urllib.parse import unquote
-from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, vmware_argument_spec, find_datacenter_by_name, find_cluster_by_name,\
+from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, vmware_argument_spec, find_datacenter_by_name, find_cluster_by_name, \
     get_parent_datacenter
 from ansible_collections.community.vmware.plugins.module_utils.vmware_rest_client import VmwareRestClient
 

--- a/plugins/modules/vmware_guest_disk.py
+++ b/plugins/modules/vmware_guest_disk.py
@@ -516,7 +516,7 @@ except ImportError:
 from random import randint
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
-from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, vmware_argument_spec,\
+from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, vmware_argument_spec, \
     wait_for_task, find_obj, get_all_objs, get_parent_datacenter
 from ansible_collections.community.vmware.plugins.module_utils.vm_device_helper import PyVmomiDeviceHelper
 

--- a/plugins/modules/vmware_vm_info.py
+++ b/plugins/modules/vmware_vm_info.py
@@ -421,6 +421,7 @@ class VmwareVmInfo(PyVmomi):
                 "ip_address": _ip_address,  # Kept for backward compatibility
                 "mac_address": _mac_address,  # Kept for backward compatibility
                 "uuid": summary.config.uuid,
+                "instance_uuid": summary.config.instanceUuid,
                 "vm_network": net_dict,
                 "esxi_hostname": esxi_hostname,
                 "datacenter": None if datacenter is None else datacenter.name,


### PR DESCRIPTION
##### SUMMARY
Fixes #1805

Add `instance_uuid` to the result of `vmware_vm_info`.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_vm_info

##### ADDITIONAL INFORMATION
