### PR TITLE
vmware_deploy_ovf: Add new parameter enable_hidden_properties

### DIFF
--- a/changelogs/fragments/802-vmware_deploy_ovf.yml
+++ b/changelogs/fragments/802-vmware_deploy_ovf.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - vmware_deploy_ovf - New parameter enable_hidden_properties to force OVF properties marked as ovf:userConfigurable=false to become user configurable
+    (https://github.com/ansible-collections/community.vmware/issues/802).

--- a/plugins/modules/vmware_deploy_ovf.py
+++ b/plugins/modules/vmware_deploy_ovf.py
@@ -70,6 +70,12 @@ options:
         description:
         - Disk provisioning type.
         type: str
+    enable_hidden_properties:
+        description:
+        - Enable source properties that are marked as ovf:userConfigurable=false
+        default: false
+        version_added: '3.11.0'
+        type: bool
     fail_on_spec_warnings:
         description:
         - Cause the module to treat OVF Import Spec warnings as errors.
@@ -596,6 +602,10 @@ class VMwareDeployOvf(PyVmomi):
             spec_params
         )
 
+        if self.params['enable_hidden_properties']:
+            for prop in self.import_spec.importSpec.configSpec.vAppConfig.property:
+                prop.info.userConfigurable = True
+
         errors = [to_native(e.msg) for e in getattr(self.import_spec, 'error', [])]
         if self.params['fail_on_spec_warnings']:
             errors.extend(
@@ -859,6 +869,10 @@ def main():
                 'monolithicFlat'
             ],
             'default': 'thin',
+        },
+        'enable_hidden_properties': {
+            'default': False,
+            'type': 'bool',
         },
         'power_on': {
             'type': 'bool',


### PR DESCRIPTION
##### SUMMARY
This forces OVF properties marked as ovf:userConfigurable=false to become user configurable.

This is useful when deploying VCSA OVAs.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_deploy_ovf

##### ADDITIONAL INFORMATION
Backport #1838