### PR TITLE
Fix cloud.common dependency

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -17,7 +17,8 @@ tags:
   - cloud
   - vmware
   - virtualization
-dependencies: {}
+dependencies:
+  cloud.common: ">=3.0.0,<=5.0.0"
 repository: https://github.com/ansible-collections/community.vmware.git
 homepage: https://github.com/ansible-collections/community.vmware
 issues: https://github.com/ansible-collections/community.vmware/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc


### PR DESCRIPTION
##### SUMMARY
Fix dependency error as cloud.common 4.0.0 has been released https://github.com/ansible-collections/cloud.common/tree/4.0.0, update cloud.common version in galaxy.yml.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
