### PR TITLE
4.0.0: Removing support for ansible-core version < 2.15.0

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -20,6 +20,7 @@ on:
     branches:
       - main
       - stable-2.x
+      - stable-3.x
   pull_request:
   # Run CI once per day (at 07:12 UTC)
   # This ensures that even if there haven't been commits that we are still
@@ -61,8 +62,8 @@ jobs:
           # - stable-2.10 # Only if your collection supports ansible-base 2.10
           # - stable-2.11 # Only if your collection supports ansible-core 2.11
           # - stable-2.12
-          - stable-2.13
-          - stable-2.14
+          # - stable-2.13
+          # - stable-2.14
           - stable-2.15
           # - devel
           - milestone
@@ -123,8 +124,8 @@ jobs:
           # - stable-2.10 # Only if your collection supports ansible-base 2.10
           # - stable-2.11 # Only if your collection supports ansible-core 2.11
           # - stable-2.12
-          - stable-2.13
-          - stable-2.14
+          # - stable-2.13
+          # - stable-2.14
           - stable-2.15
           # - devel
           - milestone

--- a/.github/workflows/extra-docs-linting.yml
+++ b/.github/workflows/extra-docs-linting.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - stable-2.x
+      - stable-3.x
   pull_request:
   # Run CI once per day (at 07:12 UTC)
   # This ensures that even if there haven't been commits that we are still testing against latest version of ansible-test for each ansible-base version

--- a/changelogs/fragments/4.0.0-required_ansible_version.yml
+++ b/changelogs/fragments/4.0.0-required_ansible_version.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+  - Removed support for ansible-core version < 2.15.0.

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,5 +1,5 @@
 ---
-requires_ansible: '>=2.13.0'
+requires_ansible: '>=2.15.0'
 
 action_groups:
   vmware:

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -1,3 +1,0 @@
-plugins/modules/vmware_deploy_ovf.py replace-urlopen!skip
-plugins/modules/vmware_deploy_ovf.py use-argspec-type-path!skip
-plugins/modules/vmware_host_acceptance.py validate-modules:parameter-state-invalid-choice

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,3 +1,0 @@
-plugins/modules/vmware_deploy_ovf.py replace-urlopen!skip
-plugins/modules/vmware_deploy_ovf.py use-argspec-type-path!skip
-plugins/modules/vmware_host_acceptance.py validate-modules:parameter-state-invalid-choice


### PR DESCRIPTION
##### SUMMARY
4.0.0 won't support ansible-core < 2.15.0.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME

##### ADDITIONAL INFORMATION