### PR TITLE
Add a VM DRS Override module

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -40,6 +40,7 @@ action_groups:
   - vmware_drs_group
   - vmware_drs_group_info
   - vmware_drs_group_manager
+  - vmware_drs_override
   - vmware_drs_rule_info
   - vmware_dvs_host
   - vmware_dvs_portgroup

--- a/plugins/modules/vmware_drs_override.py
+++ b/plugins/modules/vmware_drs_override.py
@@ -1,0 +1,156 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+DOCUMENTATION = '''
+---
+module: vmware_drs_override
+short_description: Configure DRS behavior for a specific VM in vSphere
+description:
+    - This module allows setting a DRS behavior override for individual VMs within a DRS-enabled VMware vSphere cluster.
+options:
+    hostname:
+        description:
+            - The hostname or IP address of the vCenter server.
+        required: true
+        type: str
+    username:
+        description:
+            - The username for vCenter authentication.
+        required: true
+        type: str
+    password:
+        description:
+            - The password for vCenter authentication.
+        required: true
+        type: str
+    port:
+        description:
+            - The port number for the vCenter server.
+        required: false
+        type: int
+        default: 443
+    validate_certs:
+        description:
+            - If C(false), SSL certificates will not be validated.
+        type: bool
+        default: False
+    vm_name:
+        description:
+            - Name of the VM for which the DRS override is set.
+        required: true
+        type: str
+    drs_behavior:
+        description:
+            - Desired DRS behavior for the VM.
+        choices: ['manual', 'partiallyAutomated', 'fullyAutomated']
+        default: 'manual'
+        type: str
+author:
+    - Your Name (@your_github_username)
+'''
+
+EXAMPLES = '''
+- name: Set DRS behavior for a VM
+  vmware_drs_override:
+    hostname: "vcenter.example.com"
+    username: "administrator@vsphere.local"
+    password: "yourpassword"
+    port: 443
+    validate_certs: False
+    vm_name: "my_vm_name"
+    drs_behavior: "manual"
+'''
+
+RETURN = '''
+changed:
+    description: Whether the DRS behavior was changed.
+    type: bool
+    returned: always
+msg:
+    description: A message describing the outcome of the task.
+    type: str
+    returned: always
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.community.vmware.plugins.module_utils.vmware import (
+    PyVmomi,
+    connect_to_api,
+    vmware_argument_spec,
+)
+from pyVmomi import vim, vmodl
+
+
+class VmwareDrsOverride(PyVmomi):
+    def __init__(self, module):
+        super(VmwareDrsOverride, self).__init__(module)
+        self.module = module
+        self.vm_name = module.params['vm_name']
+        self.drs_behavior = module.params['drs_behavior']
+        self.content = self.si.RetrieveContent()
+
+    def get_vm_by_name(self):
+        obj_view = self.content.viewManager.CreateContainerView(self.content.rootFolder, [vim.VirtualMachine], True)
+        for vm in obj_view.view:
+            if vm.name == self.vm_name:
+                obj_view.Destroy()
+                return vm
+        obj_view.Destroy()
+        self.module.fail_json(msg="VM '%s' not found." % self.vm_name)
+
+    def set_drs_override(self):
+        vm = self.get_vm_by_name()
+        cluster = vm.runtime.host.parent
+
+        # Check current DRS settings
+        existing_config = next((config for config in cluster.configuration.drsVmConfig if config.key == vm), None)
+        if existing_config and existing_config.behavior == self.drs_behavior:
+            self.module.exit_json(changed=False, msg="DRS behavior is already set to the desired state.")
+
+        # Create DRS VM config spec
+        drs_vm_config_spec = vim.cluster.DrsVmConfigSpec(
+            operation='add',
+            info=vim.cluster.DrsVmConfigInfo(
+                key=vm,
+                enabled=True,
+                behavior=self.drs_behavior
+            )
+        )
+
+        # Apply the cluster reconfiguration
+        cluster_config_spec = vim.cluster.ConfigSpec()
+        cluster_config_spec.drsVmConfigSpec = [drs_vm_config_spec]
+        try:
+            task = cluster.ReconfigureCluster_Task(spec=cluster_config_spec)
+            self.wait_for_task(task)
+            self.module.exit_json(changed=True, msg="DRS override applied successfully.")
+        except vmodl.MethodFault as error:
+            self.module.fail_json(msg="Failed to set DRS override: %s" % error.msg)
+
+    def wait_for_task(self, task):
+        while task.info.state == vim.TaskInfo.State.running:
+            pass
+        if task.info.state == vim.TaskInfo.State.success:
+            return task.info.result
+        else:
+            raise Exception("Task failed: %s" % task.info.error.localizedMessage)
+
+
+def main():
+    argument_spec = vmware_argument_spec()
+    argument_spec.update(dict(
+        vm_name=dict(type='str', required=True),
+        drs_behavior=dict(type='str', choices=['manual', 'partiallyAutomated', 'fullyAutomated'], default='manual')
+    ))
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True
+    )
+
+    drs_override = VmwareDrsOverride(module)
+    drs_override.set_drs_override()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Here’s a template for your pull request (PR) submission:

---

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR contains a new Ansible module, `vmware_drs_override`, to the `community.vmware` collection. The module allows users to configure Distributed Resource Scheduler (DRS) behavior overrides for individual VMs within a VMware vSphere cluster. This provides users with enhanced control over VM placement, resource allocation, and automation behavior by enabling DRS settings specific to each VM rather than relying solely on cluster-wide configurations.

Key design decisions include:
- Encapsulating functionality in a class to streamline the connection, VM lookup, and DRS configuration processes.
- Ensuring the module aligns with other `community.vmware` modules in terms of structure, error handling, and documentation.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

This PR does not fix a pre-existing issue but adds new functionality to enhance VMware DRS management in the `community.vmware` collection.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task, or feature below -->

`vmware_drs_override`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

The `vmware_drs_override` module provides the following parameters:
- `hostname`, `username`, `password`, and `port` for vCenter server access.
- `validate_certs` to handle SSL verification.
- `vm_name` and `drs_behavior` to specify the VM and desired DRS configuration (options include `manual`, `partiallyAutomated`, and `fullyAutomated`).

This module was tested using a local vCenter environment to verify correct DRS behavior application and task handling. Example playbook and command output are provided below to demonstrate module functionality.

<!--- Paste verbatim command output below, e.g., before and after your change -->
```yaml
# Example playbook:
- name: Test VMware DRS Override Module
  hosts: localhost
  gather_facts: false
  tasks:
    - name: Apply DRS override to VM
      community.vmware.vmware_drs_override:
        hostname: "vcenter.example.com"
        username: "administrator@vsphere.local"
        password: "yourpassword"
        port: 443
        validate_certs: False
        vm_name: "my_vm_name"
        drs_behavior: "manual"
      register: result

    - name: Show Result
      debug:
        var: result
```