### PR TITLE
Switch back to milestone instead of devel

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -67,8 +67,8 @@ jobs:
           - stable-2.15
           - stable-2.16
           - stable-2.17
-          - devel
-          # - milestone
+          # - devel
+          - milestone
     # Ansible-test on various stable branches does not yet work well with cgroups v2.
     # Since ubuntu-latest now uses Ubuntu 22.04, we need to fall back to the ubuntu-20.04
     # image for these stable branches. The list of branches where this is necessary will

--- a/tests/sanity/ignore-2.18.txt
+++ b/tests/sanity/ignore-2.18.txt
@@ -1,13 +1,5 @@
-plugins/inventory/vmware_host_inventory.py pylint!skip
-plugins/inventory/vmware_vm_inventory.py pylint!skip
+meta/runtime.yml runtime-metadata!skip
 plugins/modules/vmware_deploy_ovf.py replace-urlopen!skip
 plugins/modules/vmware_deploy_ovf.py use-argspec-type-path!skip
-plugins/modules/vmware_dvswitch.py pylint!skip
-plugins/modules/vmware_dvswitch_pvlans.py pylint!skip
-plugins/modules/vmware_guest_tpm.py pylint!skip
-plugins/modules/vmware_host.py pylint!skip
-plugins/modules/vmware_host_dns.py pylint!skip
-plugins/modules/vmware_host_powerstate.py pylint!skip
-plugins/modules/vmware_vmotion.py pylint!skip
 scripts/inventory/vmware_inventory.py pep8!skip
 tests/unit/mock/loader.py pep8!skip


### PR DESCRIPTION
Switch back to using milestone for the sanity tests instead of devel.

Undoing parts of #2140.