### PR TITLE
add new module vmware_all_snapshots_info.py

### DIFF
--- a/plugins/modules/vmware_all_snapshots_info.py
+++ b/plugins/modules/vmware_all_snapshots_info.py
@@ -1,0 +1,191 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, vmware_argument_spec,list_snapshots_recursively
+from pyVmomi import vim
+
+
+DOCUMENTATION = r'''
+---
+module: vmware_all_snapshots_info
+version_added: "1.0.0"
+short_description: Gathers information about all snapshots across virtual machines in a specified vmware datacenter
+description:
+  - This module collects detailed information of all the snapshots or the ones that the users decide using filtering
+  - It utilizes the PyVmomi library for communication with vCenter to retrieve snapshot data.
+author: Fernando Mendieta (@valkiriaaquatica)
+requirements:
+  - Python >= 2.7 (corresponding to the latest Ansible version's Python support)
+  - PyVmomi
+options:
+  datacenter:
+    description:
+      - The name of the datacenter to gather snapshot information from. You can get it in the vmware UI
+    required: true
+    type: str
+  filters:
+    description: >
+      Optional filters to apply to the snapshot data being gathered. You can apply one or more filters. 
+      Filters are applied based on the match_type specified. If match_type is "exact", filters require exact matches. 
+      On the other hand, when match_type is "includes", it retrieves the values that contain the specified value.
+      Available filter options include creation_time, description, folder, id, name, quiesced, state, vm_name. 
+      Multiple filters can be applied; the snapshot must meet all filter criteria to be included in the results.
+    required: false
+    type: dict
+    default: {}
+  match_type:
+    description: 
+      Indicates whether the filter match should be "exact" or "includes". An "exact" match requires the snapshot information to exactly match the filter value. "includes" will match any snapshot information that includes the filter value, allowing for partial matche
+      For example when you want to get all the snapshots that contain in their name the wordtest you place the filter name "test" and the match_type "includes"
+      For example when you want to get all snapshots that are in state poweredOn you skip the match_type (default is exact) or you write match_type "exact".
+    required: false
+    type: str
+    choices: ["exact", "includes"]
+    default: "exact"
+extends_documentation_fragment:
+  - community.vmware.vmware.documentation
+'''
+
+
+
+EXAMPLES = r'''
+---|
+  - name: Gather information about all snapshots in VMware vCenter
+    vmware_snapshot_info_all:
+      hostname: '{{ vcenter_hostname }}'
+      username: '{{ vcenter_username }}'
+      password: '{{ vcenter_password }}'
+      validate_certs: no 
+      datacenter: '{{ datacenter_name }}'
+    delegate_to: localhost
+    register: snapshots_data
+    
+  - name: Gather information of a snapshot with filters applied and match_type in exacts.
+    vmware_snapshot_info_all:
+      hostname: '{{ vcenter_hostname }}'
+      username: '{{ vcenter_username }}'
+      password: '{{ vcenter_password }}'
+      validate_certs: yes
+      datacenter: '{{ datacenter_name }}'
+      filters: 
+        state: "poweredOn"
+        vm_name: "you_marchine_name"
+    delegate_to: localhost
+    register: snapshots_data
+    
+  - name: Gather information of snapshots that in their name contain the "test" in their name.
+    vmware_snapshot_info_all:
+      hostname: '{{ vcenter_hostname }}'
+      username: '{{ vcenter_username }}'
+      password: '{{ vcenter_password }}'
+      validate_certs: yes
+      datacenter: '{{ datacenter_name }}'
+      match_type: "includes"
+      filters: 
+        name: "test"
+    delegate_to: localhost
+    register: snapshots_data
+'''
+
+RETURN = r'''
+vmware_all_snapshots_info:
+  description: A list of all snapshots information across all virtual machines in the specified datacenter
+  returned: always
+  type: list
+  elements: dict
+  contains:
+    vm_name:
+      description: The name of the virtual machine that appears in the iu.
+      type: str
+      returned: always
+    folder:
+      description: The folder path of the virtual machine in the datacenter, normally is vm
+      type: str
+      returned: always
+    name:
+      description: The name of the snapshot
+      type: str
+      returned: always
+    description:
+      description: The description of the snapshot.
+      type: str
+      returned: when it exists because depends if it has or not
+    creation_time:
+      description: The time the snapshot was created
+      type: str
+      returned: always
+    state:
+      description: The state of the virtual machine at the snapshot (powered on/off)
+      type: str
+      returned: always
+    id:
+      description: The unique identifier of the snapshot
+      type: int
+      returned: always
+    quiesced:
+      description: Indicates if the snapshot was created with the virtual machines file system quiesced
+      type: bool
+      returned: always
+'''
+class VMwareSnapshotInfo(PyVmomi):
+    def __init__(self, module):
+        super(VMwareSnapshotInfo, self).__init__(module)
+
+    def list_snapshots(self, vm):
+        return list_snapshots_recursively(vm.snapshot.rootSnapshotList) if vm.snapshot else []
+
+    def get_all_vms(self):
+        content = self.content
+        container = content.viewManager.CreateContainerView(content.rootFolder, [vim.VirtualMachine], True)
+        vms = container.view
+        container.Destroy()
+        return vms
+
+    def gather_snapshots_info(self, filters, match_type):
+        snapshot_data = []
+        for vm in self.get_all_vms():
+            for snapshot in self.list_snapshots(vm):
+                snapshot_info = {
+                    'vm_name': vm.name,
+                    'folder': vm.parent.name,
+                    **snapshot
+                }
+                if self.passes_filters(snapshot_info, filters, match_type):
+                    snapshot_data.append(snapshot_info)
+        return snapshot_data
+
+    def passes_filters(self, snapshot_info, filters, match_type):
+        for key, value in filters.items():
+            if key not in snapshot_info:
+                continue
+            actual_value = str(snapshot_info[key]).lower()
+            desired_value = str(value).lower()
+
+            if match_type == 'exact' and actual_value != desired_value:
+                return False
+            elif match_type == 'includes' and desired_value not in actual_value:
+                return False
+        return True
+
+
+def main():
+    argument_spec = vmware_argument_spec()
+    argument_spec.update(
+        datacenter=dict(required=True, type='str'),
+        filters=dict(required=False, type='dict', default={}),
+        match_type=dict(required=False, type='str', choices=['exact', 'includes'], default='exact')
+    )
+
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+
+    vmware_snapshot_info = VMwareSnapshotInfo(module)
+    filters = module.params.get('filters')
+    match_type = module.params.get('match_type')
+    all_snapshots = vmware_snapshot_info.gather_snapshots_info(filters, match_type)
+
+    module.exit_json(changed=False, vmware_all_snapshots_info=all_snapshots)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
##### SUMMARY
The new module returns all snapshots in the datacenter with no need of indicating from where machine or folder they have to belong. It also lhas filters options that can be sctrict or included, based if the user wants to retrieve all snapshots that in their name contains the word "test" or all snapshots that their state is "poweredOn". There is no need to filter, if no filter is applied it just returns all snapshots.


##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
vmware_snapshot_info_all

##### ADDITIONAL INFORMATION
With the actual module community.vmware.vmware_guest_snapshot_info the user needs to write or if the uuid or the moid is not supplied, also no filters can be applied. With this module all snapshots of th vmware are returned by default and one or more filters can be aplpied.

Below to get all snapshtos of the datacenter and then filter

```
- name: Old approach to gather VM snapshots info of all snapshots
  hosts: localhost
  gather_facts: no
  tasks:
    - name: List all VMs in the datacenter
      community.vmware.vmware_vm_info:
        hostname: "{{ vcenter_hostname }}"
        username: "{{ vcenter_username }}"
        password: "{{ vcenter_password }}"
        validate_certs: yes
      delegate_to: localhost
      register: vm_list
      tags: 
        - old 
  
    - name: Gather snapshot info for each VM
      community.vmware.vmware_guest_snapshot_info:
        hostname: "{{ vcenter_hostname }}"
        username: "{{ vcenter_username }}"
        password: "{{ vcenter_password }}"
        validate_certs: yes
        name: "{{ item.guest_name }}"
        folder: "{{ folder }}"
        datacenter: "{{ datacenter_name }}"
      loop: "{{ vm_list.virtual_machines }}"
      delegate_to: localhost
      register: snapshot_info
      tags: 
        - old
  
    - name: Display snapshot info
      debug:
        msg: "{{ snapshot_info.results }}"
      tags: 
        - old 
     ##then here applied filter to get the snapshot you want
```

New Approach

```
- name: New approach to directly gather VM snapshots info using filters
  hosts: localhost
  gather_facts: no
  tasks:
    - name: Gather snapshot info directly using VM MOID
      community.vmware.vmware_all_snapshots_info:
        hostname: "{{ vcenter_hostname }}"
        username: "{{ vcenter_username }}"
        password: "{{ vcenter_password }}"
        validate_certs: yes
        #here you can place filters
      delegate_to: localhost
      register: snapshot_info

    - name: Display snapshot info
      debug:
        msg: "{{ snapshot_info }}"

```