### PR TITLE
Correct minor typo "vminfo" to "vm_info"

### DIFF
--- a/plugins/modules/vmware_vm_info.py
+++ b/plugins/modules/vmware_vm_info.py
@@ -138,7 +138,7 @@ EXAMPLES = r'''
   register: vm_info
 
 - debug:
-    var: vminfo.virtual_machines
+    var: vm_info.virtual_machines
 
 - name: Gather only registered virtual machine templates
   community.vmware.vmware_vm_info:


### PR DESCRIPTION
##### SUMMARY
Correct minor typo in docs

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
vmware_vm_info

##### ADDITIONAL INFORMATION
Found typo in documentation, submitting correction
