### PR TITLE
Enable runtime-metadata sanity test for 2.16 and 2.17 again

### DIFF
--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -1,4 +1,3 @@
-meta/runtime.yml runtime-metadata!skip
 plugins/modules/vmware_deploy_ovf.py replace-urlopen!skip
 plugins/modules/vmware_deploy_ovf.py use-argspec-type-path!skip
 scripts/inventory/vmware_inventory.py pep8!skip

--- a/tests/sanity/ignore-2.17.txt
+++ b/tests/sanity/ignore-2.17.txt
@@ -1,4 +1,3 @@
-meta/runtime.yml runtime-metadata!skip
 plugins/modules/vmware_deploy_ovf.py replace-urlopen!skip
 plugins/modules/vmware_deploy_ovf.py use-argspec-type-path!skip
 scripts/inventory/vmware_inventory.py pep8!skip


### PR DESCRIPTION
##### SUMMARY
Enable runtime-metadata sanity test for 2.16 and 2.17 again undoing parts of #2140.

##### ISSUE TYPE
- Bugfix Pull Request

##### ADDITIONAL INFORMATION
ansible/ansible#83856
ansible/ansible#83857