### PR TITLE
vmware_guest_disk: round size to int

### DIFF
--- a/changelogs/fragments/2095_bugfix_vmware_guest_disk_round_size_to_int.yml
+++ b/changelogs/fragments/2095_bugfix_vmware_guest_disk_round_size_to_int.yml
@@ -1,2 +1,3 @@
 bugfixes:
   - vmware_guest_disk - round size to int, supporting float values properly
+    (https://github.com/ansible-collections/community.vmware/issues/123).

--- a/changelogs/fragments/2095_bugfix_vmware_guest_disk_round_size_to_int.yml
+++ b/changelogs/fragments/2095_bugfix_vmware_guest_disk_round_size_to_int.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_guest_disk - round size to int, supporting float values properly

--- a/plugins/modules/vmware_guest_disk.py
+++ b/plugins/modules/vmware_guest_disk.py
@@ -1031,7 +1031,7 @@ class PyVmomiHelper(PyVmomi):
                     disk_units = dict(tb=3, gb=2, mb=1, kb=0)
                     unit = unit.lower()
                     if unit in disk_units:
-                        current_disk['size'] = expected * (1024 ** disk_units[unit])
+                        current_disk['size'] = round(expected * (1024 ** disk_units[unit]))
                     else:
                         self.module.fail_json(msg="%s is not a supported unit for disk size for disk index [%s]."
                                                   " Supported units are ['%s']." % (unit, disk_index, "', '".join(disk_units.keys())))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes https://github.com/ansible-collections/community.vmware/issues/123
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_guest_disk

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
`capacityInKB` is of type `long`, but we have code in place to support `float` values for the disk size in the module. We should typecast the size by rounding the provided value. 
