### PR TITLE
Document requirement on requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ collections:
 
 VMware community collection depends on Python 3.9+ and on following third party libraries:
 
+* [`requests`](https://github.com/psf/requests)
 * [`Pyvmomi`](https://github.com/vmware/pyvmomi)
 * [`vSphere Automation SDK for Python`](https://github.com/vmware/vsphere-automation-sdk-python/)
 * [`vSAN Management SDK for Python`](https://developer.broadcom.com/sdks/vsan-management-sdk-for-python/latest/)

--- a/changelogs/fragments/2127-require-requests.yml
+++ b/changelogs/fragments/2127-require-requests.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Document dependency on requests (https://github.com/ansible-collections/community.vmware/issues/2127).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+requests
 pyVmomi>=6.7.1
 git+https://github.com/vmware/vsphere-automation-sdk-python.git ; python_version >= '2.7'  # Python 2.6 is not supported


### PR DESCRIPTION
Fixes #2127

##### SUMMARY
The collection requires `requests`, but we've never documented this since pyVmomi already pulled this in. But it looks like they've dropped the dependency and we didn't notice this up until now. So I think we should make this requirement explicit.

##### ISSUE TYPE
- Docs Pull Request

##### ADDITIONAL INFORMATION
https://github.com/ansible-collections/community.vmware/blob/ff672be4cb07378b6c1ed1f5dcfc9823b101f6f3/plugins/module_utils/vmware.py#L1128-L1130

[Major pyVmomi update for vSphere 8.0](https://github.com/vmware/pyvmomi/commit/a90023fedfeda48cb1824200dc4530084215f99e)