### PR TITLE
vmware_guest_info - Make "datacenter" property optional

### DIFF
--- a/changelogs/fragments/2241-vmware_guest_info-make-datacenter-property-optional.yaml
+++ b/changelogs/fragments/2241-vmware_guest_info-make-datacenter-property-optional.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+  - vmware_guest_info - `datacenter` property is now optional as it only required in cases where the VM is not uniquely identified by `name`.
+  - vmware.py - Add logic for handling the case where the `datacenter` property is not provided.

--- a/plugins/module_utils/vmware.py
+++ b/plugins/module_utils/vmware.py
@@ -1228,7 +1228,7 @@ class PyVmomi(object):
                 # We have found multiple virtual machines, decide depending upon folder value
                 if self.params['folder'] is None or self.params['datacenter'] is None:
                     self.module.fail_json(msg="Multiple virtual machines with same name [%s] found, "
-                                          "Folder and datacenter values are required parameters to find uniqueness "
+                                          "try to specify folder and / or datacenter to ensure uniqueness "
                                           "of the virtual machine" % self.params['name'],
                                           details="Please see documentation of the vmware_guest module "
                                           "for folder parameter.")

--- a/plugins/module_utils/vmware.py
+++ b/plugins/module_utils/vmware.py
@@ -1226,9 +1226,9 @@ class PyVmomi(object):
             # following code tries to find user desired one depending upon the folder specified.
             if len(vms) > 1:
                 # We have found multiple virtual machines, decide depending upon folder value
-                if self.params['folder'] is None:
+                if self.params['folder'] is None or self.params['datacenter'] is None:
                     self.module.fail_json(msg="Multiple virtual machines with same name [%s] found, "
-                                          "Folder value is a required parameter to find uniqueness "
+                                          "Folder and datacenter values are required parameters to find uniqueness "
                                           "of the virtual machine" % self.params['name'],
                                           details="Please see documentation of the vmware_guest module "
                                           "for folder parameter.")

--- a/plugins/modules/vmware_guest_info.py
+++ b/plugins/modules/vmware_guest_info.py
@@ -262,7 +262,7 @@ def main():
         use_instance_uuid=dict(type='bool', default=False),
         moid=dict(type='str'),
         folder=dict(type='str'),
-        datacenter=dict(type='str', required=True),
+        datacenter=dict(type='str'),
         tags=dict(type='bool', default=False),
         schema=dict(type='str', choices=['summary', 'vsphere'], default='summary'),
         properties=dict(type='list', elements='str'),

--- a/plugins/modules/vmware_guest_info.py
+++ b/plugins/modules/vmware_guest_info.py
@@ -48,7 +48,7 @@ options:
    folder:
      description:
      - Destination folder, absolute or relative path to find an existing guest.
-     - This is required if O(name) is supplied.
+     - This is required if O(name) is supplied and not unique.
      - The folder should include the datacenter. ESX's datacenter is ha-datacenter
      - 'Examples:'
      - '   folder: /ha-datacenter/vm'
@@ -64,7 +64,8 @@ options:
    datacenter:
      description:
      - Destination datacenter for the deploy operation
-     required: true
+     - This is required if O(name) is supplied and not unique.
+     required: false
      type: str
    tags:
      description:

--- a/tests/integration/targets/vmware_vmotion/tasks/main.yml
+++ b/tests/integration/targets/vmware_vmotion/tasks/main.yml
@@ -17,30 +17,30 @@
     esxi_password: '{{ esxi_password }}'
     folder: '/DC0/host'
     state: present
-  with_items: "{{ esxi_hosts }}"
+  with_items: '{{ esxi_hosts }}'
 
 - name: Disable the Maintenance Mode
   vmware_maintenancemode:
     esxi_hostname: '{{ item }}'
     state: absent
-  with_items: "{{ esxi_hosts }}"
+  with_items: '{{ esxi_hosts }}'
 
 - name: Create VM
   vmware_guest:
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    datacenter: "{{ dc1 }}"
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    datacenter: '{{ dc1 }}'
     validate_certs: false
     name: test_vm1
     folder: vm
-    esxi_hostname: "{{ esxi1 }}"
+    esxi_hostname: '{{ esxi1 }}'
     state: present
     guest_id: debian8_64Guest
     disk:
-    - size_gb: 1
-      type: thin
-      datastore: '{{ rw_datastore }}'
+      - size_gb: 1
+        type: thin
+        datastore: '{{ rw_datastore }}'
     hardware:
       version: 11
       memory_mb: 1024
@@ -62,8 +62,7 @@
 
 - assert:
     that:
-        - vm_vmotion.msg == "Failed to find the virtual machine with not_a_thing"
-
+      - vm_vmotion.msg == "Failed to find the virtual machine with not_a_thing"
 
 - name: Perform vMotion of virtual machine
   vmware_vmotion:
@@ -79,8 +78,7 @@
 - name: assert that changes were made
   assert:
     that:
-        - vm_vmotion is changed
-
+      - vm_vmotion is changed
 
 - name: Add ESXi Hosts to a cluster
   vmware_host:
@@ -90,13 +88,13 @@
     esxi_username: '{{ esxi_user }}'
     esxi_password: '{{ esxi_password }}'
     state: present
-  with_items: "{{ esxi_hosts }}"
+  with_items: '{{ esxi_hosts }}'
 
 - name: Disable the Maintenance Mode
   vmware_maintenancemode:
     esxi_hostname: '{{ item }}'
     state: absent
-  with_items: "{{ esxi_hosts }}"
+  with_items: '{{ esxi_hosts }}'
 
 - name: Perform vMotion of virtual machine to resource_pool
   vmware_vmotion:
@@ -112,7 +110,7 @@
 - name: assert that changes were made
   assert:
     that:
-        - vm_vmotion_to_rp is changed
+      - vm_vmotion_to_rp is changed
 
 - name: Perform storage vMotion of virtual machine
   vmware_vmotion:
@@ -128,4 +126,4 @@
 - name: assert that changes were made
   assert:
     that:
-        - vm_vmotion_to_datastore is changed
+      - vm_vmotion_to_datastore is changed


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
We run a big VMware environment featuring multiple vCenters and multiple datacenters within them.
When automating the deployment of VMs at the moment we search for existing machines with the name of the to be deployed machine in order to perform clean-up activities. At the moment we use the guest find module, but it's slow.
Therefore we looked into the guest_info module and found that if the VM is unique, the datacenter property is never actually used as it is only relevant in case multiple VMs have been found.

In case multiple VMs are found, the folder and datacenter attributes are used to decide on "the right one".
Therefore, the datacenter property could as well be an optional parameter on the module and it could simply fail in case there is more than one VM matching and "datacenter" as well as "folder" are required.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
- vmware_guest_info.py
- vmware.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
