### PR TITLE
fix issue #1808

### DIFF
--- a/plugins/modules/vmware_deploy_ovf.py
+++ b/plugins/modules/vmware_deploy_ovf.py
@@ -211,6 +211,7 @@ try:
 except ImportError:
     pass
 
+
 def path_exists(value):
     if not isinstance(value, string_types):
         value = str(value)

--- a/plugins/modules/vmware_deploy_ovf.py
+++ b/plugins/modules/vmware_deploy_ovf.py
@@ -210,7 +210,7 @@ try:
     from pyVmomi import vmodl
 except ImportError:
     pass
-
+import epdb
 
 def path_exists(value):
     if not isinstance(value, string_types):
@@ -392,12 +392,11 @@ class VMwareDeployOvf(PyVmomi):
             # Search for the network key of the same network name, that resides in a cluster parameter
             for network in networks:
                 if self.params['cluster']:
-                    for cnet in cluster.network:
-                        if network.key in cnet.key:
-                            network_mapping = vim.OvfManager.NetworkMapping()
-                            network_mapping.name = key
-                            network_mapping.network = network
-                            self.network_mappings.append(network_mapping)
+                    if network in cluster.network:
+                        network_mapping = vim.OvfManager.NetworkMapping()
+                        network_mapping.name = key
+                        network_mapping.network = network
+                        self.network_mappings.append(network_mapping)
                 else:
                     network_mapping = vim.OvfManager.NetworkMapping()
                     network_mapping.name = key

--- a/plugins/modules/vmware_deploy_ovf.py
+++ b/plugins/modules/vmware_deploy_ovf.py
@@ -210,7 +210,6 @@ try:
     from pyVmomi import vmodl
 except ImportError:
     pass
-import epdb
 
 def path_exists(value):
     if not isinstance(value, string_types):


### PR DESCRIPTION
##### SUMMARY
Fix issue #1808. Only DistributedVirtualPortgroup objects has 'key' attribute. Network and Opaque network don't nave it. Checking for being in an array should be carried out simply by object.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
vmware_deploy_ovf
