### PR TITLE
Drop using guest.toolsStatus

### DIFF
--- a/changelogs/2174.yml
+++ b/changelogs/2174.yml
@@ -1,0 +1,5 @@
+major_changes:
+  - vmware_vm_shell - Subsitute the deprecated ``guest.toolsStatus`` collection
+    (https://github.com/ansible-collections/community.vmware/pull/2174).
+  - vmware_guest_tools_upgrade - Subsitute the deprecated ``guest.toolsStatus`` collection
+    (https://github.com/ansible-collections/community.vmware/pull/2174).

--- a/plugins/modules/vmware_guest_tools_upgrade.py
+++ b/plugins/modules/vmware_guest_tools_upgrade.py
@@ -129,7 +129,7 @@ class PyVmomiHelper(PyVmomi):
     def upgrade_tools(self, vm):
         result = {'failed': False, 'changed': False, 'msg': ''}
         # Exit if VMware tools is already up to date
-        if vm.guest.toolsStatus == "toolsOk":
+        if vm.guest.toolsVersionStatus2 == "guestToolsCurrent":
             result.update(
                 changed=False,
                 msg="VMware tools is already up to date",
@@ -145,16 +145,22 @@ class PyVmomiHelper(PyVmomi):
             return result
 
         # Fail if VMware tools is either not running or not installed
-        elif vm.guest.toolsStatus in ["toolsNotRunning", "toolsNotInstalled"]:
+        elif vm.guest.toolsVersionStatus2 == 'guestToolsNotInstalled':
             result.update(
                 failed=True,
-                msg="VMware tools is either not running or not installed",
+                msg="The VMwareTools are not installed."
+            )
+            return result
+        elif vm.guest.toolsRunningStatus != 'guestToolsRunning':
+            result.update(
+                failed=True,
+                msg="The VMwareTools are not running."
             )
             return result
 
         # If vmware tools is out of date, check major OS family
         # Upgrade tools on Linux and Windows guests
-        elif vm.guest.toolsStatus == "toolsOld":
+        elif vm.guest.guestToolsTooOld == "guestToolsTooOld":
             try:
                 force = self.module.params.get('force_upgrade')
                 installer_options = self.module.params.get('installer_options')

--- a/plugins/modules/vmware_vm_shell.py
+++ b/plugins/modules/vmware_vm_shell.py
@@ -243,10 +243,12 @@ class VMwareShellManager(PyVmomi):
         if not vm:
             module.fail_json(msg='Unable to find virtual machine.')
 
-        tools_status = vm.guest.toolsStatus
-        if tools_status in ['toolsNotInstalled', 'toolsNotRunning']:
-            self.module.fail_json(msg="VMwareTools is not installed or is not running in the guest."
-                                      " VMware Tools are necessary to run this module.")
+        if vm.guest.toolsVersionStatus2 == 'guestToolsNotInstalled':
+            self.module.fail_json(msg="The VMwareTools are not installed. "
+                                      "VMware Tools are necessary to run this module.")
+        if vm.guest.toolsRunningStatus != 'guestToolsRunning':
+            self.module.fail_json(msg="The VMwareTools are not running ."
+                                      "VMware Tools are necessary to run this module.")
 
         try:
             self.execute_command(vm, module.params)


### PR DESCRIPTION
Fixes #2167

##### SUMMARY
`vmware_vm_shell` and `vmware_guest_tools_upgrade` use [guest.toolsStatus which is deprecated](https://vdc-download.vmware.com/vmwb-repository/dcr-public/184bb3ba-6fa8-4574-a767-d0c96e2a38f4/ba9422ef-405c-47dd-8553-e11b619185b2/SDK/vsphere-ws/docs/ReferenceGuide/vim.vm.GuestInfo.html).

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_vm_shell.py
vmware_guest_tools_upgrade.py

##### ADDITIONAL INFORMATION