### PR TITLE
stable-3.x: avoid attribute error on allowedDatastores

### DIFF
--- a/changelogs/fragments/2080_bugfix_hadnle_vcls_none_config.yml
+++ b/changelogs/fragments/2080_bugfix_hadnle_vcls_none_config.yml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+  - >-
+    vmware_cluster_vcls - fixed bug caused by pyvmomi >=7.0.3 returning the vlcs cluster config attribute as None when it was
+    previously undefined. Now if the vCLS config is not initialized on the cluster, the module will initialize it using the
+    user's desired state.

--- a/plugins/modules/vmware_cluster_vcls.py
+++ b/plugins/modules/vmware_cluster_vcls.py
@@ -112,16 +112,19 @@ class VMwareCluster(PyVmomi):
         Returns: True and all to add and to remove allowed and not allowed Datastores if there is diff, else False
 
         """
-        if hasattr(self.cluster.configurationEx, 'systemVMsConfig'):
-            vCLS_config = self.cluster.configurationEx.systemVMsConfig
-        else:
+        if not hasattr(self.cluster.configurationEx, 'systemVMsConfig'):
             return False, self.allowedDatastores_names, None
+
+        currentAllowedDatastores = []
         changed = False
 
         # Get List currently of allowed Datastore Names
-        currentAllowedDatastores = []
-        for ds in vCLS_config.allowedDatastores:
-            currentAllowedDatastores.append(ds.name)
+        vCLS_config = self.cluster.configurationEx.systemVMsConfig
+        try:
+            for ds in vCLS_config.allowedDatastores:
+                currentAllowedDatastores.append(ds.name)
+        except AttributeError:
+            pass
 
         # Get the to add and to remove allowed and not allowed Datastores
         toAddAllowedDatastores = list(set(self.allowedDatastores_names) - set(currentAllowedDatastores))


### PR DESCRIPTION
Backport #2080

##### SUMMARY
In pyVmomi >7.0.2, the `systemVMsConfig` attribute is `None` instead of not existing. This causes the following logic to throw an attribute error when accessing `vCLS_config.allowedDatastores`.

This PR adds support for newer pyVmomi versions while preserving the behavior for earlier versions. If `systemVMsConfig` is not defined, the module exits without doing anything. If it exists but None, the module will attempt to update/create the config so it matches the user's desired state.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_cluster_vcls

##### ADDITIONAL INFORMATION
Its possible this is a niche situation. I discovered it while using the vcsim for testing the module.

to reproduce:
```yaml
---
- hosts: localhost
  gather_facts: false
  tasks:
    - name: Run soap vcSim
      containers.podman.podman_container:
        name: vmwaresoap
        image: docker.io/vmware/vcsim:latest
        state: started
        recreate: yes
        expose:
          - 8989
        ports:
          - 8989:8989
    - ansible.builtin.shell: pip freeze | grep pyvmomi
      register: _o
    - debug:
        var: _o.stdout 
    - name: Configure vCLS Settings
      community.vmware.vmware_cluster_vcls:
        hostname: 127.0.0.1
        username: test
        password: test
        validate_certs: false
        port: 8989
        datacenter_name: DC0
        cluster_name: DC0_C0
        allowed_datastores: LocalDS_0
```
Before:
```bash
TASK [debug] *******************************************************************************************************************************************************************************************************
ok: [mikemorency] => {
    "_o.stdout": "pyvmomi==7.0.3"
}

TASK [Configure vCLS Settings] *************************************************************************************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: AttributeError: 'NoneType' object has no attribute 'allowedDatastores'
fatal: [mikemorency]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/home/mikemorency/.ansible/tmp/ansible-tmp-1716311719.8242714-1878528-25021429674672/AnsiballZ_vmware_cluster_vcls.py\", line 107, in <module>\n    _ansiballz_main()\n  File \"/home/mikemorency/.ansible/tmp/ansible-tmp-1716311719.8242714-1878528-25021429674672/AnsiballZ_vmware_cluster_vcls.py\", line 99, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/home/mikemorency/.ansible/tmp/ansible-tmp-1716311719.8242714-1878528-25021429674672/AnsiballZ_vmware_cluster_vcls.py\", line 47, in invoke_module\n    runpy.run_module(mod_name='ansible_collections.community.vmware.plugins.modules.vmware_cluster_vcls', init_globals=dict(_module_fqn='ansible_collections.community.vmware.plugins.modules.vmware_cluster_vcls', _modlib_path=modlib_path),\n  File \"/home/mikemorency/miniconda3/envs/ansible-vmware-3.10/lib/python3.10/runpy.py\", line 209, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/home/mikemorency/miniconda3/envs/ansible-vmware-3.10/lib/python3.10/runpy.py\", line 96, in _run_module_code\n    _run_code(code, mod_globals, init_globals,\n  File \"/home/mikemorency/miniconda3/envs/ansible-vmware-3.10/lib/python3.10/runpy.py\", line 86, in _run_code\n    exec(code, run_globals)\n  File \"/tmp/ansible_community.vmware.vmware_cluster_vcls_payload_ut1qj8kc/ansible_community.vmware.vmware_cluster_vcls_payload.zip/ansible_collections/community/vmware/plugins/modules/vmware_cluster_vcls.py\", line 220, in <module>\n  File \"/tmp/ansible_community.vmware.vmware_cluster_vcls_payload_ut1qj8kc/ansible_community.vmware.vmware_cluster_vcls_payload.zip/ansible_collections/community/vmware/plugins/modules/vmware_cluster_vcls.py\", line 216, in main\n  File \"/tmp/ansible_community.vmware.vmware_cluster_vcls_payload_ut1qj8kc/ansible_community.vmware.vmware_cluster_vcls_payload.zip/ansible_collections/community/vmware/plugins/modules/vmware_cluster_vcls.py\", line 157, in configure_vCLS\n  File \"/tmp/ansible_community.vmware.vmware_cluster_vcls_payload_ut1qj8kc/ansible_community.vmware.vmware_cluster_vcls_payload.zip/ansible_collections/community/vmware/plugins/modules/vmware_cluster_vcls.py\", line 122, in check_vCLS_config_diff\nAttributeError: 'NoneType' object has no attribute 'allowedDatastores'\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}

```

After:
```bash
TASK [debug] *******************************************************************************************************************************************************************************************************
ok: [mikemorency] => {
    "_o.stdout": "pyvmomi==7.0.3"
}

TASK [Configure vCLS Settings] *************************************************************************************************************************************************************************************
changed: [mikemorency]
```

And after with an older version of pyvmomi
```bash
TASK [debug] *******************************************************************************************************************************************************************************************************
ok: [mikemorency] => {
    "_o.stdout": "pyvmomi==7.0.2"
}

TASK [Configure vCLS Settings] *************************************************************************************************************************************************************************************
changed: [mikemorency]
```