### PR TITLE
vmware_guest: Fix vApp property handling

### DIFF
--- a/changelogs/fragments/2220-vmware_guest.yml
+++ b/changelogs/fragments/2220-vmware_guest.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - vmware_guest - setting vApp properties on virtual machines without vApp options raised an AttributeError.
+    Fix now gracefully handles a `None` value for vApp options when retrieving current vApp properties
+    (https://github.com/ansible-collections/community.vmware/pull/2220).

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -2067,13 +2067,14 @@ class PyVmomiHelper(PyVmomi):
         if vm_obj:
             # VM exists
             orig_spec = vm_obj.config.vAppConfig
+            orig_properties = orig_spec.property if orig_spec is not None else []
 
-            vapp_properties_current = dict((x.id, x) for x in orig_spec.property)
+            vapp_properties_current = dict((x.id, x) for x in orig_properties)
             vapp_properties_to_change = dict((x['id'], x) for x in self.params['vapp_properties'])
 
             # each property must have a unique key
             # init key counter with max value + 1
-            all_keys = [x.key for x in orig_spec.property]
+            all_keys = [x.key for x in orig_properties]
             new_property_index = max(all_keys) + 1 if all_keys else 0
 
             for property_id, property_spec in vapp_properties_to_change.items():


### PR DESCRIPTION
##### SUMMARY
The `vmware_guest` module did not properly handle setting vApp properties if the `VmConfigSpec` never contained an active `vAppConfig`. This resulted in an exception due to incorrectly trying to access `property` on `None`.

This PR changes the behaviour to default the current list of vApp properties to an empty list if there has never been any `vAppConfig`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_guest

##### ADDITIONAL INFORMATION
A simple reproducer would be a to attempt to use `community.vmware.vmware_guest` like this:

```yaml
- name: Configure vApp options
  community.vmware.vmware_guest:
    state: present
    hostname: xxx
    username: xxx
    password: xxx
    name: reproducer-vm
    vapp_properties:
      - id: name
        type: string
        label: This is a test
        category: Test
  delegate_to: localhost
  become: false
  run_once: true
```

Doing so on any VM within vSphere that has its vApp options disabled, meaning that no current vApp properties exist, leads to this exception:

```
fatal: [test-host -> localhost]: FAILED! =>
changed: false
module_stderr: |-
    Traceback (most recent call last):
      File "/Users/xxx/.ansible/tmp/ansible-tmp-1729754011.0982752-47065-171137552843633/AnsiballZ_vmware_guest.py", line 107, in <module>
        _ansiballz_main()
      File "/Users/xxx/.ansible/tmp/ansible-tmp-1729754011.0982752-47065-171137552843633/AnsiballZ_vmware_guest.py", line 99, in _ansiballz_main
        invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
      File "/Users/xxx/.ansible/tmp/ansible-tmp-1729754011.0982752-47065-171137552843633/AnsiballZ_vmware_guest.py", line 47, in invoke_module
        runpy.run_module(mod_name='ansible_collections.community.vmware.plugins.modules.vmware_guest', init_globals=dict(_module_fqn='ansible_collections.community.vmware.plugins.modules.vmware_guest', _modlib_path=modlib_path),
      File "<frozen runpy>", line 226, in run_module
      File "<frozen runpy>", line 98, in _run_module_code
      File "<frozen runpy>", line 88, in _run_code
      File "/var/folders/lb/q308qwkx1gggdlfxx_xqj9n00000gq/T/ansible_community.vmware.vmware_guest_payload_zwjpusr8/ansible_community.vmware.vmware_guest_payload.zip/ansible_collections/community/vmware/plugins/modules/vmware_guest.py", line 3640, in <module>
      File "/var/folders/lb/q308qwkx1gggdlfxx_xqj9n00000gq/T/ansible_community.vmware.vmware_guest_payload_zwjpusr8/ansible_community.vmware.vmware_guest_payload.zip/ansible_collections/community/vmware/plugins/modules/vmware_guest.py", line 3579, in main
      File "/var/folders/lb/q308qwkx1gggdlfxx_xqj9n00000gq/T/ansible_community.vmware.vmware_guest_payload_zwjpusr8/ansible_community.vmware.vmware_guest_payload.zip/ansible_collections/community/vmware/plugins/modules/vmware_guest.py", line 3195, in reconfigure_vm
      File "/var/folders/lb/q308qwkx1gggdlfxx_xqj9n00000gq/T/ansible_community.vmware.vmware_guest_payload_zwjpusr8/ansible_community.vmware.vmware_guest_payload.zip/ansible_collections/community/vmware/plugins/modules/vmware_guest.py", line 2071, in configure_vapp_properties
    AttributeError: 'NoneType' object has no attribute 'property'
module_stdout: ''
msg: |-
    MODULE FAILURE
    See stdout/stderr for the exact error
rc: 1
```

With the fix from this commit applied, the situation where `vAppConfig` equals None is gracefully handled and the vApp properties can be successfully set.