### PR TITLE
vmware_host_acceptance: Remove acceptance_level

### DIFF
--- a/changelogs/fragments/1872-vmware_host_acceptance.yml
+++ b/changelogs/fragments/1872-vmware_host_acceptance.yml
@@ -1,0 +1,4 @@
+breaking_changes:
+  - vmware_host_acceptance - Removed `acceptance_level` and used its options in `state`. This also means there will be no `state` `list` anymore.
+    In order to get information about the current acceptance level, use the new module `vmware_host_acceptance_info`
+    (https://github.com/ansible-collections/community.vmware/issues/1872).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -87,6 +87,7 @@ action_groups:
   - vmware_guest_video
   - vmware_host
   - vmware_host_acceptance
+  - vmware_host_acceptance_info
   - vmware_host_active_directory
   - vmware_host_auto_start
   - vmware_host_capability_info

--- a/tests/integration/targets/vmware_host_acceptance/tasks/main.yml
+++ b/tests/integration/targets/vmware_host_acceptance/tasks/main.yml
@@ -7,33 +7,48 @@
   vars:
     setup_attach_host: true
 
-- name: Change acceptance level of given hosts
+- name: Change acceptance level of given host in check mode
   vmware_host_acceptance:
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     esxi_hostname: '{{ esxi1 }}'
     validate_certs: false
-    acceptance_level: community
-    state: present
-  register: host_acceptance_info
-- debug: var=host_acceptance_info
-- assert:
-    that:
-      - host_acceptance_info.facts is defined
-
-- name: Change acceptance level of given hosts in check mode
-  vmware_host_acceptance:
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    esxi_hostname: '{{ esxi1 }}'
-    validate_certs: false
-    acceptance_level: community
-    state: present
-  register: host_acceptance_info_check_mode
+    state: community
+  register: host_acceptance_community_check_mode
   check_mode: true
-- debug: var=host_acceptance_info_check_mode
+- debug: var=host_acceptance_community_check_mode
 - assert:
     that:
-      - host_acceptance_info_check_mode.facts is defined
+      - host_acceptance_community_check_mode.facts is defined
+      - host_acceptance_community_check_mode.changed
+
+- name: Change acceptance level of given host
+  vmware_host_acceptance:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    esxi_hostname: '{{ esxi1 }}'
+    validate_certs: false
+    state: community
+  register: host_acceptance_community
+- debug: var=host_acceptance_community
+- assert:
+    that:
+      - host_acceptance_community.facts is defined
+      - host_acceptance_community.changed
+
+- name: Change acceptance level of given host again (idempotency)
+  vmware_host_acceptance:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    esxi_hostname: '{{ esxi1 }}'
+    validate_certs: false
+    state: community
+  register: host_acceptance_community_again
+- debug: var=host_acceptance_community_again
+- assert:
+    that:
+      - host_acceptance_community_again.facts is defined
+      - host_acceptance_community_again.changed is false

--- a/tests/integration/targets/vmware_host_acceptance_info/aliases
+++ b/tests/integration/targets/vmware_host_acceptance_info/aliases
@@ -1,0 +1,3 @@
+cloud/vcenter
+needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_host_acceptance_info/tasks/main.yml
+++ b/tests/integration/targets/vmware_host_acceptance_info/tasks/main.yml
@@ -1,0 +1,22 @@
+# Test code for the vmware_host_acceptance module.
+# Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_attach_host: true
+
+- name: Gather acceptance level of given host
+  vmware_host_acceptance_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    esxi_hostname: '{{ esxi1 }}'
+    validate_certs: false
+  register: result
+- debug: var=result
+- assert:
+    that:
+      - result.host_acceptance_info is defined
+      - result.changed is false

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -1,3 +1,2 @@
 plugins/modules/vmware_deploy_ovf.py replace-urlopen!skip
 plugins/modules/vmware_deploy_ovf.py use-argspec-type-path!skip
-plugins/modules/vmware_host_acceptance.py validate-modules:parameter-state-invalid-choice

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -1,3 +1,2 @@
 plugins/modules/vmware_deploy_ovf.py replace-urlopen!skip
 plugins/modules/vmware_deploy_ovf.py use-argspec-type-path!skip
-plugins/modules/vmware_host_acceptance.py validate-modules:parameter-state-invalid-choice


### PR DESCRIPTION
##### SUMMARY
Fixes #1872

Removing `acceptance_level` and move its options to `state` so that

```
acceptance_level: 'community'
state: present
```

will become

```
state: 'community'
```

This also means there won't be a state `list` anymore. In order to get information about the current acceptance level, I will introduce a new module `vmware_host_acceptance_info`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_host_acceptance
vmware_host_acceptance_info

##### ADDITIONAL INFORMATION