### PR TITLE
Missing an error message when guest_id is set while using template in…

### DIFF
--- a/changelogs/fragments/2036-missing_error_msg_in_vmware_guest.yml
+++ b/changelogs/fragments/2036-missing_error_msg_in_vmware_guest.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - vmware_guest - Fix a missing error message while setting a template parameter with inconsistency guest_os ID
+    (https://github.com/ansible-collections/community.vmware/pull/2036).

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -2962,6 +2962,14 @@ class PyVmomiHelper(PyVmomi):
             vm_obj = self.get_vm_or_template(template_name=self.params['template'])
             if vm_obj is None:
                 self.module.fail_json(msg="Could not find a template named %(template)s" % self.params)
+            if self.params['guest_id'] is not None and vm_obj.summary.config.guestId is not None and self.params['guest_id'] != vm_obj.summary.config.guestId:
+                details = {
+                    'vm_guest_id': self.params['guest_id'],
+                    'template_guest_id': vm_obj.summary.config.guestId,
+                }
+                self.module.fail_json(msg="Could not create vm from template with different guest_ids",
+                                      details=details)
+
         else:
             vm_obj = None
 


### PR DESCRIPTION
… vmware_guest module

##### SUMMARY
Fixes missing error message in when creating VM using vmware_guest module, with template, while setting the guest_id parameter. 


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
module vmware_guest

##### ADDITIONAL INFORMATION
```
---
- name: Run the first VM creation on vmware
  hosts: localhost
  gather_facts: true

  tasks:
  - name: Provision VM
    community.vmware.vmware_guest:
      hostname: "..."
      username: "..."
      password: "..."
      validate_certs: false

      cluster: "..."
      folder: "..."
      datacenter: "..."
      name: "vm-test-2"
      disk:
        - size_gb: 16
          type: thin
          datastore: "..."
      hardware:
        memory_mb: 512
        num_cpus: 4
      guest_id: "centos64Guest"
      template: "dbarda"
```