### PR TITLE
feat: add feature to allow template username and password on inventory

### DIFF
--- a/docs/community.vmware.vmware_guest_module.rst
+++ b/docs/community.vmware.vmware_guest_module.rst
@@ -1014,7 +1014,7 @@ Parameters
                         </ul>
                 </td>
                 <td>
-                        <div>Controlls encryption for fault tolerance replication</div>
+                        <div>Controls encryption for fault tolerance replication</div>
                 </td>
             </tr>
             <tr>
@@ -1035,7 +1035,7 @@ Parameters
                         </ul>
                 </td>
                 <td>
-                        <div>Controlls encryption for live migrations with vmotion</div>
+                        <div>Controls encryption for live migrations with vmotion</div>
                 </td>
             </tr>
 

--- a/docs/community.vmware.vmware_host_graphics_module.rst
+++ b/docs/community.vmware.vmware_host_graphics_module.rst
@@ -8,6 +8,7 @@ community.vmware.vmware_host_graphics
 **Manage Host Graphic Settings**
 
 
+Version added: 3.10.0
 
 .. contents::
    :local:
@@ -202,8 +203,8 @@ Parameters
                 </td>
                 <td>
                         <ul style="margin: 0; padding: 0"><b>Choices:</b>
-                                    <li>no</li>
-                                    <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                                    <li><div style="color: blue"><b>no</b>&nbsp;&larr;</div></li>
+                                    <li>yes</li>
                         </ul>
                 </td>
                 <td>
@@ -305,7 +306,7 @@ Common return values are documented `here <https://docs.ansible.com/ansible/late
                             <div>data about host system graphics settings.</div>
                     <br/>
                         <div style="font-size: smaller"><b>Sample:</b></div>
-                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{&#x27;changed&#x27;: True, &#x27;esxi01&#x27;: {&#x27;changed&#x27;: False, &#x27;msg&#x27;: &#x27;All Host Graphics Settings already configured&#x27;}, &#x27;esxi02&#x27;: {&#x27;changed&#x27;: True, &#x27;msg&#x27;: &quot;New host graphics settings changed to: hostDefaultGraphicsType = &#x27;shared&#x27;, sharedPassthruAssignmentPolicy = &#x27;performance&#x27;. X.Org was restarted&quot;}}</div>
+                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{&#x27;changed&#x27;: True, &#x27;esxi01&#x27;: {&#x27;changed&#x27;: False, &#x27;msg&#x27;: &#x27;All Host Graphics Settings already configured&#x27;}, &#x27;esxi02&#x27;: {&#x27;changed&#x27;: True, &#x27;msg&#x27;: &quot;New host graphics settings changed to: hostDefaultGraphicsType = &#x27;shared&#x27;, sharedPassthruAssignmentPolicy = &#x27;performance&#x27;.X.Org was restarted&quot;}}</div>
                 </td>
             </tr>
     </table>

--- a/docs/community.vmware.vmware_host_inventory_inventory.rst
+++ b/docs/community.vmware.vmware_host_inventory_inventory.rst
@@ -438,6 +438,7 @@ Parameters
                 <td>
                         <div>Password of vSphere user.</div>
                         <div>Accepts vault encrypted variable.</div>
+                        <div>Accepts Jinja to template the value</div>
                 </td>
             </tr>
             <tr>
@@ -611,6 +612,7 @@ Parameters
                 <td>
                         <div>Name of vSphere user.</div>
                         <div>Accepts vault encrypted variable.</div>
+                        <div>Accepts Jinja to template the value</div>
                 </td>
             </tr>
             <tr>
@@ -742,6 +744,15 @@ Examples
         hostname: 10.65.223.31
         username: administrator@vsphere.local
         password: Esxi@123$%
+        validate_certs: false
+        with_tags: true
+
+    # Sample configuration file for VMware Guest dynamic inventory using Jinja to template the username and password.
+        plugin: community.vmware.vmware_host_inventory
+        strict: false
+        hostname: 10.65.223.31
+        username: '{{ (lookup("file","~/.config/vmware.yaml") | from_yaml).username }}'
+        password: '{{ (lookup("file","~/.config/vmware.yaml") | from_yaml).password }}'
         validate_certs: false
         with_tags: true
 

--- a/docs/community.vmware.vmware_vm_inventory_inventory.rst
+++ b/docs/community.vmware.vmware_vm_inventory_inventory.rst
@@ -439,6 +439,7 @@ Parameters
                 <td>
                         <div>Password of vSphere user.</div>
                         <div>Accepts vault encrypted variable.</div>
+                        <div>Accepts Jinja to template the value</div>
                 </td>
             </tr>
             <tr>
@@ -615,6 +616,7 @@ Parameters
                 <td>
                         <div>Name of vSphere user.</div>
                         <div>Accepts vault encrypted variable.</div>
+                        <div>Accepts Jinja to template the value</div>
                 </td>
             </tr>
             <tr>
@@ -747,6 +749,15 @@ Examples
         hostname: 10.65.223.31
         username: administrator@vsphere.local
         password: Esxi@123$%
+        validate_certs: false
+        with_tags: true
+
+    # Sample configuration file for VMware Guest dynamic inventory using Jinja to template the username and password.
+        plugin: community.vmware.vmware_vm_inventory
+        strict: false
+        hostname: 10.65.223.31
+        username: '{{ (lookup("file","~/.config/vmware.yaml") | from_yaml).username }}'
+        password: '{{ (lookup("file","~/.config/vmware.yaml") | from_yaml).password }}'
         validate_certs: false
         with_tags: true
 

--- a/plugins/inventory/vmware_vm_inventory.py
+++ b/plugins/inventory/vmware_vm_inventory.py
@@ -671,13 +671,14 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
         if self.templar.is_template(password):
             password = self.templar.template(variable=password, disable_lookups=False)
-        elif isinstance(username, AnsibleVaultEncryptedUnicode):
-            username = username.data
+        elif isinstance(password, AnsibleVaultEncryptedUnicode):
+            password = password.data
+        
         
         if self.templar.is_template(username):
             username = self.templar.template(variable=username, disable_lookups=False)
-        elif isinstance(password, AnsibleVaultEncryptedUnicode):
-            password = password.data
+        elif isinstance(username, AnsibleVaultEncryptedUnicode):
+            username = username.data
         
         self.pyv = BaseVMwareInventory(
             hostname=self.get_option('hostname'),

--- a/plugins/inventory/vmware_vm_inventory.py
+++ b/plugins/inventory/vmware_vm_inventory.py
@@ -673,13 +673,12 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             password = self.templar.template(variable=password, disable_lookups=False)
         elif isinstance(password, AnsibleVaultEncryptedUnicode):
             password = password.data
-        
-        
+
         if self.templar.is_template(username):
             username = self.templar.template(variable=username, disable_lookups=False)
         elif isinstance(username, AnsibleVaultEncryptedUnicode):
             username = username.data
-        
+
         self.pyv = BaseVMwareInventory(
             hostname=self.get_option('hostname'),
             username=username,

--- a/plugins/inventory/vmware_vm_inventory.py
+++ b/plugins/inventory/vmware_vm_inventory.py
@@ -32,6 +32,7 @@ DOCUMENTATION = r'''
             description:
             - Name of vSphere user.
             - Accepts vault encrypted variable.
+            - Accepts Jinja to template the value
             required: true
             env:
               - name: VMWARE_USER
@@ -40,6 +41,7 @@ DOCUMENTATION = r'''
             description:
             - Password of vSphere user.
             - Accepts vault encrypted variable.
+            - Accepts Jinja to template the value
             required: true
             env:
               - name: VMWARE_PASSWORD
@@ -163,6 +165,15 @@ EXAMPLES = r'''
     hostname: 10.65.223.31
     username: administrator@vsphere.local
     password: Esxi@123$%
+    validate_certs: false
+    with_tags: true
+
+# Sample configuration file for VMware Guest dynamic inventory using Jinja to template the username and password.
+    plugin: community.vmware.vmware_vm_inventory
+    strict: false
+    hostname: 10.65.223.31
+    username: '{{ (lookup("file","~/.config/vmware.yaml") | from_yaml).username }}'
+    password: '{{ (lookup("file","~/.config/vmware.yaml") | from_yaml).password }}'
     validate_certs: false
     with_tags: true
 
@@ -658,12 +669,16 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         username = self.get_option('username')
         password = self.get_option('password')
 
-        if isinstance(username, AnsibleVaultEncryptedUnicode):
+        if self.templar.is_template(password):
+            password = self.templar.template(variable=password, disable_lookups=False)
+        elif isinstance(username, AnsibleVaultEncryptedUnicode):
             username = username.data
-
-        if isinstance(password, AnsibleVaultEncryptedUnicode):
+        
+        if self.templar.is_template(username):
+            username = self.templar.template(variable=username, disable_lookups=False)
+        elif isinstance(password, AnsibleVaultEncryptedUnicode):
             password = password.data
-
+        
         self.pyv = BaseVMwareInventory(
             hostname=self.get_option('hostname'),
             username=username,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- This enables using of Jinja2 for templating `username` and `password`
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- `community.vmware.vmware_vm_inventory`
- `community.vmware.vmware_host_inventory`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
- Currently, the username and password can be set by Environment Variables, plain or using Ansible Vault. In an inventory using LDAP credentials, with multiple environments and consequently LDAP servers, it's a pain to manage those credentials in a safer way and at the same time dynamically. Also if someone is not using Ansible Vault, allows usage of different ways for storing those secrets safely. Supporting Jinja2, allows anyone to use different `lookup` plugins that best fit their needs.
