### PR TITLE
Update vmware.vmware dependency

### DIFF
--- a/.github/workflows/extra-docs-linting.yml
+++ b/.github/workflows/extra-docs-linting.yml
@@ -31,10 +31,5 @@ jobs:
       - name: Install antsibull-docs
         run: pip install antsibull-docs --disable-pip-version-check
 
-      - name: Install dependent collections
-        run: >
-          ansible-galaxy collection install
-          'vmware.vmware>=1.6.0'
-
       - name: Run collection docs linter
         run: antsibull-docs lint-collection-docs . --plugin-docs --skip-rstcheck

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -18,7 +18,7 @@ tags:
   - vmware
   - virtualization
 dependencies:
-  vmware.vmware: ">=1.5.0,<2.0.0"
+  vmware.vmware: ">=1.6.0,<2.0.0"
 repository: https://github.com/ansible-collections/community.vmware.git
 homepage: https://github.com/ansible-collections/community.vmware
 issues: https://github.com/ansible-collections/community.vmware/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc


### PR DESCRIPTION
##### SUMMARY
I think (actually: hope) we don't have to install `vmware.vmware>=1.6.0` in `.github/workflows/extra-docs-linting.yml` to make the workflow succeed if we define this in `galaxy.yml`.

Since I'm updating the requirement to a newer minor but not _major_ version, I think this isn't a breaking change.

##### ISSUE TYPE
- Feature Pull Request

##### ADDITIONAL INFORMATION
#2219
#2221
#2222