### PR TITLE
vmware_all_snapshots_info: Fix datacenter parameter being ignored

### DIFF
--- a/changelogs/fragments/2138-vmware_all_snapshots_info.yml
+++ b/changelogs/fragments/2138-vmware_all_snapshots_info.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_all_snapshots_info - fixed the datacenter parameter was ignored(https://github.com/ansible-collections/community.vmware/pull/2165).


### PR DESCRIPTION
##### SUMMARY

The datacenter parameter was ignored in the `vmware_all_snapshots_info` module, so all VM snapshots were returned.
I fixed the issue where the datacenter parameter was being ignored when searching for VMs.

fixes https://github.com/ansible-collections/community.vmware/issues/2138

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

* plugins/modules/vmware_all_snapshots_info.py

##### ADDITIONAL INFORMATION

I tested in VCSA7.
