### PR TITLE
Deprecate vmware_cluster_drs

### DIFF
--- a/changelogs/fragments/2136-deprecate-vmware_cluster_drs.yml
+++ b/changelogs/fragments/2136-deprecate-vmware_cluster_drs.yml
@@ -1,0 +1,3 @@
+deprecated_features:
+  - vmware_cluster_drs - the module has been deprecated and will be removed in community.vmware 6.0.0
+    (https://github.com/ansible-collections/community.vmware/pull/2136).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -177,3 +177,10 @@ action_groups:
   - vsan_health_silent_checks
   - vsphere_copy
   - vsphere_file
+
+plugin_routing:
+  modules:
+    vmware_cluster_drs:
+      deprecation:
+        removal_version: 6.0.0
+        warning_text: Use vmware.vmware.cluster_drs instead.

--- a/plugins/modules/vmware_cluster_drs.py
+++ b/plugins/modules/vmware_cluster_drs.py
@@ -19,6 +19,10 @@ description:
 author:
 - Joseph Callen (@jcpowermac)
 - Abhijeet Kasurde (@Akasurde)
+deprecated:
+  removed_in: 6.0.0
+  why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+  alternative: Use M(vmware.vmware.cluster_drs) instead.
 options:
     cluster_name:
       description:


### PR DESCRIPTION
##### SUMMARY
Deprecate `community.vmware.vmware_cluster_drs` in favor of `vmware.vmware.cluster_drs`.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_cluster_drs

##### ADDITIONAL INFORMATION
[New vmware.vmware collection and impact on community.vmware](https://forum.ansible.com/t/5880)