### PR TITLE
check if dpm config is None

### DIFF
--- a/changelogs/fragments/2056-vmware_cluster_dpm-handle-dpm-none-config.yml
+++ b/changelogs/fragments/2056-vmware_cluster_dpm-handle-dpm-none-config.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - vmware_cluster_dpm - Handle case where DPM config has not been initialized yet and is None
+    (https://github.com/ansible-collections/community.vmware/pull/2056).

--- a/changelogs/fragments/2057-vmware_cluster_dpm-handle-dpm-none-config.yml
+++ b/changelogs/fragments/2057-vmware_cluster_dpm-handle-dpm-none-config.yml
@@ -1,3 +1,3 @@
 bugfixes:
   - vmware_cluster_dpm - Handle case where DPM config has not been initialized yet and is None
-    (https://github.com/ansible-collections/community.vmware/pull/2056).
+    (https://github.com/ansible-collections/community.vmware/pull/2057).

--- a/plugins/modules/vmware_cluster_dpm.py
+++ b/plugins/modules/vmware_cluster_dpm.py
@@ -117,7 +117,7 @@ class VMwareCluster(PyVmomi):
         change_message = None
         changes = False
 
-        if dpm_config.enabled != self.enable_dpm:
+        if dpm_config is None or dpm_config.enabled != self.enable_dpm:
             change_message = 'DPM enabled status changes'
             changes = True
             return changes, change_message


### PR DESCRIPTION
##### SUMMARY
An unexpected error is thrown when trying to set/create the DPM config if no config already exists. I encountered this when using the vCenter simulation project (vcsim). 

This PR allows the module to set the DPM config even if it is missing. It treats a missing config the same as a config with an undesired `enabled` state.


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_cluster_dpm module

##### ADDITIONAL INFORMATION
Im pretty sure that actual vCenter deployments have DPM configs by default, so this issue probably does not affect many use cases. Still, the fix is easy and doesn't change how the module behaves for those people. 

To reproduce:
```
---
- hosts: localhost
  gather_facts: false
  tasks:
    - name: Run soap vcSim
      containers.podman.podman_container:
        name: vmwaresoap
        image: docker.io/vmware/vcsim:latest
        state: started
        recreate: yes
        expose:
          - 8989
        ports:
          - 8989:8989
    - name: Configure DPM Settings
      community.vmware.vmware_cluster_dpm:
        hostname: 127.0.0.1
        username: test
        password: test
        validate_certs: false
        port: 8989
        datacenter_name: DC0
        cluster_name: DC0_C0
        enable_dpm: true
```

Output Before
```
TASK [Configure DPM Settings] ***************************************************************************************************************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: AttributeError: 'NoneType' object has no attribute 'enabled'
fatal: [mimorenc]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/home/mimorenc/.ansible/tmp/ansible-tmp-1714487921.355326-2249903-252951479769263/AnsiballZ_vmware_cluster_dpm.py\", line 107, in <module>\n    _ansiballz_main()\n  File \"/home/mimorenc/.ansible/tmp/ansible-tmp-1714487921.355326-2249903-252951479769263/AnsiballZ_vmware_cluster_dpm.py\", line 99, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/home/mimorenc/.ansible/tmp/ansible-tmp-1714487921.355326-2249903-252951479769263/AnsiballZ_vmware_cluster_dpm.py\", line 47, in invoke_module\n    runpy.run_module(mod_name='ansible_collections.community.vmware.plugins.modules.vmware_cluster_dpm', init_globals=dict(_module_fqn='ansible_collections.community.vmware.plugins.modules.vmware_cluster_dpm', _modlib_path=modlib_path),\n  File \"/home/mimorenc/miniconda3/envs/ansible-vmware-3.10/lib/python3.10/runpy.py\", line 209, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/home/mimorenc/miniconda3/envs/ansible-vmware-3.10/lib/python3.10/runpy.py\", line 96, in _run_module_code\n    _run_code(code, mod_globals, init_globals,\n  File \"/home/mimorenc/miniconda3/envs/ansible-vmware-3.10/lib/python3.10/runpy.py\", line 86, in _run_code\n    exec(code, run_globals)\n  File \"/tmp/ansible_community.vmware.vmware_cluster_dpm_payload_w40tsjep/ansible_community.vmware.vmware_cluster_dpm_payload.zip/ansible_collections/community/vmware/plugins/modules/vmware_cluster_dpm.py\", line 185, in <module>\n  File \"/tmp/ansible_community.vmware.vmware_cluster_dpm_payload_w40tsjep/ansible_community.vmware.vmware_cluster_dpm_payload.zip/ansible_collections/community/vmware/plugins/modules/vmware_cluster_dpm.py\", line 181, in main\n  File \"/tmp/ansible_community.vmware.vmware_cluster_dpm_payload_w40tsjep/ansible_community.vmware.vmware_cluster_dpm_payload.zip/ansible_collections/community/vmware/plugins/modules/vmware_cluster_dpm.py\", line 137, in configure_dpm\n  File \"/tmp/ansible_community.vmware.vmware_cluster_dpm_payload_w40tsjep/ansible_community.vmware.vmware_cluster_dpm_payload.zip/ansible_collections/community/vmware/plugins/modules/vmware_cluster_dpm.py\", line 120, in check_dpm_config_diff\nAttributeError: 'NoneType' object has no attribute 'enabled'\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
```

Output After
```
TASK [Configure DPM Settings] ***************************************************************************************************************************************************************************************************************
changed: [mimorenc]