### PR TITLE
stable-3.x: Fix ansible-tox-linters

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,8 @@ commands =
   antsibull-changelog lint
   {toxinidir}/tools/check-ignores-order
   yamllint -c .yamllint.yaml tests
+allowlist_externals =
+  {toxinidir}/tools/check-ignores-order
 
 [testenv:add_docs]
 deps = git+https://github.com/ansible-network/collection_prep


### PR DESCRIPTION
##### SUMMARY
Fix ansible-tox-linters.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tox.ini

##### ADDITIONAL INFORMATION
#1904
#1906