### PR TITLE
vcenter_folder - remove bad documentation

### DIFF
--- a/changelogs/fragments/2088_bugfix_correct_vcenter_folder_docs.yml
+++ b/changelogs/fragments/2088_bugfix_correct_vcenter_folder_docs.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - vcenter_folder - removed documentation that incorrectly said `folder_type` had no effect when `parent_folder` was set

--- a/plugins/modules/vcenter_folder.py
+++ b/plugins/modules/vcenter_folder.py
@@ -48,7 +48,6 @@ options:
     - "If set to V(datastore), then 'Storage Folder' is created under datacenter."
     - "If set to V(network), then 'Network Folder' is created under datacenter."
     - This parameter is required, if O(state=absent) and O(parent_folder) is not set.
-    - This option is ignored, if O(parent_folder) is set.
     default: vm
     type: str
     required: false


### PR DESCRIPTION
##### SUMMARY
The documentation for the `vcenter_folder` module says that the `folder_type` parameter has no effect when `parent_folder` is set. This is incorrect, the `folder_type` parameter is always taken into account.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
vcenter_folder
