### PR TITLE
stable-3.x: Ignore some sanity tests in 2.18

### DIFF
--- a/tests/sanity/ignore-2.18.txt
+++ b/tests/sanity/ignore-2.18.txt
@@ -1,0 +1,4 @@
+plugins/modules/vmware_deploy_ovf.py replace-urlopen!skip
+plugins/modules/vmware_deploy_ovf.py use-argspec-type-path!skip
+scripts/inventory/vmware_inventory.py pep8!skip
+tests/unit/mock/loader.py pep8!skip

--- a/tests/sanity/ignore-2.18.txt
+++ b/tests/sanity/ignore-2.18.txt
@@ -1,4 +1,5 @@
 plugins/modules/vmware_deploy_ovf.py replace-urlopen!skip
 plugins/modules/vmware_deploy_ovf.py use-argspec-type-path!skip
+plugins/modules/vmware_host_acceptance.py validate-modules:parameter-state-invalid-choice
 scripts/inventory/vmware_inventory.py pep8!skip
 tests/unit/mock/loader.py pep8!skip


### PR DESCRIPTION
Ignore some sanity tests in 2.18 that haven't been fixed yet.

_edit_:
We still have to ignore `parameter-state-invalid-choice` in `vmware_host_acceptance`. This is fixed in 4.0.0 but since this is a breaking change we can't backport it and need the ignore in 3.x.