### PR TITLE
stable-3.x: Fix vmware_content_library_manager integration tests

### DIFF
--- a/tests/integration/targets/vmware_content_library_manager/tasks/main.yml
+++ b/tests/integration/targets/vmware_content_library_manager/tasks/main.yml
@@ -144,7 +144,7 @@
     validate_certs: false
     library_name: Sample_Subscribed_Library
     library_description: Update Sample Description
-    subscription_url: https://download3.vmware.com/software/vmw-tools/lib.json
+    subscription_url: "https://wp-content.vmware.com/v2/latest/lib.json"
     update_on_demand: true
     library_type: subscribed
     ssl_thumbprint: '{{ _finger_print.stdout.split("=")[1] }}'


### PR DESCRIPTION
##### SUMMARY
Fix `vmware_content_library_manager` integration tests after Broadcom moved things from `vmware.com` to `broadcom.com`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_content_library_manager

##### ADDITIONAL INFORMATION
Backport of #2067