### PR TITLE
vmware_host_logbundle: Add timeout

### DIFF
--- a/changelogs/fragments/2092-vmware_host_logbundle.yml
+++ b/changelogs/fragments/2092-vmware_host_logbundle.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_host_logbundle - Add timeout parameter (https://github.com/ansible-collections/community.vmware/pull/2092).

--- a/plugins/modules/vmware_host_logbundle.py
+++ b/plugins/modules/vmware_host_logbundle.py
@@ -28,6 +28,12 @@ options:
         - file destination on localhost, path must be exist.
       type: str
       required: true
+    download_timeout:
+      version_added: 4.5.0
+      description:
+        - The user defined timeout in seconds of exporting the log file.
+        - The default of the function this module uses is so low that you have to set this this to a higher value in all probabilty.
+      type: int
     manifests:
       description:
         - Logs to include in the logbundle file.
@@ -170,6 +176,7 @@ class VMwareHostLogbundle(PyVmomi):
         self.dest = self.params['dest']
         self.manifests = self.params['manifests']
         self.performance_data = self.params['performance_data']
+        self.download_timeout = self.params['download_timeout']
 
         if not self.dest.endswith('.tgz'):
             self.dest = self.dest + '.tgz'
@@ -219,7 +226,10 @@ class VMwareHostLogbundle(PyVmomi):
         headers = self.generate_req_headers(url)
 
         try:
-            resp, info = fetch_url(self.module, method='GET', headers=headers, url=url)
+            if self.download_timeout is not None:
+                resp, info = fetch_url(self.module, method='GET', headers=headers, url=url, timeout=self.download_timeout)
+            else:
+                resp, info = fetch_url(self.module, method='GET', headers=headers, url=url)
             if info['status'] != 200:
                 self.module.fail_json(msg="failed to fetch logbundle from %s: %s" % (url, info['msg']))
             with open(self.dest, 'wb') as local_file:
@@ -236,6 +246,7 @@ def main():
     argument_spec.update(
         esxi_hostname=dict(type='str', required=True),
         dest=dict(type='str', required=True),
+        download_timeout=dict(type='int'),
         manifests=dict(type='list', elements='str',
                        default=['System:Base', 'System:CoreDumps', 'System:EsxImage', 'System:IOFilter',
                                 'System:LoadESX', 'System:Modules', 'System:RDMA', 'System:ResourceGroups',

--- a/tests/integration/targets/vmware_host_logbundle/tasks/main.yml
+++ b/tests/integration/targets/vmware_host_logbundle/tasks/main.yml
@@ -17,6 +17,7 @@
     password: "{{ vcenter_password }}"
     validate_certs: false
     esxi_hostname: "{{ esxi1 }}"
+    download_timeout: 1800
     dest: "{{ logbundle_archive_file_path }}"
   register: fetch_logbundle_result
 
@@ -51,6 +52,7 @@
     password: "{{ esxi_password }}"
     validate_certs: false
     esxi_hostname: "{{ esxi1 }}"
+    download_timeout: 1800
     dest: "{{ logbundle_archive_file_path }}"
   register: fetch_logbundle_result
 
@@ -85,6 +87,7 @@
     password: "{{ vcenter_password }}"
     validate_certs: false
     esxi_hostname: "{{ esxi1 }}"
+    download_timeout: 1800
     dest: "{{ logbundle_archive_file_path }}"
     manifests:
       - System:Base
@@ -122,6 +125,7 @@
     password: "{{ esxi_password }}"
     validate_certs: false
     esxi_hostname: "{{ esxi1 }}"
+    download_timeout: 1800
     dest: "{{ logbundle_archive_file_path }}"
     manifests:
       - System:Base
@@ -159,6 +163,7 @@
     password: "{{ vcenter_password }}"
     validate_certs: false
     esxi_hostname: "{{ esxi1 }}"
+    download_timeout: 1800
     dest: "{{ logbundle_archive_file_path }}"
     performance_data:
       duration: 10
@@ -197,6 +202,7 @@
     password: "{{ esxi_password }}"
     validate_certs: false
     esxi_hostname: "{{ esxi1 }}"
+    download_timeout: 1800
     dest: "{{ logbundle_archive_file_path }}"
     performance_data:
       duration: 10


### PR DESCRIPTION
##### SUMMARY
Adding an optional timeout parameter to `vmware_host_logbundle`.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_host_logbundle

##### ADDITIONAL INFORMATION
#2090

It looks like the default timeout of the function the module uses is just 10s:

https://github.com/ansible/ansible/blob/6382ea168a93d80a64aab1fbd8c4f02dc5ada5bf/lib/ansible/module_utils/urls.py#L1136-L1139