### PR TITLE
vmware_vm_info: Add prefix length to IPs in vm_network

### DIFF
--- a/changelogs/fragments/1761_vmware_vm_info.yml
+++ b/changelogs/fragments/1761_vmware_vm_info.yml
@@ -1,0 +1,3 @@
+breaking_changes:
+  - vmware_vm_info - Added prefix length to IP addresses in vm_network, so they now show up as for example 10.76.33.228/24 instead of just 10.76.33.228
+    (https://github.com/ansible-collections/community.vmware/issues/1761).

--- a/plugins/modules/vmware_vm_info.py
+++ b/plugins/modules/vmware_vm_info.py
@@ -254,7 +254,7 @@ virtual_machines:
         "vm_network": {
             "00:50:56:87:a5:9a": {
               "ipv4": [
-                "10.76.33.228"
+                "10.76.33.228/24"
               ],
               "ipv6": []
             }
@@ -357,11 +357,11 @@ class VmwareVmInfo(PyVmomi):
                         net_dict[device.macAddress] = dict()
                         net_dict[device.macAddress]['ipv4'] = []
                         net_dict[device.macAddress]['ipv6'] = []
-                        for ip_addr in device.ipAddress:
-                            if "::" in ip_addr:
-                                net_dict[device.macAddress]['ipv6'].append(ip_addr)
+                        for ip_addr in device.ipConfig.ipAddress:
+                            if "::" in ip_addr.ipAddress:
+                                net_dict[device.macAddress]['ipv6'].append(ip_addr.ipAddress + "/" + str(ip_addr.prefixLength))
                             else:
-                                net_dict[device.macAddress]['ipv4'].append(ip_addr)
+                                net_dict[device.macAddress]['ipv4'].append(ip_addr.ipAddress + "/" + str(ip_addr.prefixLength))
 
             esxi_hostname = None
             esxi_parent = None


### PR DESCRIPTION
##### SUMMARY
Fixes #1761

Add prefix length to IP addresses in `vm_network`, so they now show up as for example `10.76.33.228/24` instead of just `10.76.33.228`.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_vm_info

##### ADDITIONAL INFORMATION
I'm also switching to using `ipConfig` from [guest.net](https://vdc-repo.vmware.com/vmwb-repository/dcr-public/c476b64b-c93c-4b21-9d76-be14da0148f9/04ca12ad-59b9-4e1c-8232-fd3d4276e52c/SDK/vsphere-ws/docs/ReferenceGuide/vim.vm.GuestInfo.NicInfo.html) instead of `ipAddress` because the latter is deprecated.