### PR TITLE
vmware_first_class_disk_info - Add a module to gather infos about first class disks

### DIFF
--- a/changelogs/fragments/1996 - vmware_first_class_disk_info.yml
+++ b/changelogs/fragments/1996 - vmware_first_class_disk_info.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - vmware_first_class_disk_info - Add a module to gather informations about first class disks.
+    (https://github.com/ansible-collections/community.vmware/pull/1996).
+    (https://github.com/ansible-collections/community.vmware/issues/1988).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -53,6 +53,7 @@ action_groups:
   - vmware_evc_mode
   - vmware_export_ovf
   - vmware_first_class_disk
+  - vmware_first_class_disk_info
   - vmware_folder_info
   - vmware_guest
   - vmware_guest_boot_info

--- a/plugins/module_utils/vmware.py
+++ b/plugins/module_utils/vmware.py
@@ -1898,11 +1898,10 @@ class PyVmomi(object):
             return None
         else:
             return disks
-
-
     #
     # Conversion to JSON
     #
+
 
     def _deepmerge(self, d, u):
         """

--- a/plugins/module_utils/vmware.py
+++ b/plugins/module_utils/vmware.py
@@ -1874,6 +1874,32 @@ class PyVmomi(object):
 
         return None
 
+    def find_first_class_disks(self, datastore_obj):
+        """
+        Get first-class disks managed object
+        Args:
+            datastore_obj: Managed object of datastore
+
+        Returns: First-class disks managed object if found else None
+
+        """
+
+        disks = []
+
+        if self.is_vcenter():
+            for id in self.content.vStorageObjectManager.ListVStorageObject(datastore_obj):
+                disks.append(self.content.vStorageObjectManager.RetrieveVStorageObject(id, datastore_obj))
+
+        else:
+            for id in self.content.vStorageObjectManager.HostListVStorageObject(datastore_obj):
+                disks.append(self.content.vStorageObjectManager.HostRetrieveVStorageObject(id, datastore_obj))
+
+        if disks == []:
+            return None
+        else:
+            return disks
+
+
     #
     # Conversion to JSON
     #

--- a/plugins/module_utils/vmware.py
+++ b/plugins/module_utils/vmware.py
@@ -1902,7 +1902,6 @@ class PyVmomi(object):
     # Conversion to JSON
     #
 
-
     def _deepmerge(self, d, u):
         """
         Deep merges u into d.

--- a/plugins/modules/vmware_first_class_disk_info.py
+++ b/plugins/modules/vmware_first_class_disk_info.py
@@ -76,8 +76,7 @@ first_class_disks:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, vmware_argument_spec, wait_for_task
-
+from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, vmware_argument_spec
 
 class FirstClassDiskInfo(PyVmomi):
     def __init__(self, module):

--- a/plugins/modules/vmware_first_class_disk_info.py
+++ b/plugins/modules/vmware_first_class_disk_info.py
@@ -53,7 +53,7 @@ EXAMPLES = r'''
     datastore_name: '{{ datastore_name }}'
   register: disk_info
   delegate_to: localhost
-  
+
 - debug:
     var: disk_info.first_class_disks
 '''
@@ -75,7 +75,7 @@ first_class_disks:
   ]
 '''
 
-import re
+
 try:
     from pyVmomi import vim, vmodl
 except ImportError:
@@ -107,7 +107,6 @@ class FirstClassDiskInfo(PyVmomi):
             self.disks = self.find_first_class_disks(self.datastore_obj)
             if self.disks == []:
                 self.module.fail_json(msg='Failed to find any disk first class disk.')
-
 
         disk_infos = list()
         for disk in self.disks:
@@ -145,3 +144,4 @@ def main():
 
 if __name__ == '__main__':
     main()
+

--- a/plugins/modules/vmware_first_class_disk_info.py
+++ b/plugins/modules/vmware_first_class_disk_info.py
@@ -78,6 +78,7 @@ first_class_disks:
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, vmware_argument_spec, wait_for_task
 
+
 class FirstClassDiskInfo(PyVmomi):
     def __init__(self, module):
         super(FirstClassDiskInfo, self).__init__(module)
@@ -135,6 +136,7 @@ def main():
     _first_class_disks = first_class_disk.gather_first_class_disk_info()
 
     module.exit_json(changed=False, first_class_disks=_first_class_disks)
+
 
 if __name__ == '__main__':
     main()

--- a/plugins/modules/vmware_first_class_disk_info.py
+++ b/plugins/modules/vmware_first_class_disk_info.py
@@ -75,18 +75,12 @@ first_class_disks:
   ]
 '''
 
-
-try:
-    from pyVmomi import vim, vmodl
-except ImportError:
-    pass
-
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, TaskError, vmware_argument_spec, wait_for_task
+from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, vmware_argument_spec, wait_for_task
 
 class FirstClassDiskInfo(PyVmomi):
     def __init__(self, module):
-        super(FirstClassDisk, self).__init__(module)
+        super(FirstClassDiskInfo, self).__init__(module)
         self.datacenter_name = self.params['datacenter_name']
         self.datastore_name = self.params['datastore_name']
         self.disk_name = self.params['disk_name']
@@ -144,4 +138,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-

--- a/plugins/modules/vmware_first_class_disk_info.py
+++ b/plugins/modules/vmware_first_class_disk_info.py
@@ -1,0 +1,147 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2024, Nina Loser <nina.loser@muenchen.de>
+# Copyright: (c) 2021, Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+DOCUMENTATION = r'''
+---
+module: vmware_first_class_disk_info
+short_description: Gather info about VMware vSphere First Class Disks
+description:
+    - This module can be used to gather information about VMware vSphere First Class Disks.
+author:
+- Nina Loser (@nina2244)
+options:
+    datacenter_name:
+      description: The name of the datacenter.
+      type: str
+    datastore_name:
+      description: Name of datastore or datastore cluster of the disk.
+      required: true
+      type: str
+    disk_name:
+      description: The name of the disk. If not set return all found.
+      type: str
+extends_documentation_fragment: vmware.documentation
+'''
+
+EXAMPLES = r'''
+- name: Gather info of 1GBDisk
+  community.vmware.vmware_first_class_disk:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    datastore_name: '{{ datastore_name }}'
+    disk_name: '1GBDisk'
+  register: disk_info
+  delegate_to: localhost
+
+- debug:
+    var: disk_info.first_class_disks
+
+- name: Gather info of all first class disks
+  community.vmware.vmware_first_class_disk:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    datastore_name: '{{ datastore_name }}'
+  register: disk_info
+  delegate_to: localhost
+  
+- debug:
+    var: disk_info.first_class_disks
+'''
+
+RETURN = r'''
+first_class_disks:
+  description: list of dictionary of First-class disk and their information
+  returned: success
+  type: list
+  sample: [
+    {
+      "name": "1GBDisk"
+      "datastore_name": "DS0"
+      "size_mb": "1024"
+      "consumption_type="disk",
+      "descriptor_version=0,
+      "consumer_ids: []
+    }
+  ]
+'''
+
+import re
+try:
+    from pyVmomi import vim, vmodl
+except ImportError:
+    pass
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, TaskError, vmware_argument_spec, wait_for_task
+
+class FirstClassDiskInfo(PyVmomi):
+    def __init__(self, module):
+        super(FirstClassDisk, self).__init__(module)
+        self.datacenter_name = self.params['datacenter_name']
+        self.datastore_name = self.params['datastore_name']
+        self.disk_name = self.params['disk_name']
+
+    def gather_first_class_disk_info(self):
+        self.datastore_obj = self.find_datastore_by_name(datastore_name=self.datastore_name, datacenter_name=self.datacenter_name)
+        if not self.datastore_obj:
+            self.module.fail_json(msg='Failed to find datastore %s.' % self.datastore_name)
+
+        if self.disk_name:
+            self.disk_obj = self.find_first_class_disk_by_name(self.disk_name, self.datastore_obj)
+            if not self.disk_obj:
+                self.module.fail_json(msg='Failed to find disk %s.' % self.disk_name)
+
+            self.disks = [self.disk_obj]
+
+        else:
+            self.disks = self.find_first_class_disks(self.datastore_obj)
+            if self.disks == []:
+                self.module.fail_json(msg='Failed to find any disk first class disk.')
+
+
+        disk_infos = list()
+        for disk in self.disks:
+            disk_info = dict(
+                name=disk.config.name,
+                datastore_name=disk.config.backing.datastore.name,
+                size_mb=disk.config.capacityInMB,
+                consumption_type=disk.config.consumptionType,
+                descriptor_version=disk.config.descriptorVersion,
+                consumer_ids=list(id.id for id in disk.consumerId)
+            )
+            disk_infos.append(disk_info)
+
+        return disk_infos
+
+
+def main():
+    argument_spec = vmware_argument_spec()
+    argument_spec.update(
+        dict(
+            datacenter_name=dict(type='str'),
+            datastore_name=dict(required=True, type='str'),
+            disk_name=dict(type='str')
+        )
+    )
+
+    module = AnsibleModule(argument_spec=argument_spec,
+                           supports_check_mode=True)
+
+    first_class_disk = FirstClassDiskInfo(module)
+
+    _first_class_disks = first_class_disk.gather_first_class_disk_info()
+
+    module.exit_json(changed=False, first_class_disks=_first_class_disks)
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/vmware_first_class_disk_info.py
+++ b/plugins/modules/vmware_first_class_disk_info.py
@@ -107,6 +107,7 @@ class FirstClassDiskInfo(PyVmomi):
         for disk in self.disks:
             disk_info = dict(
                 name=disk.config.name,
+                id=disk.config.id.id,
                 datastore_name=disk.config.backing.datastore.name,
                 size_mb=disk.config.capacityInMB,
                 consumption_type=disk.config.consumptionType,

--- a/plugins/modules/vmware_first_class_disk_info.py
+++ b/plugins/modules/vmware_first_class_disk_info.py
@@ -78,6 +78,7 @@ first_class_disks:
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, vmware_argument_spec
 
+
 class FirstClassDiskInfo(PyVmomi):
     def __init__(self, module):
         super(FirstClassDiskInfo, self).__init__(module)

--- a/plugins/modules/vmware_first_class_disk_info.py
+++ b/plugins/modules/vmware_first_class_disk_info.py
@@ -33,7 +33,7 @@ extends_documentation_fragment: vmware.documentation
 
 EXAMPLES = r'''
 - name: Gather info of 1GBDisk
-  community.vmware.vmware_first_class_disk:
+  community.vmware.vmware_first_class_disk_info:
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
@@ -46,7 +46,7 @@ EXAMPLES = r'''
     var: disk_info.first_class_disks
 
 - name: Gather info of all first class disks
-  community.vmware.vmware_first_class_disk:
+  community.vmware.vmware_first_class_disk_info:
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
@@ -100,7 +100,7 @@ class FirstClassDiskInfo(PyVmomi):
 
         else:
             self.disks = self.find_first_class_disks(self.datastore_obj)
-            if self.disks == []:
+            if not self.disks:
                 self.module.fail_json(msg='Failed to find any disk first class disk.')
 
         disk_infos = list()
@@ -111,7 +111,7 @@ class FirstClassDiskInfo(PyVmomi):
                 size_mb=disk.config.capacityInMB,
                 consumption_type=disk.config.consumptionType,
                 descriptor_version=disk.config.descriptorVersion,
-                consumer_ids=list(id.id for id in disk.consumerId)
+                consumer_ids=list(id.id for id in disk.config.consumerId)
             )
             disk_infos.append(disk_info)
 

--- a/plugins/modules/vmware_first_class_disk_info.py
+++ b/plugins/modules/vmware_first_class_disk_info.py
@@ -101,7 +101,7 @@ class FirstClassDiskInfo(PyVmomi):
         else:
             self.disks = self.find_first_class_disks(self.datastore_obj)
             if not self.disks:
-                self.module.fail_json(msg='Failed to find any disk first class disk.')
+                return []
 
         disk_infos = list()
         for disk in self.disks:

--- a/plugins/modules/vmware_first_class_disk_info.py
+++ b/plugins/modules/vmware_first_class_disk_info.py
@@ -68,9 +68,9 @@ first_class_disks:
       "name": "1GBDisk",
       "datastore_name": "DS0",
       "size_mb": "1024",
-      "consumption_type="disk",
-      "descriptor_version=0,
-      "consumer_ids: []
+      "consumption_type": "disk",
+      "descriptor_version": 0,
+      "consumer_ids": []
     }
   ]
 '''

--- a/plugins/modules/vmware_first_class_disk_info.py
+++ b/plugins/modules/vmware_first_class_disk_info.py
@@ -65,9 +65,9 @@ first_class_disks:
   type: list
   sample: [
     {
-      "name": "1GBDisk"
-      "datastore_name": "DS0"
-      "size_mb": "1024"
+      "name": "1GBDisk",
+      "datastore_name": "DS0",
+      "size_mb": "1024",
       "consumption_type="disk",
       "descriptor_version=0,
       "consumer_ids: []

--- a/tests/integration/targets/vmware_first_class_disk_info/aliases
+++ b/tests/integration/targets/vmware_first_class_disk_info/aliases
@@ -1,0 +1,3 @@
+cloud/vcenter
+needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_first_class_disk_info/tasks/main.yml
+++ b/tests/integration/targets/vmware_first_class_disk_info/tasks/main.yml
@@ -90,7 +90,7 @@
       - "(disk_info['first_class_disks'] | length) == 1"
       - "disk_info['first_class_disks'][0]['name'] == 'firstclassdisk'"
       - "disk_info['first_class_disks'][0]['datastore_name'] == rw_datastore"
-      - "disk_info['first_class_disks'][0]['size_mb'] == '1024'"
+      - "disk_info['first_class_disks'][0]['size_mb'] == 1024"
       - "disk_info['first_class_disks'][0]['consumption_type'] is defined"
       - "disk_info['first_class_disks'][0]['descriptor_version'] is defined"
       - "disk_info['first_class_disks'][0]['consumer_ids'] is defined"

--- a/tests/integration/targets/vmware_first_class_disk_info/tasks/main.yml
+++ b/tests/integration/targets/vmware_first_class_disk_info/tasks/main.yml
@@ -41,9 +41,6 @@
     <<: *disk_info
   register: disk_info
 
-- debug:
-    var: result_create_vcenter
-
 - name: assert for first-class disk info
   assert:
     that:
@@ -71,9 +68,6 @@
     <<: *disk_info
   register: disk_info
 
-- debug:
-    var: result_create_vcenter
-
 - name: assert for first-class disk info
   assert:
     that:
@@ -89,9 +83,6 @@
     validate_certs: false
   register: disk_info
   delegate_to: localhost
-
-- debug:
-    var: result_create_vcenter
 
 - name: assert for first-class disk info
   assert:

--- a/tests/integration/targets/vmware_first_class_disk_info/tasks/main.yml
+++ b/tests/integration/targets/vmware_first_class_disk_info/tasks/main.yml
@@ -47,7 +47,7 @@
       - "(disk_info['first_class_disks'] | length) == 1"
       - "disk_info['first_class_disks'][0]['name'] == 'firstclassdisk'"
       - "disk_info['first_class_disks'][0]['datastore_name'] == rw_datastore"
-      - "disk_info['first_class_disks'][0]['size_mb'] == '1024'"
+      - "disk_info['first_class_disks'][0]['size_mb'] == 1024"
       - "disk_info['first_class_disks'][0]['consumption_type'] is defined"
       - "disk_info['first_class_disks'][0]['descriptor_version'] is defined"
       - "disk_info['first_class_disks'][0]['consumer_ids'] is defined"

--- a/tests/integration/targets/vmware_first_class_disk_info/tasks/main.yml
+++ b/tests/integration/targets/vmware_first_class_disk_info/tasks/main.yml
@@ -1,0 +1,103 @@
+# Test code for the vmware_first_class_disk_info module.
+# Copyright: (c) 2021, Mario Lenz <m@riolenz.de>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_attach_host: true
+    setup_datastore: true
+
+- name: Gather Info if no first-class disk exists
+  vmware_first_class_disk_info: &disk_info
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datastore_name: "{{ rw_datastore }}"
+  register: disk_info
+  delegate_to: localhost
+
+- debug:
+    var: disk_info
+
+- assert:
+    that:
+      - "disk_info['first_class_disks'] == []"
+
+- name: Create first-class disk through vCenter
+  vmware_first_class_disk:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    disk_name: "firstclassdisk"
+    size: 1GB
+    datastore_name: "{{ rw_datastore }}"
+    state: present
+    validate_certs: false
+
+- name: Gather Info of the generated first-class disk
+  vmware_first_class_disk_info:
+    <<: *disk_info
+  register: disk_info
+
+- debug:
+    var: result_create_vcenter
+
+- name: assert for first-class disk info
+  assert:
+    that:
+      - "(disk_info['first_class_disks'] | length) == 1"
+      - "disk_info['first_class_disks'][0]['name'] == 'firstclassdisk'"
+      - "disk_info['first_class_disks'][0]['datastore_name'] == rw_datastore"
+      - "disk_info['first_class_disks'][0]['size_mb'] == '1024'"
+      - "disk_info['first_class_disks'][0]['consumption_type'] is defined"
+      - "disk_info['first_class_disks'][0]['descriptor_version'] is defined"
+      - "disk_info['first_class_disks'][0]['consumer_ids'] is defined"
+
+- name: Create a second first-class disk through vCenter
+  vmware_first_class_disk:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    disk_name: "secondclassdisk"
+    size: 1GB
+    datastore_name: "{{ rw_datastore }}"
+    state: present
+    validate_certs: false
+
+- name: Gather Info of the two generated first-class disk
+  vmware_first_class_disk_info:
+    <<: *disk_info
+  register: disk_info
+
+- debug:
+    var: result_create_vcenter
+
+- name: assert for first-class disk info
+  assert:
+    that:
+      - "(disk_info['first_class_disks'] | length) == 2"
+
+- name: Gather Info of first-class disk 'firstclassdisk'
+  vmware_first_class_disk_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datastore_name: "{{ rw_datastore }}"
+    disk_name: "firstclassdisk"
+  register: disk_info
+  delegate_to: localhost
+
+- debug:
+    var: result_create_vcenter
+
+- name: assert for first-class disk info
+  assert:
+    that:
+      - "(disk_info['first_class_disks'] | length) == 1"
+      - "disk_info['first_class_disks'][0]['name'] == 'firstclassdisk'"
+      - "disk_info['first_class_disks'][0]['datastore_name'] == rw_datastore"
+      - "disk_info['first_class_disks'][0]['size_mb'] == '1024'"
+      - "disk_info['first_class_disks'][0]['consumption_type'] is defined"
+      - "disk_info['first_class_disks'][0]['descriptor_version'] is defined"
+      - "disk_info['first_class_disks'][0]['consumer_ids'] is defined"


### PR DESCRIPTION
##### SUMMARY
Add a module to gather infos about first class disks
Fixes #1988 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
vmware.py-> find_first_class_disks(self, datastore_obj)
vmware_first_class_disk_info.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
