### PR TITLE
stable-3.x: Missing error msg in vmware_guest

### DIFF
--- a/changelogs/fragments/2036-missing_error_msg_in_vmware_guest.yml
+++ b/changelogs/fragments/2036-missing_error_msg_in_vmware_guest.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - vmware_guest - Fix a missing error message while setting a template parameter with inconsistency guest_os ID
+    (https://github.com/ansible-collections/community.vmware/pull/2036).

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -2988,6 +2988,14 @@ class PyVmomiHelper(PyVmomi):
             vm_obj = self.get_vm_or_template(template_name=self.params['template'])
             if vm_obj is None:
                 self.module.fail_json(msg="Could not find a template named %(template)s" % self.params)
+            if self.params['guest_id'] is not None and vm_obj.summary.config.guestId is not None and self.params['guest_id'] != vm_obj.summary.config.guestId:
+                details = {
+                    'vm_guest_id': self.params['guest_id'],
+                    'template_guest_id': vm_obj.summary.config.guestId,
+                }
+                self.module.fail_json(msg="Could not create vm from template with different guest_ids",
+                                      details=details)
+
         else:
             vm_obj = None
 


### PR DESCRIPTION
##### SUMMARY
Fixes missing error message in when creating VM using vmware_guest module, with template, while setting the guest_id parameter.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_guest

##### ADDITIONAL INFORMATION
Backport of #2036