### PR TITLE
Support migrate VM in vmware_guest module

### DIFF
--- a/changelogs/2081-migrate_vm_in_vmware_guest.yml
+++ b/changelogs/2081-migrate_vm_in_vmware_guest.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_guest - supporting migrate VM if the requested ESXi hostname was updated.


### PR DESCRIPTION
##### SUMMARY
Adding support for VM migration in the vmware_guest module. 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_guest

##### ADDITIONAL INFORMATION
When the user is asking for a different hostname, there is no operation handling that. This PR adds the support for VM migration to a different hostname. 