### PR TITLE
vmware_deploy_ovf: Add option to source properties marked as ovf:user…

### DIFF
--- a/changelogs/fragments/802-vmware_deploy_ovf.yml
+++ b/changelogs/fragments/802-vmware_deploy_ovf.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - vmware_deploy_ovf - New parameter enable_hidden_properties to force OVF properties marked as ovf:userConfigurable=false to become user configurable
+    (https://github.com/ansible-collections/community.vmware/issues/802).

--- a/plugins/modules/vmware_deploy_ovf.py
+++ b/plugins/modules/vmware_deploy_ovf.py
@@ -74,7 +74,7 @@ options:
         description:
         - Enable source properties that are marked as ovf:userConfigurable=false
         default: false
-        version_added: '3.9.0'
+        version_added: '3.11.0'
     fail_on_spec_warnings:
         description:
         - Cause the module to treat OVF Import Spec warnings as errors.

--- a/plugins/modules/vmware_deploy_ovf.py
+++ b/plugins/modules/vmware_deploy_ovf.py
@@ -70,6 +70,11 @@ options:
         description:
         - Disk provisioning type.
         type: str
+    enable_hidden_properties:
+        description:
+        - Enable source properties that are marked as ovf:userConfigurable=false
+        default: false
+        version_added: '3.9.0'
     fail_on_spec_warnings:
         description:
         - Cause the module to treat OVF Import Spec warnings as errors.
@@ -594,6 +599,10 @@ class VMwareDeployOvf(PyVmomi):
             spec_params
         )
 
+        if self.params['enable_hidden_properties']:
+            for prop in self.import_spec.importSpec.configSpec.vAppConfig.property:
+                prop.info.userConfigurable = True
+
         errors = [to_native(e.msg) for e in getattr(self.import_spec, 'error', [])]
         if self.params['fail_on_spec_warnings']:
             errors.extend(
@@ -857,6 +866,10 @@ def main():
                 'monolithicFlat'
             ],
             'default': 'thin',
+        },
+        'enable_hidden_properties': {
+            'default': False,
+            'type': 'bool',
         },
         'power_on': {
             'type': 'bool',

--- a/plugins/modules/vmware_deploy_ovf.py
+++ b/plugins/modules/vmware_deploy_ovf.py
@@ -75,6 +75,7 @@ options:
         - Enable source properties that are marked as ovf:userConfigurable=false
         default: false
         version_added: '3.11.0'
+        type: bool
     fail_on_spec_warnings:
         description:
         - Cause the module to treat OVF Import Spec warnings as errors.


### PR DESCRIPTION
##### SUMMARY
This forces OVF properties marked as ovf:userConfigurable=false to become user configurable.

This is useful when deploying VCSA OVAs.

Fixes: #802 

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_deploy_ovf: Add option to force applying non-user configurable properties



