### PR TITLE
Fix integration tests: include -> include_tasks

### DIFF
--- a/tests/integration/targets/vmware_category/tasks/main.yml
+++ b/tests/integration/targets/vmware_category/tasks/main.yml
@@ -4,4 +4,4 @@
 
 - import_role:
     name: prepare_vmware_tests
-- include: associable_obj_types.yml
+- include_tasks: associable_obj_types.yml

--- a/tests/integration/targets/vmware_host_auto_start/tasks/main.yml
+++ b/tests/integration/targets/vmware_host_auto_start/tasks/main.yml
@@ -50,8 +50,8 @@
       with_items: ['test_vm1', 'test_vm2']
 
     - include_tasks: reset_auto_start_config.yml
-    - include: vcenter_auto_start_ops.yml
+    - include_tasks: vcenter_auto_start_ops.yml
     - include_tasks: reset_auto_start_config.yml
-    - include: esxi_auto_start_ops.yml
+    - include_tasks: esxi_auto_start_ops.yml
   always:
     - include_tasks: reset_auto_start_config.yml

--- a/tests/integration/targets/vmware_object_rename/tasks/main.yml
+++ b/tests/integration/targets/vmware_object_rename/tasks/main.yml
@@ -2,4 +2,4 @@
 # Copyright: (c) 2019, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- include: dc_rename.yml
+- include_tasks: dc_rename.yml

--- a/tests/integration/targets/vmware_tag/tasks/main.yml
+++ b/tests/integration/targets/vmware_tag/tasks/main.yml
@@ -2,6 +2,6 @@
 # Copyright: (c) 2019, Pavan Bidkar <pbidkar@vmware.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- include: tag_crud_ops.yml
-- include: tag_manager_ops.yml
-- include: tag_manager_duplicate_tag_cat.yml
+- include_tasks: tag_crud_ops.yml
+- include_tasks: tag_manager_ops.yml
+- include_tasks: tag_manager_duplicate_tag_cat.yml

--- a/tests/integration/targets/vmware_tag_info/tasks/main.yml
+++ b/tests/integration/targets/vmware_tag_info/tasks/main.yml
@@ -2,4 +2,4 @@
 # Copyright: (c) 2020, Abhijeet Kasurde <akasurde@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- include: tag_info.yml
+- include_tasks: tag_info.yml

--- a/tests/integration/targets/vmware_tag_manager/tasks/main.yml
+++ b/tests/integration/targets/vmware_tag_manager/tasks/main.yml
@@ -28,6 +28,6 @@
   - name: Set category one id
     set_fact: cat_one_id={{ category_one_create['category_results']['category_id'] }}
 
-  - include: tag_manager_dict.yml
+  - include_tasks: tag_manager_dict.yml
   always:
-  - include: cleanup.yml
+  - include_tasks: cleanup.yml

--- a/tests/sanity/ignore-2.17.txt
+++ b/tests/sanity/ignore-2.17.txt
@@ -1,0 +1,4 @@
+plugins/modules/vmware_deploy_ovf.py replace-urlopen!skip
+plugins/modules/vmware_deploy_ovf.py use-argspec-type-path!skip
+scripts/inventory/vmware_inventory.py pep8!skip
+tests/unit/mock/loader.py pep8!skip


### PR DESCRIPTION
##### SUMMARY
Use `include_tasks` instead of `include` in the integration tests.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_category
vmware_host_auto_start
vmware_object_rename
vmware_tag
vmware_tag_info
vmware_tag_manager

##### ADDITIONAL INFORMATION
#1921
