### PR TITLE
Update vmware_vm_info.py

### DIFF
--- a/changelogs/fragments/2194-vmware_vm_info.yml
+++ b/changelogs/fragments/2194-vmware_vm_info.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_vm_info - Improve performance when parsing custom attributes information (https://github.com/ansible-collections/community.vmware/pull/2194)

--- a/plugins/modules/vmware_vm_info.py
+++ b/plugins/modules/vmware_vm_info.py
@@ -303,8 +303,14 @@ class VmwareVmInfo(PyVmomi):
         return self.vmware_client.get_tags_for_vm(vm_mid=vm_dynamic_obj._moId)
 
     def get_vm_attributes(self, vm):
-        return dict((x.name, v.value) for x in self.custom_field_mgr
-                    for v in vm.customValue if x.key == v.key)
+        custom_field_values = vm.customValue
+        custom_field_mgr = self.custom_field_mgr
+        vm_attributes = {}
+        for custom_field in custom_field_mgr:
+            for custom_value in custom_field_values:
+                if custom_field.key == custom_value.key:
+                    vm_attributes[custom_field.name] = custom_value.value
+        return vm_attributes
 
     # https://github.com/vmware/pyvmomi-community-samples/blob/master/samples/getallvms.py
     def get_virtual_machines(self):


### PR DESCRIPTION

##### SUMMARY
unrolling the return statement for "def get_vm_attributes(self, vm)" results in a ~25 fold speed increase processing a 2,200 VMs inventory. From 2.7 seconds average per VM getting attributes for original code to 0.11 seconds for the new unrolled code 



##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
vmware_vm_info.py

##### ADDITIONAL INFORMATION
Comparison using original and new code

```

    def get_vm_attributes1(self, vm):
        return dict((x.name, v.value) for x in self.custom_field_mgr
                    for v in vm.customValue if x.key == v.key)

    def get_vm_attributes2(self, vm):
      custom_field_values = vm.customValue
      custom_field_mgr = self.custom_field_mgr
      vm_attributes = {}
      for custom_field in custom_field_mgr:
          for custom_value in custom_field_values:
              if custom_field.key == custom_value.key:
                  vm_attributes[custom_field.name] = custom_value.value
      return vm_attributes



    def get_virtual_machines(self):
[.............]
            vm_attributes = dict()
            if self.module.params.get('show_attribute'):
                attributes_start = time.time()
                vm_attributes = self.get_vm_attributes1(vm)
                attributes_end = time.time()
                logging.debug(vm_attributes)
                logging.debug("Time to get VM attributes1: %f seconds", attributes_end - attributes_start)
                attributes_start = time.time()
                vm_attributes = self.get_vm_attributes2(vm)
                attributes_end = time.time()
                logging.debug(vm_attributes)
                logging.debug("Time to get VM attributes2: %f seconds", attributes_end - attributes_start)


2024-10-02 16:41:31,188 - DEBUG - {'BusinessArea': 'b1', 'Project': '199400081', 'CriticalityLevel': '1', 'DataSensitivity': 'L1', 'LicensedProduct': 'N/A', 'OS': 'Windows2019', 'SystemEnvironment': 'prd'}
2024-10-02 16:41:31,189 - DEBUG - Time to get VM attributes1: 2.718272 seconds
2024-10-02 16:41:31,303 - DEBUG - {'BusinessArea': 'b1', 'Project': '199400081', 'CriticalityLevel': '1', 'DataSensitivity': 'L1', 'LicensedProduct': 'N/A', 'OS': 'Windows2019', 'SystemEnvironment': 'prd'}
2024-10-02 16:41:31,304 - DEBUG - Time to get VM attributes2: 0.114557 seconds
```
