### PR TITLE
stable-3.x: Fix Pylint errors in CI

### DIFF
--- a/changelogs/fragments/2024027-fix_ci.yml
+++ b/changelogs/fragments/2024027-fix_ci.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Use `isinstance()` instead of `type()` for a typecheck (https://github.com/ansible-collections/community.vmware/pull/2012).

--- a/plugins/module_utils/vmware.py
+++ b/plugins/module_utils/vmware.py
@@ -1088,11 +1088,11 @@ def option_diff(options, current_options, truthy_strings_as_bool=True):
     for option_key, option_value in options.items():
         if truthy_strings_as_bool and is_boolean(option_value):
             option_value = VmomiSupport.vmodlTypes['bool'](is_truthy(option_value))
-        elif type(option_value) is int:
+        elif isinstance(option_value, int):
             option_value = VmomiSupport.vmodlTypes['int'](option_value)
-        elif type(option_value) is float:
+        elif isinstance(option_value, float):
             option_value = VmomiSupport.vmodlTypes['float'](option_value)
-        elif type(option_value) is str:
+        elif isinstance(option_value, str):
             option_value = VmomiSupport.vmodlTypes['string'](option_value)
 
         if option_key not in current_options_dict or current_options_dict[option_key] != option_value:

--- a/scripts/inventory/vmware_inventory.py
+++ b/scripts/inventory/vmware_inventory.py
@@ -283,7 +283,7 @@ class VMWareInventory(object):
         self.maxlevel = int(config.get('vmware', 'max_object_level'))
         self.debugl('max object level is %s' % self.maxlevel)
         self.lowerkeys = config.get('vmware', 'lower_var_keys')
-        if type(self.lowerkeys) != bool:
+        if not isinstance(self.lowerkeys, bool):
             if str(self.lowerkeys).lower() in ['yes', 'true', '1']:
                 self.lowerkeys = True
             else:

--- a/tests/unit/mock/loader.py
+++ b/tests/unit/mock/loader.py
@@ -30,7 +30,7 @@ class DictDataLoader(DataLoader):
 
     def __init__(self, file_mapping=None):
         file_mapping = {} if file_mapping is None else file_mapping
-        assert type(file_mapping) == dict
+        assert isinstance(file_mapping, dict)
 
         super(DictDataLoader, self).__init__()
 


### PR DESCRIPTION
##### SUMMARY
Fix the following Pylint errors in the CI:

```
ERROR: plugins/module_utils/vmware.py:1091:13: unidiomatic-typecheck: Use isinstance() rather than type() for a typecheck.
ERROR: plugins/module_utils/vmware.py:1093:13: unidiomatic-typecheck: Use isinstance() rather than type() for a typecheck.
ERROR: plugins/module_utils/vmware.py:1095:13: unidiomatic-typecheck: Use isinstance() rather than type() for a typecheck.
ERROR: scripts/inventory/vmware_inventory.py:286:11: unidiomatic-typecheck: Use isinstance() rather than type() for a typecheck.
ERROR: tests/unit/mock/loader.py:33:15: unidiomatic-typecheck: Use isinstance() rather than type() for a typecheck.
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/module_utils/vmware.py
scripts/inventory/vmware_inventory.py
tests/unit/mock/loader.py

##### ADDITIONAL INFORMATION
#2011