### PR TITLE
Install vmware.vmware>=1.6.0 for docs linting

### DIFF
--- a/.github/workflows/extra-docs-linting.yml
+++ b/.github/workflows/extra-docs-linting.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install dependent collections
         run: >
           ansible-galaxy collection install
-          vmware.vmware
+          vmware.vmware>=1.6.0
 
       - name: Run collection docs linter
         run: antsibull-docs lint-collection-docs . --plugin-docs --skip-rstcheck


### PR DESCRIPTION
##### SUMMARY
Follow-up to #2219

Install `vmware.vmware` >= 1.6.0 for docs linting / checks.

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request

##### ADDITIONAL INFORMATION
#2217
#2218
ansible-collections/collection_template#82