### PR TITLE
add module to check for VMs with Storage DRS Overrides on given datastore clusters

### DIFF
--- a/plugins/modules/vmware_sdrs_vm_overrides_info.py
+++ b/plugins/modules/vmware_sdrs_vm_overrides_info.py
@@ -6,10 +6,11 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
+
 __metaclass__ = type
 
 
-DOCUMENTATION = r'''
+DOCUMENTATION = r"""
 ---
 module: vmware_sdrs_vm_overrides_info
 short_description: Check for VM overrides in a SDRS datastore cluster
@@ -27,48 +28,51 @@ options:
 extends_documentation_fragment:
 - community.vmware.vmware.documentation
 
-'''
+"""
 
-EXAMPLES = r'''
-- name: Checks a datastore cluster for VMs with Storage DRS enabled
-  community.vmware.vmware_sdrs_vm_overrides_info:
+EXAMPLES = r"""
+- name: Create datastore cluster and enable SDRS
+  swisscom.vmware.vmware_sdrs_vm_overrides_info:
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
     datastore_cluster_name: '{{ datastore_cluster_name }}'
   delegate_to: localhost
-'''
+"""
 
-RETURN = r'''
+RETURN = r"""
 result:
     description: information about datastore clusters with VMs with SDRS enabled
     returned: always
     type: str
     sample:  {"changed": false, "result": {"DSC_1": {"vm_overrides": {"VM_1": {"srds_enabled_status": false, "vm_behavior": null}, "VM_2": {"srds_enabled_status": false, "vm_behavior": null}}}}}
-'''
-
-try:
-    from pyVmomi import vim
-except ImportError:
-    pass
+"""
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, vmware_argument_spec
+from ansible_collections.community.vmware.plugins.module_utils.vmware import (
+    PyVmomi,
+    vmware_argument_spec,
+)
 
 
 class VMwareDatastoreClusterManager(PyVmomi):
     def __init__(self, module):
         super(VMwareDatastoreClusterManager, self).__init__(module)
-        self.datastore_cluster_name = self.params.get('datastore_cluster_name')
-        self.datastore_cluster_obj = self.find_datastore_cluster_by_name(self.datastore_cluster_name)
+        self.datastore_cluster_name = self.params.get("datastore_cluster_name")
+        self.datastore_cluster_obj = self.find_datastore_cluster_by_name(
+            self.datastore_cluster_name
+        )
 
     def check_vm_overrides(self):
         """
         Check SDRS status of VMs in datastore cluster
         """
-        results = dict(changed=False, result = {})
+        results = dict(changed=False, result={})
 
-        vm_configs = [vm_spec for vm_spec in self.datastore_cluster_obj.podStorageDrsEntry.storageDrsConfig.vmConfig]
+        vm_configs = [
+            vm_spec
+            for vm_spec in self.datastore_cluster_obj.podStorageDrsEntry.storageDrsConfig.vmConfig
+        ]
         vm_overrides = dict()
 
         for vm in vm_configs:
@@ -78,29 +82,25 @@ class VMwareDatastoreClusterManager(PyVmomi):
                 vm_overrides[vm.vm.name]["vm_behavior"] = vm.behavior
 
         if vm_overrides.keys():
-            results["result"] = dict(
-                vm_overrides = vm_overrides
-                )
+            results["result"] = dict(vm_overrides=vm_overrides)
         else:
             results["result"] = ""
 
         self.module.exit_json(**results)
 
+
 def main():
     argument_spec = vmware_argument_spec()
     argument_spec.update(
         dict(
-            datastore_cluster_name=dict(type='str', required=True),
+            datastore_cluster_name=dict(type="str", required=True),
         )
     )
-    module = AnsibleModule(
-        argument_spec=argument_spec,
-        supports_check_mode=True
-    )
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
 
     datastore_cluster_mgr = VMwareDatastoreClusterManager(module)
     datastore_cluster_mgr.check_vm_overrides()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/plugins/modules/vmware_sdrs_vm_overrides_info.py
+++ b/plugins/modules/vmware_sdrs_vm_overrides_info.py
@@ -30,7 +30,7 @@ extends_documentation_fragment:
 '''
 
 EXAMPLES = r'''
-- name: Create datastore cluster and enable SDRS
+- name: Checks a datastore cluster for VMs with Storage DRS enabled
   swisscom.vmware.vmware_sdrs_vm_overrides_info:
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'

--- a/plugins/modules/vmware_sdrs_vm_overrides_info.py
+++ b/plugins/modules/vmware_sdrs_vm_overrides_info.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# (c) 2023, Lionel Sutcliffe <sutcliffe.lionel@gmail.com>
-# (c) 2023, Olivia Lütolf <olivia.luetolf@swisscom.com>
+# Copyright: (c) 2023, Lionel Sutcliffe <sutcliffe.lionel@gmail.com>
+# Copyright: (c) 2023, Olivia Lütolf <olivia.luetolf@swisscom.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function

--- a/plugins/modules/vmware_sdrs_vm_overrides_info.py
+++ b/plugins/modules/vmware_sdrs_vm_overrides_info.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 # Copyright: (c) 2023, Lionel Sutcliffe <sutcliffe.lionel@gmail.com>
-# Copyright: (c) 2023, Olivia Lütolf <olivia.luetolf@swisscom.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
@@ -31,7 +30,7 @@ extends_documentation_fragment:
 """
 
 EXAMPLES = r"""
-- name: Create datastore cluster and enable SDRS
+- name: Check if SDRS Overrides exist in datastore cluster
   community.vmware.vmware_sdrs_vm_overrides_info:
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'

--- a/plugins/modules/vmware_sdrs_vm_overrides_info.py
+++ b/plugins/modules/vmware_sdrs_vm_overrides_info.py
@@ -43,11 +43,22 @@ RETURN = r"""
 result:
     description: information about datastore clusters with VMs with SDRS enabled
     returned: always
-    type: str
-    sample:  {"changed": false, "result": 
-             {"DSC_1": {"vm_overrides": 
-             {"VM_1": {"srds_enabled_status": false, "vm_behavior": null}, 
-             "VM_2": {"srds_enabled_status": false, "vm_behavior": null}}}}}
+    type: dict
+    sample: {
+        "changed": false, 
+        "result": {
+            "DSC_1": {
+                "vm_overrides": {
+                    "VM_1": {
+                        "srds_enabled_status": false, "vm_behavior": null
+                        }, 
+                     "VM_2": {
+                        "srds_enabled_status": false, "vm_behavior": null
+                        }
+                    }
+                }
+            }
+        }
 """
 
 from ansible.module_utils.basic import AnsibleModule

--- a/plugins/modules/vmware_sdrs_vm_overrides_info.py
+++ b/plugins/modules/vmware_sdrs_vm_overrides_info.py
@@ -45,7 +45,10 @@ result:
     description: information about datastore clusters with VMs with SDRS enabled
     returned: always
     type: str
-    sample:  {"changed": false, "result": {"DSC_1": {"vm_overrides": {"VM_1": {"srds_enabled_status": false, "vm_behavior": null}, "VM_2": {"srds_enabled_status": false, "vm_behavior": null}}}}}
+    sample:  {"changed": false, "result": 
+             {"DSC_1": {"vm_overrides": 
+             {"VM_1": {"srds_enabled_status": false, "vm_behavior": null}, 
+             "VM_2": {"srds_enabled_status": false, "vm_behavior": null}}}}}
 """
 
 from ansible.module_utils.basic import AnsibleModule
@@ -69,10 +72,7 @@ class VMwareDatastoreClusterManager(PyVmomi):
         """
         results = dict(changed=False, result={})
 
-        vm_configs = [
-            vm_spec
-            for vm_spec in self.datastore_cluster_obj.podStorageDrsEntry.storageDrsConfig.vmConfig
-        ]
+        vm_configs = list(self.datastore_cluster_obj.podStorageDrsEntry.storageDrsConfig.vmConfig)
         vm_overrides = dict()
 
         for vm in vm_configs:

--- a/plugins/modules/vmware_sdrs_vm_overrides_info.py
+++ b/plugins/modules/vmware_sdrs_vm_overrides_info.py
@@ -47,14 +47,12 @@ result:
     sample: {
         "changed": false,
         "result": {
-            "DSC_1": {
-                "vm_overrides": {
-                    "VM_1": {
-                        "srds_enabled_status": false, "vm_behavior": null
-                        },
-                     "VM_2": {
-                        "srds_enabled_status": false, "vm_behavior": null
-                        }
+            "vm_overrides": {
+                "VM_1": {
+                    "srds_enabled_status": false, "vm_behavior": null
+                    },
+                 "VM_2": {
+                    "srds_enabled_status": false, "vm_behavior": null
                     }
                 }
             }

--- a/plugins/modules/vmware_sdrs_vm_overrides_info.py
+++ b/plugins/modules/vmware_sdrs_vm_overrides_info.py
@@ -32,7 +32,7 @@ extends_documentation_fragment:
 
 EXAMPLES = r"""
 - name: Create datastore cluster and enable SDRS
-  swisscom.vmware.vmware_sdrs_vm_overrides_info:
+  community.vmware.vmware_sdrs_vm_overrides_info:
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'

--- a/plugins/modules/vmware_sdrs_vm_overrides_info.py
+++ b/plugins/modules/vmware_sdrs_vm_overrides_info.py
@@ -49,10 +49,10 @@ result:
         "result": {
             "vm_overrides": {
                 "VM_1": {
-                    "srds_enabled_status": false, "vm_behavior": null
+                    "sdrs_enabled_status": false, "vm_behavior": null
                     },
                  "VM_2": {
-                    "srds_enabled_status": false, "vm_behavior": null
+                    "sdrs_enabled_status": false, "vm_behavior": null
                     }
                 }
             }
@@ -86,7 +86,7 @@ class VMwareDatastoreClusterManager(PyVmomi):
         for vm in vm_configs:
             if vm.enabled is not None or vm.behavior is not None:
                 vm_overrides[vm.vm.name] = {}
-                vm_overrides[vm.vm.name]["srds_enabled_status"] = vm.enabled
+                vm_overrides[vm.vm.name]["sdrs_enabled_status"] = vm.enabled
                 vm_overrides[vm.vm.name]["vm_behavior"] = vm.behavior
 
         if vm_overrides.keys():

--- a/plugins/modules/vmware_sdrs_vm_overrides_info.py
+++ b/plugins/modules/vmware_sdrs_vm_overrides_info.py
@@ -45,13 +45,13 @@ result:
     returned: always
     type: dict
     sample: {
-        "changed": false, 
+        "changed": false,
         "result": {
             "DSC_1": {
                 "vm_overrides": {
                     "VM_1": {
                         "srds_enabled_status": false, "vm_behavior": null
-                        }, 
+                        },
                      "VM_2": {
                         "srds_enabled_status": false, "vm_behavior": null
                         }

--- a/plugins/modules/vmware_sdrs_vm_overrides_info.py
+++ b/plugins/modules/vmware_sdrs_vm_overrides_info.py
@@ -17,7 +17,7 @@ description:
     - This module can be used to check if VM overrides exist in a SDRS enabled datastore cluster in a given VMware environment.
     - All parameters and VMware object values are case sensitive.
 author:
--  Lionel Sutcliffe
+-  Lionel Sutcliffe (@sudo-lupus)
 options:
     datastore_cluster_name:
       description:

--- a/plugins/modules/vmware_sdrs_vm_overrides_info.py
+++ b/plugins/modules/vmware_sdrs_vm_overrides_info.py
@@ -1,0 +1,106 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2023, Lionel Sutcliffe <sutcliffe.lionel@gmail.com>
+# (c) 2023, Olivia Lütolf <olivia.luetolf@swisscom.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = r'''
+---
+module: vmware_sdrs_vm_overrides_info
+short_description: Check for VM overrides in a SDRS datastore cluster
+description:
+    - This module can be used to check if VM overrides exist in a SDRS enabled datastore cluster in a given VMware environment.
+    - All parameters and VMware object values are case sensitive.
+author:
+-  Lionel Sutcliffe
+options:
+    datastore_cluster_name:
+      description:
+      - The name of the datastore cluster.
+      required: true
+      type: str
+extends_documentation_fragment:
+- community.vmware.vmware.documentation
+
+'''
+
+EXAMPLES = r'''
+- name: Create datastore cluster and enable SDRS
+  swisscom.vmware.vmware_sdrs_vm_overrides_info:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    datastore_cluster_name: '{{ datastore_cluster_name }}'
+  delegate_to: localhost
+'''
+
+RETURN = r'''
+result:
+    description: information about datastore clusters with VMs with SDRS enabled
+    returned: always
+    type: str
+    sample:  {"changed": false, "result": {"DSC_1": {"vm_overrides": {"VM_1": {"srds_enabled_status": false, "vm_behavior": null}, "VM_2": {"srds_enabled_status": false, "vm_behavior": null}}}}}
+'''
+
+try:
+    from pyVmomi import vim
+except ImportError:
+    pass
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, vmware_argument_spec
+
+
+class VMwareDatastoreClusterManager(PyVmomi):
+    def __init__(self, module):
+        super(VMwareDatastoreClusterManager, self).__init__(module)
+        self.datastore_cluster_name = self.params.get('datastore_cluster_name')
+        self.datastore_cluster_obj = self.find_datastore_cluster_by_name(self.datastore_cluster_name)
+
+    def check_vm_overrides(self):
+        """
+        Check SDRS status of VMs in datastore cluster
+        """
+        results = dict(changed=False, result = {})
+
+        vm_configs = [vm_spec for vm_spec in self.datastore_cluster_obj.podStorageDrsEntry.storageDrsConfig.vmConfig]
+        vm_overrides = dict()
+
+        for vm in vm_configs:
+            if vm.enabled is not None or vm.behavior is not None:
+                vm_overrides[vm.vm.name] = {}
+                vm_overrides[vm.vm.name]["srds_enabled_status"] = vm.enabled
+                vm_overrides[vm.vm.name]["vm_behavior"] = vm.behavior
+
+        if vm_overrides.keys():
+            results["result"] = dict(
+                vm_overrides = vm_overrides
+                )
+        else:
+            results["result"] = ""
+
+        self.module.exit_json(**results)
+
+def main():
+    argument_spec = vmware_argument_spec()
+    argument_spec.update(
+        dict(
+            datastore_cluster_name=dict(type='str', required=True),
+        )
+    )
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True
+    )
+
+    datastore_cluster_mgr = VMwareDatastoreClusterManager(module)
+    datastore_cluster_mgr.check_vm_overrides()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/vmware_sdrs_vm_overrides_info.py
+++ b/plugins/modules/vmware_sdrs_vm_overrides_info.py
@@ -31,7 +31,7 @@ extends_documentation_fragment:
 
 EXAMPLES = r'''
 - name: Checks a datastore cluster for VMs with Storage DRS enabled
-  swisscom.vmware.vmware_sdrs_vm_overrides_info:
+  community.vmware.vmware_sdrs_vm_overrides_info:
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'


### PR DESCRIPTION
##### SUMMARY
Added a module to check if Storage DRS Overrides are present in a given datastore cluster as in our setup these are not desired and are therefore manually removed after evaluation on a case-to-case basis.
Currently no module exists to handle this task.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_sdrs_vm_overrides_info.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
RETURN = r'''
result:
    description: information about datastore clusters with VMs with SDRS enabled
    returned: always
    type: str
    sample:  {"changed": false, "result": {"DSC_1": {"vm_overrides": {"VM_1": {"srds_enabled_status": false, "vm_behavior": null}, "VM_2": {"srds_enabled_status": false, "vm_behavior": null}}}}}
'''

```
