### PR TITLE
Fix InsecureRequestWarning

### DIFF
--- a/changelogs/fragments/1969-InsecureRequestWarning.yml
+++ b/changelogs/fragments/1969-InsecureRequestWarning.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - Fix InsecureRequestWarning for modules based on the VmwareRestClient module util when setting ``validate_certs`` to ``False``
+    (https://github.com/ansible-collections/community.vmware/pull/1969).


### PR DESCRIPTION
##### SUMMARY
It looks like we're sometimes running into an `InsecureRequestWarning`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/module_utils/vmware_rest_client.py

##### ADDITIONAL INFORMATION
[Vmware ssl certs (works in one module, not the other!)](https://forum.ansible.com/t/vmware-ssl-certs-works-in-one-module-not-the-other/3279)