### PR TITLE
vmware_deploy_ovf: Fix sanity tests

### DIFF
--- a/plugins/modules/vmware_deploy_ovf.py
+++ b/plugins/modules/vmware_deploy_ovf.py
@@ -13,7 +13,7 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 author:
     - Alexander Nikitin (@ihumster)
-    - Matt Martz <matt@sivel.net>
+    - Matt Martz (@sivel)
 short_description: 'Deploys a VMware virtual machine from an OVF or OVA file, placed on file system or HTTP server'
 description:
     - 'This module can be used to deploy a VMware VM from an OVF or OVA file, placed on file system or HTTP server'

--- a/plugins/modules/vmware_deploy_ovf.py
+++ b/plugins/modules/vmware_deploy_ovf.py
@@ -276,8 +276,9 @@ class WebHandle(object):
 
     def _parse_url(self, url):
         exp1 = r"(?P<url>(?:(?P<scheme>[a-zA-Z]+:\/\/)?(?P<hostname>(?:[-a-zA-Z0-9@%_\+~#=]{1,256}\.){1,256}(?:[-a-zA-Z0-9@%_\+~#=]{1,256})))"
-        exp2 = r"(?::(?P<port>[[:digit:]]+))?(?P<path>(?:\/[-a-zA-Z0-9!$&'()*+,\\\/:;=@\[\]._~%]*)*)(?P<query>(?:(?:\#|\?)[-a-zA-Z0-9!$&'()*+,\\\/:;=@\[\]._~]*)*))"
-        return re.match(exp1 + exp2, url)
+        exp2 = r"(?::(?P<port>[[:digit:]]+))?(?P<path>(?:\/[-a-zA-Z0-9!$&'()*+,\\\/:;=@\[\]._~%]*)*)"
+        exp3 = r"(?P<query>(?:(?:\#|\?)[-a-zA-Z0-9!$&'()*+,\\\/:;=@\[\]._~]*)*))"
+        return re.match(exp1 + exp2 + exp3, url)
 
     def _get_thumbprint(self, hostname):
         pem = ssl.get_server_certificate((hostname, 443))


### PR DESCRIPTION
##### SUMMARY
After merging #1803 the daily CI run fails the sanity tests:

```
plugins/modules/vmware_deploy_ovf.py:279:161: E501: line too long (164 > 160 characters)
plugins/modules/vmware_deploy_ovf.py:0:0: invalid-documentation: DOCUMENTATION.author: Invalid author for dictionary value @ data['author']. Got ['Alexander Nikitin (@ihumster)', 'Matt Martz ']
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_deploy_ovf

##### ADDITIONAL INFORMATION
[Sanity (Ⓐstable-2.14)](https://github.com/mariolenz/community.vmware/actions/runs/5845998282/job/15850666577#logs)
