### PR TITLE
vmware_vm_shell - improve doc ( folder var description )

### DIFF
--- a/plugins/modules/vmware_vm_shell.py
+++ b/plugins/modules/vmware_vm_shell.py
@@ -47,6 +47,7 @@ options:
       - '   folder: /folder1/datacenter1/vm'
       - '   folder: folder1/datacenter1/vm'
       - '   folder: /folder1/datacenter1/vm/folder2'
+      - The 'vm_id_type' variable is required to be set to 'inventory_path', otherwise 'folder' will be None
       type: str
     vm_id:
       description:

--- a/plugins/modules/vmware_vm_shell.py
+++ b/plugins/modules/vmware_vm_shell.py
@@ -47,7 +47,7 @@ options:
       - '   folder: /folder1/datacenter1/vm'
       - '   folder: folder1/datacenter1/vm'
       - '   folder: /folder1/datacenter1/vm/folder2'
-      - The 'vm_id_type' variable is required to be set to 'inventory_path', otherwise 'folder' will be None
+      - Required if O(vm_id_type=inventory_path)
       type: str
     vm_id:
       description:


### PR DESCRIPTION
##### SUMMARY
Doc improve. Add important description to folder var info
The 'vm_id_type' variable is required to be set to 'inventory_path', otherwise folder will be None

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
vmware_vm_shell_module

##### ADDITIONAL INFORMATION
The documentation is not clear enough. It is not clear in the vmware_vm_shell_module that with the default vm_id_type value, the folder value will be set to None and it will not work at all

```python
# vmware_vm_shell.py
        if module.params['vm_id_type'] == 'inventory_path':
            vm = find_vm_by_id(self.content,
                               vm_id=module.params['vm_id'],
                               vm_id_type="inventory_path",
                               folder=folder)
        else:
            vm = find_vm_by_id(self.content,
                               vm_id=module.params['vm_id'],
                               vm_id_type=module.params['vm_id_type'],
                               datacenter=datacenter,
                               cluster=cluster)

# vmware.py
def find_vm_by_id(content, vm_id, vm_id_type="vm_name", datacenter=None,
                  cluster=None, folder=None, match_first=False):
```
