### PR TITLE
Add switchIpAddress to vmware_dvswitch module

### DIFF
--- a/changelogs/fragments/1949-dvswitch_netflow_switch_ip.yml
+++ b/changelogs/fragments/1949-dvswitch_netflow_switch_ip.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_dvswitch - Add switchIpAddress/switch_ip parameter for netflow config

--- a/plugins/modules/vmware_dvswitch.py
+++ b/plugins/modules/vmware_dvswitch.py
@@ -719,7 +719,7 @@ class VMwareDvSwitch(PyVmomi):
                 changed = changed_internalFlowsOnly = True
                 internalFlowsOnly_previous = current_config.internalFlowsOnly
                 new_config.internalFlowsOnly = self.netFlow_internal_flows_only
-            if current_switchIpAddress != self.netFlow_switch_ip:
+            if self.netFlow_switch_ip is not None and current_switchIpAddress != self.netFlow_switch_ip:
                 changed = changed_switchIpAddress = True
                 switchIpAddress_previous = current_switchIpAddress
                 new_switchIpAddress = self.netFlow_switch_ip

--- a/plugins/modules/vmware_dvswitch.py
+++ b/plugins/modules/vmware_dvswitch.py
@@ -200,6 +200,7 @@ options:
                     - Assign an IP address to see the distributed switch as a single network device in the NetFlow collector.
                     - This is instead of as multiple devices corresponding to each host.
                     - In an IPv6 environment, the ESXi hosts ignore the switch IP address.
+                version_added: '4.3.0'
             active_flow_timeout:
                 type: int
                 description: The time, in seconds, to wait before sending information after the flow is initiated.


### PR DESCRIPTION
##### SUMMARY
This change makes it possible to change the `Switch IP address` parameter for the NetFlow config of a distributed vSwitch:
![image](https://github.com/ansible-collections/community.vmware/assets/42647570/80be328b-f9ae-4a4c-866b-faea7e36be64)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_dvswitch

##### ADDITIONAL INFORMATION
As this is a parameter which belongs to the NetFlow config, I added it under the conditional of the `netFlow_collector_ip`, if this unwanted I can of course pull it one layer out!
I'm not used to contributing to Modules so far, so please just point out every issue or improvement if needed, I will fix it 👍🏻

Tested with a self-built EE via navigator so far.
Thanks!