### PR TITLE
Fix existing disk erroneously being recreated when dealing with 8 or more disks

### DIFF
--- a/changelogs/fragments/2173-fix-existing-disk-recreation-on-vm-with-8-or-more-disks.yml
+++ b/changelogs/fragments/2173-fix-existing-disk-recreation-on-vm-with-8-or-more-disks.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - vmware_guest - Fix existing disk erroneously being re-created when modifying vm with 8 or more disks.
+    (https://github.com/ansible-collections/community.vmware/pull/2173).

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -2645,6 +2645,7 @@ class PyVmomiHelper(PyVmomi):
                                       "the target object (%d vs %d)" % (len(self.params.get('disk')), len(disks)))
 
         disk_index = 0
+        disk_index_scsi = 0
         for expected_disk_spec in self.params.get('disk'):
             disk_modified = False
             # If we are manipulating and existing objects which has disks and disk_index is in disks
@@ -2654,15 +2655,16 @@ class PyVmomiHelper(PyVmomi):
                 diskspec.operation = vim.vm.device.VirtualDeviceSpec.Operation.edit
                 diskspec.device = disks[disk_index]
             else:
-                diskspec = self.device_helper.create_hard_disk(scsi_ctl, disk_index)
+                diskspec = self.device_helper.create_hard_disk(scsi_ctl, disk_index_scsi)
                 diskspec.operation = vim.vm.device.VirtualDeviceSpec.Operation.add
                 disk_modified = True
 
             # increment index for next disk search
             disk_index += 1
+            disk_index_scsi += 1
             # index 7 is reserved to SCSI controller
-            if disk_index == 7:
-                disk_index += 1
+            if disk_index_scsi == 7:
+                disk_index_scsi += 1
 
             if expected_disk_spec['disk_mode']:
                 disk_mode = expected_disk_spec.get('disk_mode', 'persistent')


### PR DESCRIPTION
##### SUMMARY
Modifying a vm that has 8 or more disks leads to the last disk erroneously being recreated (which will fail, because it already exists), because vmware_guest uses `disks[disk_index]`  to access the disk config, and `disk_index` skips index 7, while `disks` does NOT skip that index. Therefore the module thinks the disk does not exist, even though it does exist. Having more than 8 disks this will also lead to various disk size issues because it is applying the disk size from the incorrect disk. Fix by keeping the scsi index separate.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
vmware_guest