### PR TITLE
Stable-4.x: vmware_all_snapshots_info: Fix datacenter ignored

### DIFF
--- a/changelogs/fragments/2138-vmware_all_snapshots_info.yml
+++ b/changelogs/fragments/2138-vmware_all_snapshots_info.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_all_snapshots_info - fixed the datacenter parameter was ignored(https://github.com/ansible-collections/community.vmware/pull/2165).


### PR DESCRIPTION
##### SUMMARY

The `datacenter` parameter was ignored in the `vmware_all_snapshots_info` module, so all VM snapshots were returned.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

* vmware_all_snapshots_info

##### ADDITIONAL INFORMATION

Backport of #2165