### PR TITLE
Update 5.0.0 dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The collection includes the VMware modules and plugins supported by Ansible VMwa
 
 ## Ansible version compatibility
 
-This collection has been tested against following Ansible versions: **>=2.15.0**.
+This collection has been tested against following Ansible versions: **>=2.17.0**.
 
 Plugins and modules within a collection may be tested with only specific Ansible versions.
 A collection may contain metadata that identifies these versions.
@@ -39,10 +39,9 @@ collections:
 
 VMware community collection depends on Python 3.9+ and on following third party libraries:
 
-* [`requests`](https://github.com/psf/requests)
-* [`Pyvmomi`](https://github.com/vmware/pyvmomi)
-* [`vSphere Automation SDK for Python`](https://github.com/vmware/vsphere-automation-sdk-python/)
-* [`vSAN Management SDK for Python`](https://developer.broadcom.com/sdks/vsan-management-sdk-for-python/latest/)
+* [`pyvmomi`](https://pypi.org/project/pyvmomi/) >=8.0.3.0.1
+* [`vmware-vcenter`](https://pypi.org/project/vmware-vcenter/)
+* [`vmware-vapi-common-client`](https://pypi.org/project/vmware-vapi-common-client/)
 
 ### Installing required libraries and SDK
 

--- a/changelogs/fragments/5.0.0-requirements.yml
+++ b/changelogs/fragments/5.0.0-requirements.yml
@@ -1,0 +1,5 @@
+breaking_changes:
+  - Dropping support for pyVmomi < 8.0.3.0.1 (https://github.com/ansible-collections/community.vmware/pull/2163).
+  - Depending on ``vmware-vcenter`` and ``vmware-vapi-common-client`` instead of
+    ``https://github.com/vmware/vsphere-automation-sdk-python.git``
+    (https://github.com/ansible-collections/community.vmware/pull/2163).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-requests
-pyVmomi>=6.7.1
-git+https://github.com/vmware/vsphere-automation-sdk-python.git ; python_version >= '2.7'  # Python 2.6 is not supported
+pyVmomi>=8.0.3.0.1
+vmware-vcenter
+vmware-vapi-common-client


### PR DESCRIPTION
Fixes #2123

##### SUMMARY
Require pyVmomi >= 8.0.3.0.1 in order to be able to drop the requirement on the vSAN Management SDK for Python, which has been a pain to install.

Also, substitute the requirement for / dependency on `https://github.com/vmware/vsphere-automation-sdk-python.git` with the PyPI packages `vmware-vcenter` and `vmware-vapi-common-client`.

Additionally, at least one of those pulls in `requirements` so we can remove it, too.

Also document the dependency on ansible-core 2.17.0.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
requirements.txt
README.md

##### ADDITIONAL INFORMATION
[vSAN Management SDK for Python](https://developer.broadcom.com/sdks/vsan-management-sdk-for-python/latest/)
[vsphere-automation-sdk-python  PyPI package](https://github.com/vmware/vsphere-automation-sdk-python/issues/38#issuecomment-2206842664)
#2153