### PR TITLE
Document snapshot_id available for state=revert

### DIFF
--- a/changelogs/fragments/2055-vmware_guest_snapshot.yml
+++ b/changelogs/fragments/2055-vmware_guest_snapshot.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - vmware_guest_snapshot - Update documentation regarding snapshot_id parameter
+    (https://github.com/ansible-collections/community.vmware/issues/2145).

--- a/plugins/modules/vmware_guest_snapshot.py
+++ b/plugins/modules/vmware_guest_snapshot.py
@@ -88,7 +88,7 @@ options:
    snapshot_id:
      description:
      - Sets the snapshot id to manage.
-     - This param is available when O(state=absent).
+     - This param is available when O(state=absent) or O(state=revert).
      type: int
      version_added: 3.10.0
    description:


### PR DESCRIPTION
Fixes #2145

##### SUMMARY
Document that `snapshot_id` parameter is also available when `state=revert`, not only when `state=absent`.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
vmware_guest_snapshot

##### ADDITIONAL INFORMATION
