### PR TITLE
4.x: Deprecate vmware_cluster_vcls

### DIFF
--- a/changelogs/fragments/2156-deprecate-vmware_cluster_vcls.yml
+++ b/changelogs/fragments/2156-deprecate-vmware_cluster_vcls.yml
@@ -1,0 +1,3 @@
+deprecated_features:
+  - vmware_cluster_vcls - the module has been deprecated and will be removed in community.vmware 6.0.0
+    (https://github.com/ansible-collections/community.vmware/pull/2156).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -188,3 +188,7 @@ plugin_routing:
       deprecation:
         removal_version: 6.0.0
         warning_text: Use vmware.vmware.cluster_drs instead.
+    vmware_cluster_vcls:
+      deprecation:
+        removal_version: 6.0.0
+        warning_text: Use vmware.vmware.cluster_vcls instead.

--- a/plugins/modules/vmware_cluster_vcls.py
+++ b/plugins/modules/vmware_cluster_vcls.py
@@ -20,6 +20,10 @@ description:
 author:
 - Joseph Callen (@jcpowermac)
 - Nina Loser (@Nina2244)
+deprecated:
+  removed_in: 6.0.0
+  why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+  alternative: Use M(vmware.vmware.cluster_vcls) instead.
 options:
     cluster_name:
       description:


### PR DESCRIPTION
##### SUMMARY
Deprecate `community.vmware.vmware_cluster_vcls` in favor of `vmware.vmware.cluster_vcls`.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_cluster_vcls

##### ADDITIONAL INFORMATION
Backport of #2156