### PR TITLE
Add space for logs of vmware_object_role_permission_info

### DIFF
--- a/plugins/modules/vmware_object_role_permission_info.py
+++ b/plugins/modules/vmware_object_role_permission_info.py
@@ -216,7 +216,7 @@ class VMwareObjectRolePermission(PyVmomi):
                 vimtype=[vim_type],
                 name=self.params["object_name"],
             )
-            msg = "%s of type %s" % (
+            msg = "%s of type %s " % (
                 self.params["object_name"],
                 self.params["object_type"],
             )


### PR DESCRIPTION
##### SUMMARY
I have add a little space for vmware_object_role_permission_info :)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_object_role_permission_info 

##### ADDITIONAL INFORMATION
Logs:
```
(item=StoragePod) => {"ansible_loop_var": "item", "changed": false, "item": "StoragePod", "msg": "banane of type StoragePodwas not found"}
```