### PR TITLE
stable-4.x: Fix disk creation 'invalid configuration for device' error

### DIFF
--- a/changelogs/fragments/2009-fix-disk-add-failing-with-invalid-configuration-for-device.yml
+++ b/changelogs/fragments/2009-fix-disk-add-failing-with-invalid-configuration-for-device.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - vm_device_helper - Fix 'invalid configuration for device' error caused by missing fileoperation parameter.
+    (https://github.com/ansible-collections/community.vmware/pull/2009).

--- a/plugins/module_utils/vm_device_helper.py
+++ b/plugins/module_utils/vm_device_helper.py
@@ -253,6 +253,7 @@ class PyVmomiDeviceHelper(object):
     def create_hard_disk(self, disk_ctl, disk_index=None):
         diskspec = vim.vm.device.VirtualDeviceSpec()
         diskspec.operation = vim.vm.device.VirtualDeviceSpec.Operation.add
+        diskspec.fileOperation = vim.vm.device.VirtualDeviceSpec.FileOperation.create
         diskspec.device = vim.vm.device.VirtualDisk()
         diskspec.device.key = -randint(20000, 24999)
         diskspec.device.backing = vim.vm.device.VirtualDisk.FlatVer2BackingInfo()


### PR DESCRIPTION
Backport #2009

##### SUMMARY
Under some circumstances, disk creation fails with an `invalid configuration for device` error.
Once this error shows up for a VM, it persistently happens whenever trying to add disks, however, I do not know how to make it show up for a VM, sometimes it is just there. 

In comparing the API calls done by VCenter (which works) and ansible (which fails with the error above), I noticed that VCenter sets `fileOperation` to `create`. Setting this in ansible, as done in this patch, fixes the disk creation in ansible.

The [docs](https://vdc-repo.vmware.com/vmwb-repository/dcr-public/dce91b06-cc93-42d6-b277-78fb13a16d6e/7d3494a5-bca7-400f-a18f-f539787ec798/vim.vm.device.VirtualDeviceSpec.html#field_detail) describe the `fileOperation` parameter like this: 

> Type of operation being performed on the backing of the specified virtual device. If no file operation is specified in the [VirtualDevice](https://vdc-repo.vmware.com/vmwb-repository/dcr-public/dce91b06-cc93-42d6-b277-78fb13a16d6e/7d3494a5-bca7-400f-a18f-f539787ec798/vim.vm.device.VirtualDevice.html)Spec, then any backing filenames in the VirtualDevice must refer to files that already exist. The "replace" and "delete" values for this property are only applicable to virtual disk backing files.

So it really **must**  be set when the backing file does not exist, (which it ofc doesn't when creating a disk).  

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vm_device_helper