### PR TITLE
vmware_dvs_portgroup: don't update on non-specified num_ports

### DIFF
--- a/changelogs/fragments/2053-vmware_dvs_portgroup.yml
+++ b/changelogs/fragments/2053-vmware_dvs_portgroup.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - vmware_dvs_portgroup - Fix erroneously reporting a change when `port_binding` is static and `num_ports` not specified
+    (https://github.com/ansible-collections/community.vmware/pull/2053).

--- a/plugins/modules/vmware_dvs_portgroup.py
+++ b/plugins/modules/vmware_dvs_portgroup.py
@@ -734,7 +734,7 @@ class VMwareDvsPortgroup(PyVmomi):
 
         # Check config
         if self.module.params['port_allocation'] != 'elastic' and self.module.params['port_binding'] != 'ephemeral':
-            if self.dvs_portgroup.config.numPorts != self.module.params['num_ports']:
+            if self.module.params['num_ports'] is not None and self.dvs_portgroup.config.numPorts != self.module.params['num_ports']:
                 return 'update'
 
         # Default port config

--- a/tests/integration/targets/vmware_dvs_portgroup/tasks/main.yml
+++ b/tests/integration/targets/vmware_dvs_portgroup/tasks/main.yml
@@ -805,3 +805,85 @@
     - assert:
         that:
           - delete_test_dvs_port_group_issues_637_idempotency_check_result.changed is sameas true
+
+- name: Create portgroup for num_ports check
+  community.vmware.vmware_dvs_portgroup:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    portgroup_name: "portgroup2053"
+    switch_name: "{{ dvswitch1 }}"
+    vlan_id: 2053
+    port_binding: static
+  register: create_portgroup2053_result
+
+- assert:
+    that:
+      - create_portgroup2053_result is changed
+
+- name: Check idempotency for unspecified num_ports
+  community.vmware.vmware_dvs_portgroup:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    portgroup_name: "portgroup2053"
+    switch_name: "{{ dvswitch1 }}"
+    vlan_id: 2053
+    port_binding: static
+  register: portgroup2053_check1_result
+
+- assert:
+    that:
+      - portgroup2053_check1_result is not changed
+
+- name: Update for num_ports
+  community.vmware.vmware_dvs_portgroup:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    portgroup_name: "portgroup2053"
+    switch_name: "{{ dvswitch1 }}"
+    vlan_id: 2053
+    port_binding: static
+    num_ports: 8
+  register: portgroup2053_check2_result
+
+- assert:
+    that:
+      - portgroup2053_check2_result is changed
+
+- name: Check idempotency for unspecified num_ports
+  community.vmware.vmware_dvs_portgroup:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    portgroup_name: "portgroup2053"
+    switch_name: "{{ dvswitch1 }}"
+    vlan_id: 2053
+    port_binding: static
+  register: portgroup2053_check3_result
+
+- assert:
+    that:
+      - portgroup2053_check3_result is not changed
+
+- name: Delete num_ports check portgroup
+  community.vmware.vmware_dvs_portgroup:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    portgroup_name: "portgroup2053"
+    switch_name: "{{ dvswitch1 }}"
+    vlan_id: 2053
+    port_binding: static
+    state: absent
+  register: delete_portgroup2053_result
+
+- assert:
+    that:
+      - delete_portgroup2053_result is changed


### PR DESCRIPTION
The module would report `changed` when `port_binding`=`static` and `num_ports` not specified even though the resulting update would be without actual changes.

##### SUMMARY
The `vmware_dvs_portgroup` reports changes when when `port_binding`=`static` and `num_ports` isn't specified.
The resulting call would specify `vim.dvs.DistributedVirtualPortgroup.ConfigSpec.numPorts` as None though, resulting in no changes.
This PR makes sure to not report a change for `num_ports` inconsistencies if it isn't specified

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_dvs_portgroup

##### ADDITIONAL INFORMATION
Other than in the commit, I believe `num_ports` is only used [here](https://github.com/ansible-collections/community.vmware/blob/366b9fe28cfc4ab75a57df8d9f6930f2ff6e257e/plugins/modules/vmware_dvs_portgroup.py#L485).
