### PR TITLE
vmware_vm_vm_drs_rule: add datacenter argument

### DIFF
--- a/changelogs/fragments/2102_vm_vm_drs_rule_datacenter_argument.yml
+++ b/changelogs/fragments/2102_vm_vm_drs_rule_datacenter_argument.yml
@@ -1,2 +1,2 @@
-bugfixes:
+minor_changes:
   - vmware_vm_vm_drs_rule - added datacenter argument to correctly deal with multiple clusters with same name(https://github.com/ansible-collections/community.vmware/issues/2101).

--- a/changelogs/fragments/2102_vm_vm_drs_rule_datacenter_argument.yml
+++ b/changelogs/fragments/2102_vm_vm_drs_rule_datacenter_argument.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_vm_vm_drs_rule - added datacenter argument to correctly deal with multiple clusters with same name(https://github.com/ansible-collections/community.vmware/issues/2101).

--- a/plugins/modules/vmware_vm_vm_drs_rule.py
+++ b/plugins/modules/vmware_vm_vm_drs_rule.py
@@ -371,7 +371,7 @@ def main():
         state=dict(type='str', default='present', choices=['absent', 'present']),
         vms=dict(type='list', elements='str'),
         cluster_name=dict(type='str', required=True),
-        datacenter=dict(type='str', required=False, aliases=['datacenter_name']),
+        datacenter=dict(type='str', required=False),
         drs_rule_name=dict(type='str', required=True),
         enabled=dict(type='bool', default=False),
         mandatory=dict(type='bool', default=False),

--- a/plugins/modules/vmware_vm_vm_drs_rule.py
+++ b/plugins/modules/vmware_vm_vm_drs_rule.py
@@ -18,6 +18,13 @@ description:
 author:
 - Abhijeet Kasurde (@Akasurde)
 options:
+  datacenter:
+    aliases:
+      - datacenter_name
+    description:
+      - "Datacenter to search for given cluster. If not set, we use first cluster we encounter with O(cluster_name)."
+    required: false
+    type: str
   cluster_name:
     description:
     - Desired cluster name where virtual machines are present for the DRS rule.
@@ -73,6 +80,7 @@ EXAMPLES = r'''
     hostname: "{{ esxi_server }}"
     username: "{{ esxi_username }}"
     password: "{{ esxi_password }}"
+    datacenter: "{{ datacenter }}"
     cluster_name: "{{ cluster_name }}"
     vms:
         - vm1
@@ -88,6 +96,7 @@ EXAMPLES = r'''
     hostname: "{{ esxi_server }}"
     username: "{{ esxi_username }}"
     password: "{{ esxi_password }}"
+    datacenter: "{{ datacenter }}"
     cluster_name: "{{ cluster_name }}"
     enabled: true
     vms:
@@ -103,6 +112,7 @@ EXAMPLES = r'''
     hostname: "{{ esxi_server }}"
     username: "{{ esxi_username }}"
     password: "{{ esxi_password }}"
+    datacenter: "{{ datacenter }}"
     cluster_name: "{{ cluster_name }}"
     drs_rule_name: vm1-vm2-affinity-rule-001
     state: absent
@@ -136,13 +146,15 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 from ansible_collections.community.vmware.plugins.module_utils.vmware import (
     PyVmomi, vmware_argument_spec, wait_for_task,
-    find_vm_by_id, find_cluster_by_name)
+    find_vm_by_id, find_cluster_by_name, find_datacenter_by_name)
 
 
 class VmwareDrs(PyVmomi):
     def __init__(self, module):
         super(VmwareDrs, self).__init__(module)
         self.vm_list = module.params['vms']
+        self.__datacenter_name = module.params.get('datacenter', None)
+        self.__datacenter_obj = None
         self.cluster_name = module.params['cluster_name']
         self.rule_name = module.params['drs_rule_name']
         self.enabled = module.params['enabled']
@@ -150,8 +162,12 @@ class VmwareDrs(PyVmomi):
         self.affinity_rule = module.params['affinity_rule']
         self.state = module.params['state']
 
+        if self.__datacenter_name is not None:
+            self.__datacenter_obj = find_datacenter_by_name(self.content, self.__datacenter_name)
+            if self.__datacenter_obj is None and module.check_mode is False:
+                raise Exception("Datacenter '%s' not found" % self.__datacenter_name)
         # Sanity check for cluster
-        self.cluster_obj = find_cluster_by_name(content=self.content,
+        self.cluster_obj = find_cluster_by_name(content=self.content, datacenter=self.__datacenter_obj,
                                                 cluster_name=self.cluster_name)
         if self.cluster_obj is None:
             self.module.fail_json(msg="Failed to find the cluster %s" % self.cluster_name)
@@ -357,6 +373,7 @@ def main():
         state=dict(type='str', default='present', choices=['absent', 'present']),
         vms=dict(type='list', elements='str'),
         cluster_name=dict(type='str', required=True),
+        datacenter=dict(type='str', required=False, aliases=['datacenter_name']),
         drs_rule_name=dict(type='str', required=True),
         enabled=dict(type='bool', default=False),
         mandatory=dict(type='bool', default=False),

--- a/plugins/modules/vmware_vm_vm_drs_rule.py
+++ b/plugins/modules/vmware_vm_vm_drs_rule.py
@@ -19,6 +19,7 @@ author:
 - Abhijeet Kasurde (@Akasurde)
 options:
   datacenter:
+    version_added: '4.6.0'
     description:
       - "Datacenter to search for given cluster. If not set, we use first cluster we encounter with O(cluster_name)."
     required: false

--- a/plugins/modules/vmware_vm_vm_drs_rule.py
+++ b/plugins/modules/vmware_vm_vm_drs_rule.py
@@ -19,8 +19,6 @@ author:
 - Abhijeet Kasurde (@Akasurde)
 options:
   datacenter:
-    aliases:
-      - datacenter_name
     description:
       - "Datacenter to search for given cluster. If not set, we use first cluster we encounter with O(cluster_name)."
     required: false


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add datacenter argument to vmware_vm_vm_drs_rule module


Code adjustments copy-pasted from vmware_vm_host_drs_rule module

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #2101 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_vm_vm_drs_rule
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Previously no datacenter could be provided. The result was that the module always tried to create/manage rules in the first cluster in vcenter that matches the name.
Now a datacenter name can be provided if nessessary.
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
