### PR TITLE
Support regexp for datastore autoselect

### DIFF
--- a/changelogs/fragments/regexp-for-autoselect-datastore.yml
+++ b/changelogs/fragments/regexp-for-autoselect-datastore.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Support for regular expression when using `autoselect_datastore: True`."

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -295,7 +295,7 @@ options:
             type: str
             description:
             - The name of datastore which will be used for the disk.
-            - If O(disk.autoselect_datastore) is set to True, will select the less used datastore whose name contains this "disk.datastore" string.
+            - If O(disk.autoselect_datastore) is set to True, will select the less used datastore whose name matches this "disk.datastore" pattern.
         filename:
             type: str
             description:
@@ -2768,7 +2768,7 @@ class PyVmomiHelper(PyVmomi):
 
                     if (ds.summary.freeSpace > datastore_freespace) or (ds.summary.freeSpace == datastore_freespace and not datastore):
                         # If datastore field is provided, filter destination datastores
-                        if self.params['disk'][0]['datastore'] and ds.name.find(self.params['disk'][0]['datastore']) < 0:
+                        if self.params['disk'][0]['datastore'] and re.search(self.params['disk'][0]['datastore'], ds.name):
                             continue
 
                         datastore = ds


### PR DESCRIPTION
##### SUMMARY
When automatically selecting a datastore, use regular expression instead of a simple string search.

This will increase the utility of the autoselect feature to support use cases such as when the user wants to select

> datastores matching '\_MyTeam_' but without the prefix 'DoNotUse_'.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_guest

##### ADDITIONAL INFORMATION
This is backwards compatible for simple strings, and since there are limits on special characters allowed in datastore names I believe there shouldn't be any cases where users would need to adjust their input because of this change.
