### PR TITLE
Fix update VM while adding a new disk

### DIFF
--- a/changelogs/fragments/2044-error_in_adding_disk_to_vm_in_vmware_guest.yml
+++ b/changelogs/fragments/2044-error_in_adding_disk_to_vm_in_vmware_guest.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - vmware_guest - Fix a error while updating the VM by adding a new disk. 
+    While adding a disk to an  existing VM, it leaves it in invalid state.
+    (https://github.com/ansible-collections/community.vmware/pull/2044).

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -2655,6 +2655,7 @@ class PyVmomiHelper(PyVmomi):
                 diskspec.device = disks[disk_index]
             else:
                 diskspec = self.device_helper.create_hard_disk(scsi_ctl, disk_index)
+                diskspec.operation = vim.vm.device.VirtualDeviceSpec.Operation.add
                 disk_modified = True
 
             # increment index for next disk search
@@ -2683,10 +2684,9 @@ class PyVmomiHelper(PyVmomi):
             if expected_disk_spec['filename']:
                 self.add_existing_vmdk(vm_obj, expected_disk_spec, diskspec, scsi_ctl)
                 continue
-            if vm_obj is None or self.params['template']:
-                # We are creating new VM or from Template
-                # Only create virtual device if not backed by vmdk in original template
-                if diskspec.device.backing.fileName == '':
+
+            # Only create virtual device if not backed by vmdk in original template
+            if diskspec.device.backing.fileName == '':
                     diskspec.fileOperation = vim.vm.device.VirtualDeviceSpec.FileOperation.create
 
             # which datastore?

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -2687,7 +2687,7 @@ class PyVmomiHelper(PyVmomi):
 
             # Only create virtual device if not backed by vmdk in original template
             if diskspec.device.backing.fileName == '':
-                    diskspec.fileOperation = vim.vm.device.VirtualDeviceSpec.FileOperation.create
+                diskspec.fileOperation = vim.vm.device.VirtualDeviceSpec.FileOperation.create
 
             # which datastore?
             if expected_disk_spec.get('datastore'):


### PR DESCRIPTION
##### SUMMARY
In update VM - while adding disk to existing VM leaves it in an invalid state

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_guest module

##### ADDITIONAL INFORMATION
While trying to add a disk to an existing VM (in poweredoff state) using the provision_vm role

```
---
    - name: Provision VM
      community.vmware.vmware_guest:
        hostname: "{{ vCenter_hostname }}"
        username: "{{ vCenter_username }}"
        password: "{{ vCenter_password }}"
        validate_certs: false
        cluster: ""
        folder: ""
        datacenter: ""
        name: "vm-test-2"
        cdrom:
          - controller_number: 0
            unit_number: 0
            state: present
            type: iso
            iso_path: "[datastore1] ISO/rhel-9.3-x86_64-dvd.iso"
        disk:
          - size_gb: 40
            type: thin
            datastore: "datastore1"
        hardware:
          memory_mb: 2000
          num_cpus: 4
          boot_firmware: efi
          secure_boot: true
        guest_id: "centos64Guest"


    - name: Add disk VM
      community.vmware.vmware_guest:
        hostname: "{{ vCenter_hostname }}"
        username: "{{ vCenter_username }}"
        password: "{{ vCenter_password }}"
        validate_certs: false
        cluster: ""
        folder: ""
        datacenter: ""
        name: "vm-test-2"
        cdrom:
          - controller_number: 0
            unit_number: 0
            state: present
            type: iso
            iso_path: "[datastore1] ISO/rhel-9.3-x86_64-dvd.iso"
        disk:
          - size_gb: 40
            type: thin
            datastore: "datastore1"
          - size_gb: 10
            type: thin
            datastore: "datastore1"
        hardware:
          memory_mb: 2000
          num_cpus: 4
          boot_firmware: efi
          secure_boot: true
        guest_id: "centos64Guest"
```


The outcome of that playbook was an error: Unable to access file [datastore1], and the new disk seems to be in size '0':
The output of vmware_guest_disk_info is:
```
    "guest_disk_info": {
        "0": {
            "backing_datastore": "datastore1",
            "backing_disk_mode": "persistent",
            "backing_diskmode": "persistent",
            "backing_eagerlyscrub": false,
            "backing_filename": "[datastore1] vm-test-2/vm-test-2.vmdk",
            "backing_sharing": "sharingNone",
            "backing_thinprovisioned": true,
            "backing_type": "FlatVer2",
            "backing_uuid": "6000C29c-fc88-0c34-edb2-bfd402fc5903",
            "backing_writethrough": false,
            "capacity_in_bytes": 42949672960,
            "capacity_in_kb": 41943040,
            "controller_bus_number": 0,
            "controller_key": 1000,
            "controller_type": "paravirtual",
            "iolimit_limit": -1,
            "iolimit_shares_level": "normal",
            "iolimit_shares_limit": 1000,
            "key": 2000,
            "label": "Hard disk 1",
            "shares_level": "normal",
            "shares_limit": 1000,
            "summary": "41,943,040 KB",
            "unit_number": 0
        },
        "1": {
            "backing_datastore": "datastore1",
            "backing_disk_mode": "persistent",
            "backing_diskmode": "persistent",
            "backing_eagerlyscrub": null,
            "backing_filename": "[datastore1]",
            "backing_sharing": "sharingNone",
            "backing_thinprovisioned": false,
            "backing_type": "FlatVer2",
            "backing_uuid": null,
            "backing_writethrough": false,
            "capacity_in_bytes": 0,
            "capacity_in_kb": 0,
            "controller_bus_number": 0,
            "controller_key": 1000,
            "controller_type": "paravirtual",
            "iolimit_limit": -1,
            "iolimit_shares_level": "normal",
            "iolimit_shares_limit": 1000,
            "key": 2001,
            "label": "Hard disk 2",
            "shares_level": "normal",
            "shares_limit": 1000,
            "summary": "0 KB",
            "unit_number": 1
        }
```
