### PR TITLE
4.x: Deprecate vmware_cluster

### DIFF
--- a/changelogs/fragments/2143-deprecate-vmware_cluster.yml
+++ b/changelogs/fragments/2143-deprecate-vmware_cluster.yml
@@ -1,0 +1,3 @@
+deprecated_features:
+  - vmware_cluster - the module has been deprecated and will be removed in community.vmware 6.0.0
+    (https://github.com/ansible-collections/community.vmware/pull/2143).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -180,6 +180,10 @@ action_groups:
 
 plugin_routing:
   modules:
+    vmware_cluster:
+      deprecation:
+        removal_version: 6.0.0
+        warning_text: Use vmware.vmware.cluster instead.
     vmware_cluster_drs:
       deprecation:
         removal_version: 6.0.0

--- a/plugins/modules/vmware_cluster.py
+++ b/plugins/modules/vmware_cluster.py
@@ -20,6 +20,10 @@ description:
 author:
 - Joseph Callen (@jcpowermac)
 - Abhijeet Kasurde (@Akasurde)
+deprecated:
+  removed_in: 6.0.0
+  why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+  alternative: Use M(vmware.vmware.cluster) instead.
 options:
     cluster_name:
       description:


### PR DESCRIPTION
##### SUMMARY
Deprecate `community.vmware.vmware_cluster` in favor of `vmware.vmware.cluster`.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_cluster

##### ADDITIONAL INFORMATION
Backport of #2143