### PR TITLE
Depend on vmware.vmware

### DIFF
--- a/changelogs/fragments/2159-depend-on-vmware.vmware.yml
+++ b/changelogs/fragments/2159-depend-on-vmware.vmware.yml
@@ -1,0 +1,3 @@
+breaking_changes:
+  - Adding a dependency on the ``vmware.vmware`` collection
+    (https://github.com/ansible-collections/community.vmware/pull/2159).

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -17,7 +17,8 @@ tags:
   - cloud
   - vmware
   - virtualization
-dependencies: {}
+dependencies:
+  vmware.vmware: ">=1.5.0,<2.0.0"
 repository: https://github.com/ansible-collections/community.vmware.git
 homepage: https://github.com/ansible-collections/community.vmware
 issues: https://github.com/ansible-collections/community.vmware/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc


### PR DESCRIPTION
##### SUMMARY
We've deprecated some modules in favor of ones from [vmware.vmware](https://github.com/ansible-collections/vmware.vmware). Let's make this collection a dependency, so it's already there when people want to use it.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
galaxy.yml

##### ADDITIONAL INFORMATION
[New vmware.vmware collection and impact on community.vmware](https://forum.ansible.com/t/5880)