### PR TITLE
Require pyVmomi 6.7.1

### DIFF
--- a/changelogs/fragments/2071-clarify-pyvmomi-requirement.yml
+++ b/changelogs/fragments/2071-clarify-pyvmomi-requirement.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Clarify pyVmomi requirement (https://github.com/ansible-collections/community.vmware/pull/2071).

--- a/plugins/module_utils/vmware.py
+++ b/plugins/module_utils/vmware.py
@@ -39,11 +39,9 @@ try:
     from pyVim import connect
     from pyVmomi import vim, vmodl, VmomiSupport
     HAS_PYVMOMI = True
-    HAS_PYVMOMIJSON = hasattr(VmomiSupport, 'VmomiJSONEncoder')
 except ImportError:
     PYVMOMI_IMP_ERR = traceback.format_exc()
     HAS_PYVMOMI = False
-    HAS_PYVMOMIJSON = False
 
 from ansible.module_utils._text import to_text, to_native
 from ansible.module_utils.six import integer_types, iteritems, string_types, raise_from
@@ -1972,9 +1970,6 @@ class PyVmomi(object):
         provided then all properties are deeply converted.  The resulting
         JSON is sorted to improve human readability.
 
-        Requires upstream support from pyVmomi > 6.7.1
-        (https://github.com/vmware/pyvmomi/pull/732)
-
         Args:
           - obj (object): vim object
           - properties (list, optional): list of properties following
@@ -1985,9 +1980,6 @@ class PyVmomi(object):
         Return:
           dict
         """
-        if not HAS_PYVMOMIJSON:
-            self.module.fail_json(msg='The installed version of pyvmomi lacks JSON output support; need pyvmomi>6.7.1')
-
         result = dict()
         if properties:
             for prop in properties:

--- a/plugins/modules/vmware_cluster_info.py
+++ b/plugins/modules/vmware_cluster_info.py
@@ -42,7 +42,7 @@ options:
      description:
        - Specify the output schema desired.
        - The V(summary) output schema is the legacy output from the module.
-       - The V(vsphere) output schema is the vSphere API class definition which requires pyvmomi>6.7.1.
+       - The V(vsphere) output schema is the vSphere API class definition.
      choices: ['summary', 'vsphere']
      default: 'summary'
      type: str

--- a/plugins/modules/vmware_datacenter_info.py
+++ b/plugins/modules/vmware_datacenter_info.py
@@ -29,7 +29,7 @@ options:
       description:
       - Specify the output schema desired.
       - The V(summary) output schema is the legacy output from the module.
-      - The V(vsphere) output schema is the vSphere API class definition which requires pyvmomi>6.7.1.
+      - The V(vsphere) output schema is the vSphere API class definition.
       choices: ['summary', 'vsphere']
       default: 'summary'
       type: str

--- a/plugins/modules/vmware_datastore_info.py
+++ b/plugins/modules/vmware_datastore_info.py
@@ -58,7 +58,6 @@ options:
      - Specify the output schema desired.
      - The 'summary' output schema is the legacy output from the module
      - The 'vsphere' output schema is the vSphere API class definition
-       which requires pyvmomi>6.7.1
      choices: ['summary', 'vsphere']
      default: 'summary'
      type: str

--- a/plugins/modules/vmware_dvswitch_info.py
+++ b/plugins/modules/vmware_dvswitch_info.py
@@ -43,7 +43,6 @@ options:
         - Specify the output schema desired.
         - The 'summary' output schema is the legacy output from the module
         - The 'vsphere' output schema is the vSphere API class definition
-          which requires pyvmomi>6.7.1
       choices: ['summary', 'vsphere']
       default: 'summary'
       type: str

--- a/plugins/modules/vmware_guest_info.py
+++ b/plugins/modules/vmware_guest_info.py
@@ -87,7 +87,6 @@ options:
      - Specify the output schema desired.
      - The V(summary) output schema is the legacy output from the module
      - The V(vsphere) output schema is the vSphere API class definition
-       which requires pyvmomi>6.7.1
      choices: ['summary', 'vsphere']
      default: 'summary'
      type: str

--- a/plugins/modules/vmware_host_facts.py
+++ b/plugins/modules/vmware_host_facts.py
@@ -47,7 +47,6 @@ options:
     - Specify the output schema desired.
     - The V(summary) output schema is the legacy output from the module
     - The V(vsphere) output schema is the vSphere API class definition
-      which requires pyvmomi>6.7.1
     choices: ['summary', 'vsphere']
     default: 'summary'
     type: str

--- a/plugins/modules/vmware_vcenter_settings_info.py
+++ b/plugins/modules/vmware_vcenter_settings_info.py
@@ -22,7 +22,7 @@ options:
     description:
       - Specify the output schema desired.
       - The 'summary' output schema is the legacy output from the module.
-      - The 'vsphere' output schema is the vSphere API class definition which requires pyvmomi>6.7.1.
+      - The 'vsphere' output schema is the vSphere API class definition.
     choices: ['summary', 'vsphere']
     default: 'summary'
     type: str

--- a/plugins/modules/vmware_vsan_health_info.py
+++ b/plugins/modules/vmware_vsan_health_info.py
@@ -108,11 +108,9 @@ import traceback
 try:
     from pyVmomi import vmodl, VmomiSupport
     HAS_PYVMOMI = True
-    HAS_PYVMOMIJSON = hasattr(VmomiSupport, 'VmomiJSONEncoder')
 except ImportError:
     PYVMOMI_IMP_ERR = traceback.format_exc()
     HAS_PYVMOMI = False
-    HAS_PYVMOMIJSON = False
 
 VSANPYTHONSDK_IMP_ERR = None
 try:
@@ -185,9 +183,6 @@ def main():
 
     if not HAS_VSANPYTHONSDK:
         module.fail_json(msg=missing_required_lib('vSAN Management SDK for Python'), exception=VSANPYTHONSDK_IMP_ERR)
-
-    if not HAS_PYVMOMIJSON:
-        module.fail_json(msg='The installed version of pyvmomi lacks JSON output support; need pyvmomi>6.7.1')
 
     vsan_info_manager = VSANInfoManager(module)
     vsan_info_manager.gather_info()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pyVmomi>=6.7
+pyVmomi>=6.7.1
 git+https://github.com/vmware/vsphere-automation-sdk-python.git ; python_version >= '2.7'  # Python 2.6 is not supported


### PR DESCRIPTION
##### SUMMARY
At least some of the modules require pyVmomi 6.7.1 or later, but we didn't specify this in the `requirements.txt`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
requirements.txt

##### ADDITIONAL INFORMATION
[6.7.1](https://pypi.org/project/pyvmomi/6.7.1/) has been released 2018-10-23, 5 1/2 years ago.