### PR TITLE
vmware_dvs_portgroup: Make status present the default

### DIFF
--- a/changelogs/fragments/2055-vmware_dvs_portgroup-status_default.yml
+++ b/changelogs/fragments/2055-vmware_dvs_portgroup-status_default.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - vmware_dvs_portgroup - Make `state` default to `present` instead of having it as a required parameter
+    (https://github.com/ansible-collections/community.vmware/pull/2055).

--- a/plugins/modules/vmware_dvs_portgroup.py
+++ b/plugins/modules/vmware_dvs_portgroup.py
@@ -64,11 +64,12 @@ options:
     state:
         description:
             - Determines if the portgroup should be present or not.
-        required: true
+        required: false
         type: str
         choices:
             - 'present'
             - 'absent'
+        default: 'present'
     vlan_trunk:
         description:
             - Indicates whether this is a VLAN trunk or not.
@@ -893,7 +894,7 @@ def main():
             num_ports=dict(type='int'),
             port_binding=dict(required=True, type='str', choices=['static', 'ephemeral']),
             port_allocation=dict(type='str', choices=['fixed', 'elastic']),
-            state=dict(required=True, choices=['present', 'absent'], type='str'),
+            state=dict(type='str', choices=['present', 'absent'], default='present'),
             vlan_trunk=dict(type='bool', default=False),
             vlan_private=dict(type='bool', default=False),
             network_policy=dict(


### PR DESCRIPTION
##### SUMMARY
`vmware_dvs_portgroup` doesn't have a default for `state`. Usually, modules have this and define `present`. I think it would make sense to do it like this here, too.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_dvs_portgroup

##### ADDITIONAL INFORMATION
https://github.com/ansible-collections/community.vmware/pull/2053#issuecomment-2075374617

cc @lennardk