### PR TITLE
vmware_guest_tools_info: Use toolsVersionStatus2

### DIFF
--- a/changelogs/fragments/2033-vmware_guest_tools_info.yml
+++ b/changelogs/fragments/2033-vmware_guest_tools_info.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_guest_tools_info - Use `toolsVersionStatus2` instead of `toolsVersionStatus` (https://github.com/ansible-collections/community.vmware/issues/2033).

--- a/changelogs/fragments/2033-vmware_guest_tools_info.yml
+++ b/changelogs/fragments/2033-vmware_guest_tools_info.yml
@@ -1,2 +1,6 @@
 minor_changes:
   - vmware_guest_tools_info - Use `toolsVersionStatus2` instead of `toolsVersionStatus` (https://github.com/ansible-collections/community.vmware/issues/2033).
+deprecated_features:
+  - vmware_guest_tools_info - `vm_tools_install_status` will be removed from next major version (5.0.0) of the collection
+    since the API call that provides this information has been deprecated by VMware.
+    Use `vm_tools_running_status` / `vm_tools_version_status` instead (https://github.com/ansible-collections/community.vmware/issues/2033).

--- a/plugins/modules/vmware_guest_tools_info.py
+++ b/plugins/modules/vmware_guest_tools_info.py
@@ -150,6 +150,11 @@ class PyVmomiHelper(PyVmomi):
             vm_tools_last_install_count=self.current_vm_obj.config.tools.lastInstallInfo.counter,
         )
 
+        self.module.deprecate(
+            msg="The API providing vm_tools_install_status has been deprecated by VMware; use vm_tools_running_status / vm_tools_version_status instead",
+            version="5.0.0",
+            collection_name="community.vmware"
+        )
         return {'changed': False, 'failed': False, 'vmtools_info': vmtools_info}
 
 

--- a/plugins/modules/vmware_guest_tools_info.py
+++ b/plugins/modules/vmware_guest_tools_info.py
@@ -143,7 +143,7 @@ class PyVmomiHelper(PyVmomi):
             vm_ipaddress=self.current_vm_obj.summary.guest.ipAddress,
             vm_tools_running_status=self.current_vm_obj.summary.guest.toolsRunningStatus,
             vm_tools_install_status=self.current_vm_obj.summary.guest.toolsStatus,
-            vm_tools_version_status=self.current_vm_obj.summary.guest.toolsVersionStatus,
+            vm_tools_version_status=self.current_vm_obj.summary.guest.toolsVersionStatus2,
             vm_tools_install_type=self.current_vm_obj.config.tools.toolsInstallType,
             vm_tools_version=self.current_vm_obj.config.tools.toolsVersion,
             vm_tools_upgrade_policy=self.current_vm_obj.config.tools.toolsUpgradePolicy,


### PR DESCRIPTION
Fixes #2033 

##### SUMMARY
`toolsVersionStatus` is [deprecated](https://vdc-download.vmware.com/vmwb-repository/dcr-public/184bb3ba-6fa8-4574-a767-d0c96e2a38f4/ba9422ef-405c-47dd-8553-e11b619185b2/SDK/vsphere-ws/docs/ReferenceGuide/vim.vm.Summary.GuestSummary.html) and `toolsVersionStatus2` should be used.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_guest_tools_info

##### ADDITIONAL INFORMATION
I've just seen that `toolsStatus` is also deprecated. But removing it would be a breaking change... ~I'll mark this PR WIP until I know what to do about it.~
Let's deprecate `vm_tools_install_status` in favour of `vm_tools_running_status` / `vm_tools_version_status` as an alternative.