### PR TITLE
vmware_dvs_host: Defaults for vmnics and lag_uplinks

### DIFF
--- a/changelogs/fragments/1516-vmware_dvs_host.yml
+++ b/changelogs/fragments/1516-vmware_dvs_host.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+  - vmware_dvs_host - removed defaults for `vmnics` and `lag_uplinks` (https://github.com/ansible-collections/community.vmware/issues/1516).

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,8 @@ commands =
   antsibull-changelog lint
   {toxinidir}/tools/check-ignores-order
   yamllint -c .yamllint.yaml tests
+allowlist_externals =
+  {toxinidir}/tools/check-ignores-order
 
 [testenv:add_docs]
 deps = git+https://github.com/ansible-network/collection_prep


### PR DESCRIPTION
Fixes: #1516

##### SUMMARY
Remove defaults for `vmnics` and `lag_uplinks`.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_dvs_host

##### ADDITIONAL INFORMATION
