### PR TITLE
Install vmware.vmware for docs linting

### DIFF
--- a/.github/workflows/extra-docs-linting.yml
+++ b/.github/workflows/extra-docs-linting.yml
@@ -26,10 +26,15 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.13'
 
       - name: Install antsibull-docs
         run: pip install antsibull-docs --disable-pip-version-check
+
+      - name: Install dependent collections
+        run: >
+          ansible-galaxy collection install
+          vmware.vmware
 
       - name: Run collection docs linter
         run: antsibull-docs lint-collection-docs . --plugin-docs --skip-rstcheck


### PR DESCRIPTION
##### SUMMARY
Install `vmware.vmware` when doing the docs linting / checks.

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request

##### ADDITIONAL INFORMATION
#2217
#2218
ansible-collections/collection_template#82
