### PR TITLE
stable-4.x: Deprecate vmware_cluster_drs_recommendations

### DIFF
--- a/changelogs/fragments/2218-deprecate-vmware_cluster_drs_recommendations.yml
+++ b/changelogs/fragments/2218-deprecate-vmware_cluster_drs_recommendations.yml
@@ -1,0 +1,3 @@
+deprecated_features:
+  - vmware_cluster_drs_recommendations - the module has been deprecated and will be removed in community.vmware 6.0.0
+    (https://github.com/ansible-collections/community.vmware/pull/2218).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -192,6 +192,10 @@ plugin_routing:
       deprecation:
         removal_version: 6.0.0
         warning_text: Use vmware.vmware.cluster_drs instead.
+    vmware_cluster_drs_recommendations:
+      deprecation:
+        removal_version: 6.0.0
+        warning_text: Use vmware.vmware.cluster_drs_recommendations instead.
     vmware_cluster_vcls:
       deprecation:
         removal_version: 6.0.0

--- a/plugins/modules/vmware_cluster_drs_recommendations.py
+++ b/plugins/modules/vmware_cluster_drs_recommendations.py
@@ -18,6 +18,10 @@ description:
     - Apply DRS Recommendations for Cluster.
 author:
 - Nina Loser (@Nina2244)
+deprecated:
+  removed_in: 6.0.0
+  why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+  alternative: Use M(vmware.vmware.cluster_drs_recommendations) instead.
 options:
     cluster_name:
       description:


### PR DESCRIPTION
Backport of #2218

##### SUMMARY
Deprecate `community.vmware.vmware_cluster_drs_recommendations` in favor of `vmware.vmware.cluster_drs_recommendations`.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_cluster_drs_recommendations

##### ADDITIONAL INFORMATION
ansible-collections/vmware.vmware#70