### PR TITLE
vmware_guest_tools_info: Remove vm_tools_install_status

### DIFF
--- a/changelogs/fragments/2078-vmware_guest_tools_info.yml
+++ b/changelogs/fragments/2078-vmware_guest_tools_info.yml
@@ -1,0 +1,3 @@
+breaking_changes:
+  - vmware_guest_tools_info - Removed deprecated ``vm_tools_install_status`` from the result
+    (https://github.com/ansible-collections/community.vmware/issues/2078).

--- a/plugins/modules/vmware_guest_tools_info.py
+++ b/plugins/modules/vmware_guest_tools_info.py
@@ -107,7 +107,6 @@ vmtools_info:
         "vm_hw_version": "vmx-14",
         "vm_ipaddress": "10.10.10.10",
         "vm_name": "test_vm",
-        "vm_tools_install_status": "toolsOk",
         "vm_tools_install_type": "guestToolsTypeMSI",
         "vm_tools_last_install_count": 0,
         "vm_tools_running_status": "guestToolsRunning",
@@ -142,7 +141,6 @@ class PyVmomiHelper(PyVmomi):
             vm_guest_hostname=self.current_vm_obj.summary.guest.hostName,
             vm_ipaddress=self.current_vm_obj.summary.guest.ipAddress,
             vm_tools_running_status=self.current_vm_obj.summary.guest.toolsRunningStatus,
-            vm_tools_install_status=self.current_vm_obj.summary.guest.toolsStatus,
             vm_tools_version_status=self.current_vm_obj.summary.guest.toolsVersionStatus2,
             vm_tools_install_type=self.current_vm_obj.config.tools.toolsInstallType,
             vm_tools_version=self.current_vm_obj.config.tools.toolsVersion,
@@ -150,11 +148,6 @@ class PyVmomiHelper(PyVmomi):
             vm_tools_last_install_count=self.current_vm_obj.config.tools.lastInstallInfo.counter,
         )
 
-        self.module.deprecate(
-            msg="The API providing vm_tools_install_status has been deprecated by VMware; use vm_tools_running_status / vm_tools_version_status instead",
-            version="5.0.0",
-            collection_name="community.vmware"
-        )
         return {'changed': False, 'failed': False, 'vmtools_info': vmtools_info}
 
 

--- a/tests/integration/targets/vmware_guest_tools_info/tasks/main.yml
+++ b/tests/integration/targets/vmware_guest_tools_info/tasks/main.yml
@@ -33,7 +33,8 @@
 - name: assert VMware tools info returned
   assert:
     that:
-      - "vmtools_info.vmtools_info.vm_tools_install_status != ''"
+      - "vmtools_info.vmtools_info.vm_tools_version_status != ''"
+      - "vmtools_info.vmtools_info.vm_tools_running_status != ''"
 
 - name: get VMware tools info of virtual machine by name
   vmware_guest_tools_info:
@@ -48,4 +49,5 @@
 - name: assert VMware tools info returned
   assert:
     that:
-      - "vmtools_info.vmtools_info.vm_tools_install_status != ''"
+      - "vmtools_info.vmtools_info.vm_tools_version_status != ''"
+      - "vmtools_info.vmtools_info.vm_tools_running_status != ''"


### PR DESCRIPTION
Fixes #2078

##### SUMMARY
Removing `vm_tools_install_status` which reports the [deprecated toolsStatus](https://vdc-download.vmware.com/vmwb-repository/dcr-public/184bb3ba-6fa8-4574-a767-d0c96e2a38f4/ba9422ef-405c-47dd-8553-e11b619185b2/SDK/vsphere-ws/docs/ReferenceGuide/vim.vm.Summary.GuestSummary.html) as announced in #2034.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_guest_tools_info

##### ADDITIONAL INFORMATION
