### PR TITLE
5.0.0: Removing support for ansible-core version < 2.17.0

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -64,8 +64,8 @@ jobs:
           # - stable-2.12
           # - stable-2.13
           # - stable-2.14
-          - stable-2.15
-          - stable-2.16
+          # - stable-2.15
+          # - stable-2.16
           - stable-2.17
           # - devel
           - milestone
@@ -131,8 +131,8 @@ jobs:
           # - stable-2.12
           # - stable-2.13
           # - stable-2.14
-          - stable-2.15
-          - stable-2.16
+          # - stable-2.15
+          # - stable-2.16
           - stable-2.17
           # - devel
           - milestone

--- a/changelogs/fragments/5.0.0-required_ansible_version.yml
+++ b/changelogs/fragments/5.0.0-required_ansible_version.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+  - Removed support for ansible-core version < 2.17.0.

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,5 +1,5 @@
 ---
-requires_ansible: '>=2.15.0'
+requires_ansible: '>=2.17.0'
 
 action_groups:
   vmware:

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -1,3 +1,0 @@
-meta/runtime.yml runtime-metadata!skip
-plugins/modules/vmware_deploy_ovf.py replace-urlopen!skip
-plugins/modules/vmware_deploy_ovf.py use-argspec-type-path!skip

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -1,4 +1,0 @@
-plugins/modules/vmware_deploy_ovf.py replace-urlopen!skip
-plugins/modules/vmware_deploy_ovf.py use-argspec-type-path!skip
-scripts/inventory/vmware_inventory.py pep8!skip
-tests/unit/mock/loader.py pep8!skip


### PR DESCRIPTION
Fixes #1880

##### SUMMARY
5.0.0 won't support ansible-core < 2.17.0.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME

##### ADDITIONAL INFORMATION