### PR TITLE
vmware_guest_tools_upgrade: All possible tools status

### DIFF
--- a/changelogs/fragments/2237-vmware_guest_tools_upgrade.yml
+++ b/changelogs/fragments/2237-vmware_guest_tools_upgrade.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_guest_tools_upgrade - Account for all possible tools status (https://github.com/ansible-collections/community.vmware/issues/2237).


### PR DESCRIPTION
##### SUMMARY
Fixes #2237

Account for all possible [status](https://dp-downloads.broadcom.com/api-content/apis/API_VWSA_001/8.0U3/html/ReferenceGuides/vim.vm.GuestInfo.ToolsVersionStatus.html):

- guestToolsBlacklisted
- guestToolsCurrent
- guestToolsNeedUpgrade
- guestToolsNotInstalled
- guestToolsSupportedNew
- guestToolsSupportedOld
- guestToolsTooNew
- guestToolsTooOld
- guestToolsUnmanaged

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_guest_tools_upgrade

##### ADDITIONAL INFORMATION
https://forum.ansible.com/t/10684