### PR TITLE
vsphere_copy: make spelling of StreamVmdk consistent

### DIFF
--- a/plugins/modules/vsphere_copy.py
+++ b/plugins/modules/vsphere_copy.py
@@ -51,7 +51,7 @@ options:
       - Optional argument - Set a diskformat for certain uploads like stream optimized VMDKs
       - There is no official documentation, but it looks like V(StreamVmdk) needs to be set for stream optimized VMDKs that are uploaded to vSAN storage
       - Setting this for non-VMDK files might lead to undefined behavior and is not supported.
-    choices: ["streamVmdk"]
+    choices: ["StreamVmdk"]
     type: str
 
 notes:
@@ -149,7 +149,7 @@ def main():
         datastore=dict(required=True),
         path=dict(required=True, aliases=['dest'], type='str'),
         timeout=dict(default=10, type='int'),
-        diskformat=dict(required=False, type='str', choices=['streamVmdk']))
+        diskformat=dict(required=False, type='str', choices=['StreamVmdk']))
     )
 
     module = AnsibleModule(


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This is a follow up to #1995 
I overlooked the capitalization in some of the changes suggested by maintainers, this makes it consistent across all occurrences. 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
vsphere_copy

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
