### PR TITLE
Remove version_added: 2.x

### DIFF
--- a/plugins/modules/vmware_cluster_info.py
+++ b/plugins/modules/vmware_cluster_info.py
@@ -112,7 +112,6 @@ RETURN = r'''
 clusters:
     description:
       - metadata about the available clusters
-      - datacenter added in the return values from version 1.6.0
     returned: always
     type: dict
     sample: {

--- a/plugins/modules/vmware_dvs_portgroup.py
+++ b/plugins/modules/vmware_dvs_portgroup.py
@@ -259,7 +259,6 @@ options:
         - 'off'
         - 'no'
         - 'inherited'
-        version_added: '2.3.0'
     in_traffic_shaping:
         description:
             - Dictionary which configures the ingress traffic shaping settings for the portgroup.
@@ -290,7 +289,6 @@ options:
                 - Ignored if O(in_traffic_shaping.inherited=true).
         required: false
         type: dict
-        version_added: '2.3.0'
     out_traffic_shaping:
         description:
             - Dictionary which configures the egress traffic shaping settings for the portgroup.
@@ -322,7 +320,6 @@ options:
                 - Ignored if O(out_traffic_shaping.inherited=true).
         required: false
         type: dict
-        version_added: '2.3.0'
 extends_documentation_fragment:
 - community.vmware.vmware.documentation
 

--- a/plugins/modules/vmware_dvswitch.py
+++ b/plugins/modules/vmware_dvswitch.py
@@ -181,7 +181,6 @@ options:
         required: false
         type: str
     net_flow:
-        version_added: '2.7.0'
         description:
             - Dictionary which configures the Net Flow for the Distributed Switch.
         suboptions:

--- a/plugins/modules/vmware_export_ovf.py
+++ b/plugins/modules/vmware_export_ovf.py
@@ -74,7 +74,6 @@ options:
     default: false
     description:
     - All extra configuration options are exported for a virtual machine.
-    version_added: '2.0.0'
   download_timeout:
     description:
     - The user defined timeout in second of exporting file.

--- a/plugins/modules/vmware_guest_instant_clone.py
+++ b/plugins/modules/vmware_guest_instant_clone.py
@@ -254,7 +254,6 @@ RETURN = r'''
 vm_info:
     description:
       - metadata about the virtual machine
-      - added instance_uuid from version 1.12.0
     returned: always
     type: dict
     sample: {

--- a/plugins/modules/vmware_guest_vgpu.py
+++ b/plugins/modules/vmware_guest_vgpu.py
@@ -91,7 +91,6 @@ options:
      type: str
 extends_documentation_fragment:
 - community.vmware.vmware.documentation
-version_added: '2.5.0'
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/vmware_host_iscsi_info.py
+++ b/plugins/modules/vmware_host_iscsi_info.py
@@ -100,7 +100,6 @@ iscsi_properties:
 detected_iscsi_drives:
   description:
     - list of detected iSCSI drive
-    - added from version 1.9.0
   returned: always
   type: list
   sample: >-

--- a/plugins/modules/vmware_host_user_manager.py
+++ b/plugins/modules/vmware_host_user_manager.py
@@ -15,7 +15,6 @@ author:
   - sky-joker (@sky-joker)
 description:
   - This module can add, update or delete local users on ESXi host.
-version_added: '2.1.0'
 options:
   esxi_hostname:
     description:

--- a/plugins/modules/vmware_migrate_vmk.py
+++ b/plugins/modules/vmware_migrate_vmk.py
@@ -50,7 +50,6 @@ options:
         required: true
         type: str
     migrate_vlan_id:
-        version_added: '2.4.0'
         description:
             - VLAN to use for the VMK interface when migrating from VDS to VSS
             - Will be ignored when migrating from VSS to VDS

--- a/plugins/modules/vmware_object_role_permission.py
+++ b/plugins/modules/vmware_object_role_permission.py
@@ -26,7 +26,7 @@ options:
   role:
     description:
     - The role to be assigned permission.
-    - User can also specify role name presented in Web UI. Supported added in 1.5.0.
+    - User can also specify role name presented in Web UI.
     required: true
     type: str
   principal:

--- a/plugins/modules/vmware_tag_manager.py
+++ b/plugins/modules/vmware_tag_manager.py
@@ -29,7 +29,7 @@ options:
       - List of tag(s) to be managed.
       - User can also specify category name by specifying colon separated value. For example, "category_name:tag_name".
       - User can also specify tag and category as dict, when tag or category contains colon.
-        See example for more information. Added in version 2.10.
+        See example for more information.
       - User can skip category name if you have unique tag names.
       required: true
       type: list

--- a/plugins/modules/vmware_vm_info.py
+++ b/plugins/modules/vmware_vm_info.py
@@ -17,7 +17,6 @@ module: vmware_vm_info
 short_description: Return basic info pertaining to a VMware machine guest
 description:
 - Return basic information pertaining to a vSphere or ESXi virtual machine guest.
-- Cluster name as fact is added in version 2.7.
 author:
 - Joseph Callen (@jcpowermac)
 - Abhijeet Kasurde (@Akasurde)
@@ -105,7 +104,6 @@ options:
       default: false
       type: bool
     show_allocated:
-      version_added: '2.5.0'
       description:
         - Allocated storage in byte and memory in MB are shown if it set to True.
       default: false

--- a/plugins/modules/vmware_vmotion.py
+++ b/plugins/modules/vmware_vmotion.py
@@ -51,13 +51,11 @@ options:
       aliases: ['destination']
       type: str
     destination_cluster:
-      version_added: '2.5.0'
       description:
       - Name of the destination cluster the virtual machine should be running on.
       - Only works if drs is enabled for this cluster.
       type: str
     destination_datastore_cluster:
-      version_added: '2.5.0'
       description:
       - Name of the destination datastore cluster (storage pod) the virtual machine's vmdk should be moved on.
       - Only works if drs is enabled for the cluster the vm is running / should run.

--- a/plugins/modules/vmware_vswitch.py
+++ b/plugins/modules/vmware_vswitch.py
@@ -62,7 +62,6 @@ options:
       portgroup such as promiscuous mode, where guest adapter listens
       to all the packets, MAC address changes and forged transmits.
     - Dict which configures the different security values for portgroup.
-    version_added: '2.4.0'
     suboptions:
       promiscuous_mode:
         type: bool
@@ -79,7 +78,6 @@ options:
   teaming:
     description:
       - Dictionary which configures the different teaming values for portgroup.
-    version_added: '2.4.0'
     suboptions:
       load_balancing:
         type: str
@@ -115,7 +113,6 @@ options:
   traffic_shaping:
     description:
       - Dictionary which configures traffic shaping for the switch.
-    version_added: '2.4.0'
     suboptions:
       enabled:
         type: bool

--- a/plugins/modules/vmware_vswitch_info.py
+++ b/plugins/modules/vmware_vswitch_info.py
@@ -22,7 +22,6 @@ author:
 - Abhijeet Kasurde (@Akasurde)
 options:
   policies:
-    version_added: '2.4.0'
     description:
     - Gather information about Security, Traffic Shaping, as well as Teaming and failover.
     - The property C(ts) stands for Traffic Shaping and C(lb) for Load Balancing.


### PR DESCRIPTION
##### SUMMARY
Now that version 2 is nearly EOL, I don't think that it's important if something has been added in 2.2, 2.4, 2.7 or wherever.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
vmware_cluster_info
vmware_dvs_portgroup
vmware_dvswitch.py
vmware_export_ovf
vmware_guest_instant_clone
vmware_guest_vgpu
vmware_host_iscsi_info
vmware_host_user_manager
vmware_migrate_vmk
vmware_object_role_permission
vmware_tag_manager
vmware_vm_info
vmware_vmotion
vmware_vswitch
vmware_vswitch_info

##### ADDITIONAL INFORMATION
