### PR TITLE
stable-3.x: Disable Codecov

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -20,6 +20,7 @@ on:
     branches:
       - main
       - stable-2.x
+      - stable-3.x
   pull_request:
   # Run CI once per day (at 07:12 UTC)
   # This ensures that even if there haven't been commits that we are still
@@ -96,6 +97,8 @@ jobs:
           # which should improve CI performance. See limitations on
           # https://github.com/ansible-community/ansible-test-gh-action#pull-request-change-detection
           pull-request-change-detection: false
+          # Disable Codecov
+          coverage: never
 
 ###
 # Unit tests (OPTIONAL)
@@ -150,6 +153,8 @@ jobs:
           # which should improve CI performance. See limitations on
           # https://github.com/ansible-community/ansible-test-gh-action#pull-request-change-detection
           pull-request-change-detection: false
+          # Disable Codecov
+          coverage: never
 
   check:  # This job does nothing and is only used for the branch protection
           # or multi-stage CI jobs, like making sure that all tests pass before


### PR DESCRIPTION
Disable Codecov for now. I don't think it provides valuable information to us, at least not at the moment.

Backport of #1920