### PR TITLE
Add subproperties option to vmware_vm_inventory

### DIFF
--- a/changelogs/fragments/1972-vm_inventory_subproperties.yml
+++ b/changelogs/fragments/1972-vm_inventory_subproperties.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_vm_inventory - Add parameter `subproperties` (https://github.com/ansible-collections/community.vmware/pull/1972).

--- a/plugins/inventory/vmware_vm_inventory.py
+++ b/plugins/inventory/vmware_vm_inventory.py
@@ -98,6 +98,7 @@ DOCUMENTATION = r'''
                        'customValue', 'summary.runtime.powerState', 'config.guestId',
                        ]
         subproperties:
+            version_added: 4.2.0
             description:
             - List of subproperties from an normal property.
             - These subproperties will also populated to the hostvars of the given VM.

--- a/plugins/inventory/vmware_vm_inventory.py
+++ b/plugins/inventory/vmware_vm_inventory.py
@@ -761,7 +761,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         strict = self.get_option('strict')
 
         vm_properties = self.get_option('properties')
-        vm_subproperties = {e['property']:e['subelements'] for e in self.get_option('subproperties')}
+        vm_subproperties = {e['property']: e['subelements'] for e in self.get_option('subproperties')}
         vm_properties.extend(vm_subproperties.keys())
 
         if not isinstance(vm_properties, list):
@@ -803,14 +803,14 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 if vm_obj_property.name in vm_subproperties:
                     for subproperty in vm_subproperties[vm_obj_property.name]:
                         subproperty_parts = subproperty.split('.')
-                        
+
                         value = vm_obj_property.val
                         for subproperty_part in subproperty_parts:
                             value = value.__getattribute__(subproperty_part)
-                        
+
                         subproperty_parsed = parse_vim_property(value)
-                        properties[vm_obj_property.name+"."+subproperty] = subproperty_parsed
-                else:   
+                        properties[vm_obj_property.name + "." + subproperty] = subproperty_parsed
+                else:
                     properties[vm_obj_property.name] = vm_obj_property.val
 
             if (properties.get('runtime.connectionState') or properties['runtime'].connectionState) in ('orphaned', 'inaccessible', 'disconnected'):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This Change adds an option 'subproperties' to the vmware_vm_inventory plugin.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_vm_inventory

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
# Gather subproperties such as the parent (mostly cluster) of an ESXi
plugin: community.vmware.vmware_vm_inventory
strict: false
hostname: 10.65.223.31
username: administrator@vsphere.local
password: Esxi@123$%
validate_certs: false
properties:
- 'name'
- 'guest.ipAddress'
- 'config.name'
- 'config.uuid'
subproperties:
- property: 'summary.runtime.host'
  subelements:
  - 'name'
  - 'parent.name'
```
