### PR TITLE
[WIP] Drop unnecessary tests for pyVmomi

### DIFF
--- a/plugins/modules/vcenter_standard_key_provider.py
+++ b/plugins/modules/vcenter_standard_key_provider.py
@@ -178,14 +178,6 @@ key_provider_clusters:
         ]
 '''
 
-HAS_PYVMOMI = False
-try:
-    from pyVmomi import vim
-
-    HAS_PYVMOMI = True
-except ImportError:
-    pass
-
 import os
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native

--- a/plugins/modules/vcenter_standard_key_provider.py
+++ b/plugins/modules/vcenter_standard_key_provider.py
@@ -181,7 +181,7 @@ key_provider_clusters:
 import os
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
-from ansible_collections.community.vmware.plugins.module_utils.vmware import vmware_argument_spec, PyVmomi, vim
+from ansible_collections.community.vmware.plugins.module_utils.vmware import vmware_argument_spec, PyVmomi
 
 
 class PyVmomiHelper(PyVmomi):
@@ -189,6 +189,7 @@ class PyVmomiHelper(PyVmomi):
         super(PyVmomiHelper, self).__init__(module)
         self.crypto_mgr = self.content.cryptoManager
         self.key_provider_id = None
+        from pyVmomi import vim
 
     def get_key_provider_clusters(self):
         key_provider_clusters = None

--- a/plugins/modules/vcenter_standard_key_provider.py
+++ b/plugins/modules/vcenter_standard_key_provider.py
@@ -181,7 +181,7 @@ key_provider_clusters:
 import os
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
-from ansible_collections.community.vmware.plugins.module_utils.vmware import vmware_argument_spec, PyVmomi
+from ansible_collections.community.vmware.plugins.module_utils.vmware import vmware_argument_spec, PyVmomi, vim
 
 
 class PyVmomiHelper(PyVmomi):

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -1098,13 +1098,6 @@ import re
 import time
 import string
 
-HAS_PYVMOMI = False
-try:
-    from pyVmomi import vim, vmodl
-    HAS_PYVMOMI = True
-except ImportError:
-    pass
-
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.common.network import is_mac
 from ansible.module_utils._text import to_text, to_native

--- a/plugins/modules/vmware_guest_storage_policy.py
+++ b/plugins/modules/vmware_guest_storage_policy.py
@@ -153,13 +153,6 @@ changed_policies:
 
 import traceback
 from ansible.module_utils.basic import missing_required_lib
-PYVMOMI_IMP_ERR = None
-try:
-    from pyVmomi import pbm, vim
-    HAS_PYVMOMI = True
-except ImportError:
-    HAS_PYVMOMI = False
-    PYVMOMI_IMP_ERR = traceback.format_exc()
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 from ansible_collections.community.vmware.plugins.module_utils.vmware import vmware_argument_spec, wait_for_task
@@ -421,10 +414,6 @@ def run_module():
             ['disk', 'vm_home'],
         ],
     )
-
-    if not HAS_PYVMOMI:
-        module.fail_json(msg=missing_required_lib("pyVmomi"),
-                         exception=PYVMOMI_IMP_ERR)
 
     if module.params['folder']:
         # FindByInventoryPath() does not require an absolute path

--- a/plugins/modules/vmware_guest_tpm.py
+++ b/plugins/modules/vmware_guest_tpm.py
@@ -98,13 +98,6 @@ instance:
     sample: None
 '''
 
-HAS_PYVMOMI = False
-try:
-    from pyVmomi import vim
-    HAS_PYVMOMI = True
-except ImportError:
-    pass
-
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 from ansible_collections.community.vmware.plugins.module_utils.vmware import vmware_argument_spec, PyVmomi, wait_for_task

--- a/plugins/modules/vmware_host_graphics.py
+++ b/plugins/modules/vmware_host_graphics.py
@@ -83,12 +83,6 @@ results:
   }
 '''
 
-try:
-    from pyVmomi import vim
-    HAS_PYVMOMI = True
-except ImportError:
-    HAS_PYVMOMI = False
-
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.vmware.plugins.module_utils.vmware import vmware_argument_spec, PyVmomi
 from ansible.module_utils._text import to_native
@@ -178,9 +172,6 @@ def main():
             ['cluster_name', 'esxi_hostname'],
         ],
     )
-
-    if not HAS_PYVMOMI:
-        module.fail_json(msg='pyvmomi required for this module')
 
     vmware_host_graphics = VMwareHostGraphicSettings(module)
     vmware_host_graphics.ensure()

--- a/plugins/modules/vmware_host_lockdown.py
+++ b/plugins/modules/vmware_host_lockdown.py
@@ -117,12 +117,6 @@ results:
             }
 '''
 
-try:
-    from pyVmomi import vim
-    HAS_PYVMOMI = True
-except ImportError:
-    HAS_PYVMOMI = False
-
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.vmware.plugins.module_utils.vmware import vmware_argument_spec, PyVmomi
 from ansible.module_utils._text import to_native
@@ -195,9 +189,6 @@ def main():
             ['cluster_name', 'esxi_hostname'],
         ]
     )
-
-    if not HAS_PYVMOMI:
-        module.fail_json(msg='pyvmomi required for this module')
 
     vmware_lockdown_mgr = VmwareLockdownManager(module)
     vmware_lockdown_mgr.ensure()

--- a/plugins/modules/vmware_host_lockdown_exceptions.py
+++ b/plugins/modules/vmware_host_lockdown_exceptions.py
@@ -82,12 +82,6 @@ results:
             }
 '''
 
-try:
-    from pyVmomi import vim
-    HAS_PYVMOMI = True
-except ImportError:
-    HAS_PYVMOMI = False
-
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.vmware.plugins.module_utils.vmware import vmware_argument_spec, PyVmomi
 from ansible.module_utils._text import to_native
@@ -176,9 +170,6 @@ def main():
             ['cluster_name', 'esxi_hostname'],
         ]
     )
-
-    if not HAS_PYVMOMI:
-        module.fail_json(msg='pyvmomi required for this module')
 
     vmware_lockdown_mgr = VmwareLockdownManager(module)
     vmware_lockdown_mgr.ensure()

--- a/plugins/modules/vmware_host_snmp.py
+++ b/plugins/modules/vmware_host_snmp.py
@@ -177,12 +177,6 @@ results:
     }
 '''
 
-try:
-    from pyVmomi import vim
-    HAS_PYVMOMI = True
-except ImportError:
-    HAS_PYVMOMI = False
-
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, vmware_argument_spec, find_obj
 from ansible.module_utils._text import to_native
@@ -573,9 +567,6 @@ def main():
         argument_spec=argument_spec,
         supports_check_mode=True,
     )
-
-    if not HAS_PYVMOMI:
-        module.fail_json(msg='pyvmomi required for this module')
 
     host_snmp = VmwareHostSnmp(module)
     host_snmp.ensure()

--- a/plugins/modules/vmware_resource_pool.py
+++ b/plugins/modules/vmware_resource_pool.py
@@ -190,12 +190,6 @@ resource_pool_config:
       }
 '''
 
-try:
-    from pyVmomi import vim, vmodl
-    HAS_PYVMOMI = True
-except ImportError:
-    HAS_PYVMOMI = False
-
 from ansible.module_utils._text import to_native
 from ansible_collections.community.vmware.plugins.module_utils.vmware import get_all_objs, vmware_argument_spec, find_datacenter_by_name, \
     find_cluster_by_name, find_object_by_name, wait_for_task, find_resource_pool_by_name, PyVmomi
@@ -478,9 +472,6 @@ def main():
                                ['cluster', 'esxi_hostname', 'parent_resource_pool'],
                            ],
                            supports_check_mode=True)
-
-    if not HAS_PYVMOMI:
-        module.fail_json(msg='pyvmomi is required for this module')
 
     vmware_rp = VMwareResourcePool(module)
     vmware_rp.process_state()

--- a/plugins/modules/vmware_vm_config_option.py
+++ b/plugins/modules/vmware_vm_config_option.py
@@ -102,13 +102,6 @@ instance:
     sample: None
 '''
 
-HAS_PYVMOMI = False
-try:
-    from pyVmomi import vim
-    HAS_PYVMOMI = True
-except ImportError:
-    pass
-
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 from ansible_collections.community.vmware.plugins.module_utils.vmware import find_obj, vmware_argument_spec, PyVmomi

--- a/plugins/modules/vmware_vsan_cluster.py
+++ b/plugins/modules/vmware_vsan_cluster.py
@@ -52,12 +52,6 @@ EXAMPLES = r'''
       loop: "{{ groups['esxi'][1:] }}"
 '''
 
-try:
-    from pyVmomi import vim, vmodl
-    HAS_PYVMOMI = True
-except ImportError:
-    HAS_PYVMOMI = False
-
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.vmware.plugins.module_utils.vmware import (
     HAS_PYVMOMI, connect_to_api, get_all_objs, vmware_argument_spec,

--- a/plugins/modules/vmware_vsan_health_info.py
+++ b/plugins/modules/vmware_vsan_health_info.py
@@ -105,15 +105,6 @@ vsan_health_info:
 import json
 import traceback
 
-try:
-    from pyVmomi import vmodl, VmomiSupport
-    HAS_PYVMOMI = True
-    HAS_PYVMOMIJSON = hasattr(VmomiSupport, 'VmomiJSONEncoder')
-except ImportError:
-    PYVMOMI_IMP_ERR = traceback.format_exc()
-    HAS_PYVMOMI = False
-    HAS_PYVMOMIJSON = False
-
 VSANPYTHONSDK_IMP_ERR = None
 try:
     import vsanapiutils
@@ -185,9 +176,6 @@ def main():
 
     if not HAS_VSANPYTHONSDK:
         module.fail_json(msg=missing_required_lib('vSAN Management SDK for Python'), exception=VSANPYTHONSDK_IMP_ERR)
-
-    if not HAS_PYVMOMIJSON:
-        module.fail_json(msg='The installed version of pyvmomi lacks JSON output support; need pyvmomi>6.7.1')
 
     vsan_info_manager = VSANInfoManager(module)
     vsan_info_manager.gather_info()


### PR DESCRIPTION
##### SUMMARY
I think there are some unnecessary tests if pyVmomi can be imported in some modules because it's already tested in `plugins/module_utils/vmware.py`. We could simplify things if we remove them.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vcenter_standard_key_provider
vmware_guest
vmware_guest_storage_policy
vmware_guest_tpm
vmware_host_graphics
vmware_host_lockdown
vmware_host_lockdown_exceptions
vmware_host_snmp
vmware_resource_pool
vmware_vm_config_option
vmware_vsan_cluster
vmware_vsan_health_info

##### ADDITIONAL INFORMATION
As far as I can see `vmware_vm_vss_dvs_migrate`, `vmware_migrate_vmk` and `vmware_vsan_cluster` don't use the `PyVmomi` class from `plugins/module_utils/vmware.py` so let's ignore them for now and have a look at them later.