### PR TITLE
stable-3.x: Fix failure of vm reconfiguration with enabled virt_based_security

### DIFF
--- a/changelogs/fragments/1848-fix-vm-reconfiguration-with-enabled-vbs.yml
+++ b/changelogs/fragments/1848-fix-vm-reconfiguration-with-enabled-vbs.yml
@@ -1,3 +1,3 @@
-minor_changes:
+bugfixes:
   - vmware_guest - Fix failure of vm reconfiguration with enabled virt_based_security
     (https://github.com/ansible-collections/community.vmware/pull/1848).

--- a/changelogs/fragments/1848-fix-vm-reconfiguration-with-enabled-vbs.yml
+++ b/changelogs/fragments/1848-fix-vm-reconfiguration-with-enabled-vbs.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - vmware_guest - Fix failure of vm reconfiguration with enabled virt_based_security
+    (https://github.com/ansible-collections/community.vmware/pull/1848).

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -1719,7 +1719,7 @@ class PyVmomiHelper(PyVmomi):
 
         virt_based_security = self.params['hardware']['virt_based_security']
         if virt_based_security is not None:
-            if vm_obj is None or virt_based_security != self.configspec.flags.vbsEnabled:
+            if vm_obj is None or virt_based_security != vm_obj.config.flags.vbsEnabled:
                 self.change_detected = True
                 if self.configspec.flags is None:
                     self.configspec.flags = vim.vm.FlagInfo()


### PR DESCRIPTION
##### SUMMARY
VM reconfiguration is currently broken when `virt_based_security` is configured due to checking for `vbsEnabled` on the wrong object.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_guest

##### ADDITIONAL INFORMATION
Backport #1848