### PR TITLE
README.md: Update vSAN SDK link which redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ VMware community collection depends on Python 3.9+ and on following third party 
 
 * [`Pyvmomi`](https://github.com/vmware/pyvmomi)
 * [`vSphere Automation SDK for Python`](https://github.com/vmware/vsphere-automation-sdk-python/)
-* [`vSAN Management SDK for Python`](https://code.vmware.com/web/sdk/vsan-python)
+* [`vSAN Management SDK for Python`](https://developer.broadcom.com/sdks/vsan-management-sdk-for-python/latest/)
 
 ### Installing required libraries and SDK
 


### PR DESCRIPTION
##### SUMMARY
The page behind the old link has moved meaning it now redirects to a company landing page. The updated link takes the user to the presumed intended location.

##### ISSUE TYPE
- Docs Pull Request

##### Component Name 
README.md

##### ADDITIONAL INFORMATION
Note the following from the [newly linked page](https://developer.broadcom.com/sdks/vsan-management-sdk-for-python/latest/#:~:text=NOTE%3A%20Starting%20with%20vSphere%208.0%20Update%203%20release%20version%2C%20the%20vSAN%20Management%20SDK%20for%20Python%20is%20integrated%20into%20the%20Python%20SDK%20for%20the%20VMware%20vSphere%20API%20(pyVmomi).%20From%20the%20Python%20Package%20Index%20(PyPi)%2C%20you%20can%20download%20a%20single%20package%20to%20manage%20vSAN%2C%20vCenter%2C%20and%20ESXi):

> Starting with vSphere 8.0 Update 3 release version, the vSAN Management SDK for Python is integrated into the Python SDK for the VMware vSphere API ([pyVmomi](https://developer.broadcom.com/sdks/pyvmomi/latest)). From the Python Package Index ([PyPi](https://pypi.org/project/pyvmomi/)), you can download a single package to manage vSAN, vCenter, and ESXi.
