### PR TITLE
add better error message for missing datastore

### DIFF
--- a/changelogs/fragments/2103_better_vcls_missing_datastore_error.yml
+++ b/changelogs/fragments/2103_better_vcls_missing_datastore_error.yml
@@ -1,2 +1,3 @@
 minor_changes:
   - vmware_cluster_vcls - Fail module with descriptive error if an added datastore does not exist in vcenter
+    (https://github.com/ansible-collections/community.vmware/pull/2103).

--- a/changelogs/fragments/2103_better_vcls_missing_datastore_error.yml
+++ b/changelogs/fragments/2103_better_vcls_missing_datastore_error.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_cluster_vcls - Fail module with descriptive error if an added datastore does not exist in vcenter


### PR DESCRIPTION
##### SUMMARY
If you try to add a datastore that does not exist to the allowed datastores list in the vCLS config, you get a cryptic error message. If a user encounters the error, its really not clear what went wrong.

This change adds a more descriptive error message in the case that the datastore a user tries to add cannot be found. 
I deconstructed the existing method a bit as well, since it was beginning to get large and complex.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_cluster_vcls

##### ADDITIONAL INFORMATION
Test Playbook:
```yaml
- hosts: localhost
  gather_facts: false
  tasks:
  - name: Configure vCLS Datastore Settings
    community.vmware.vmware_cluster_vcls:
      hostname: foo
      username: foo
      password: foo
      datacenter_name: foo
      cluster_name: foo
      allowed_datastores: ["doesnotexist"]
```
Before:
```
TASK [Configure vCLS Datastore Settings] ********************************************************************************
fatal: [mikemorency]: FAILED! => {"changed": false, "msg": "('A specified parameter was not correct: spec.systemVMsConfig.allowedDatastores[1].key', None)"}
```
After:
```
TASK [Configure vCLS Datastore Settings] ********************************************************************************
fatal: [mikemorency]: FAILED! => {"changed": false, "msg": "Failed to add datastore 'doesnotexist' because it does not exist."}
```
