### PR TITLE
vmware_vm_info: Fix AttributeError

### DIFF
--- a/changelogs/fragments/1919-vmware_vm_info.yml
+++ b/changelogs/fragments/1919-vmware_vm_info.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_vm_info - Fix an AttributeError when gathering network information (https://github.com/ansible-collections/community.vmware/pull/1919).

--- a/plugins/modules/vmware_vm_info.py
+++ b/plugins/modules/vmware_vm_info.py
@@ -352,11 +352,12 @@ class VmwareVmInfo(PyVmomi):
                         net_dict[device.macAddress] = dict()
                         net_dict[device.macAddress]['ipv4'] = []
                         net_dict[device.macAddress]['ipv6'] = []
-                        for ip_addr in device.ipConfig.ipAddress:
-                            if "::" in ip_addr.ipAddress:
-                                net_dict[device.macAddress]['ipv6'].append(ip_addr.ipAddress + "/" + str(ip_addr.prefixLength))
-                            else:
-                                net_dict[device.macAddress]['ipv4'].append(ip_addr.ipAddress + "/" + str(ip_addr.prefixLength))
+                        if device.ipConfig is not None:
+                            for ip_addr in device.ipConfig.ipAddress:
+                                if "::" in ip_addr.ipAddress:
+                                    net_dict[device.macAddress]['ipv6'].append(ip_addr.ipAddress + "/" + str(ip_addr.prefixLength))
+                                else:
+                                    net_dict[device.macAddress]['ipv4'].append(ip_addr.ipAddress + "/" + str(ip_addr.prefixLength))
 
             esxi_hostname = None
             esxi_parent = None


### PR DESCRIPTION
##### SUMMARY
According to the documentation `ipConfig` in [GuestNicInfo(vim.vm.GuestInfo.NicInfo)](https://vdc-repo.vmware.com/vmwb-repository/dcr-public/c476b64b-c93c-4b21-9d76-be14da0148f9/04ca12ad-59b9-4e1c-8232-fd3d4276e52c/SDK/vsphere-ws/docs/ReferenceGuide/vim.vm.GuestInfo.NicInfo.html) might be unset. This can lead to an `AttributeError: 'NoneType' object has no attribute 'ipAddress'`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
I wasn't really able to reproduce this with:

- powered off VM
- powered on VM without VMware Tools installed
- powered on VM without VMware Tools installed and running
- powered on VM without VMware Tools installed and running, not all NICs configured

But it looks like [some users](https://github.com/ansible-collections/community.vmware/pull/1871#issuecomment-1807252637) run into this issue.