### PR TITLE
vmware_vmotion: Catch no placement recommendation

### DIFF
--- a/changelogs/fragments/2208-vmware_vmotion.yml
+++ b/changelogs/fragments/2208-vmware_vmotion.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - vmware_vmotion - Fix a `list index out of range` error when vSphere doesn't provide a placement recommendation
+    (https://github.com/ansible-collections/community.vmware/pull/2208).

--- a/plugins/modules/vmware_vmotion.py
+++ b/plugins/modules/vmware_vmotion.py
@@ -478,6 +478,10 @@ class VmotionManager(PyVmomi):
                                                    relocateSpec=relocate_spec)
         placement = self.cluster_object.PlaceVm(placement_spec)
 
+        if not placement.recommendations:
+            self.module.fail_json(
+                msg='No placement recommendation from vSphere.')
+
         if self.host_object is None:
             self.host_object = placement.recommendations[0].action[0].targetHost
         if self.datastore_object is None:


### PR DESCRIPTION
##### SUMMARY
I think there's a problem here:

https://github.com/ansible-collections/community.vmware/blob/7c2cc76ac4f13332802ff74c0dfdcd90cfd65bea/plugins/modules/vmware_vmotion.py#L481-L484

If vSphere doesn't give a recommendation, this might result in a `list index out of range` error.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_vmotion

##### ADDITIONAL INFORMATION
#2207