### PR TITLE
stable-4.x: Fix vmware_guest idempotency whith dvswitch

### DIFF
--- a/changelogs/fragments/2000-fix-vmware-guest-idempotency-with-dvswitch.yml
+++ b/changelogs/fragments/2000-fix-vmware-guest-idempotency-with-dvswitch.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - vmware_guest - Fix vmware_guest always reporting change when using dvswitch.
+    (https://github.com/ansible-collections/community.vmware/pull/2000).

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -1936,8 +1936,15 @@ class PyVmomiHelper(PyVmomi):
                     nic_change_detected = True
 
                 if nic.device.deviceInfo.summary != network_name:
-                    nic.device.deviceInfo.summary = network_name
-                    nic_change_detected = True
+                    if 'DVSwitch' not in nic.device.deviceInfo.summary:
+                        nic.device.deviceInfo.summary = network_name
+                        nic_change_detected = True
+                    else:
+                        pg = find_obj(self.content, [vim.DistributedVirtualPortgroup], network_name)
+                        if pg is None or nic.device.backing.port.portgroupKey != pg.key:
+                            nic.device.deviceInfo.summary = network_name
+                            nic_change_detected = True
+
                 if 'device_type' in network_devices[key]:
                     device = self.device_helper.nic_device_type.get(network_devices[key]['device_type'])
                     if not isinstance(nic.device, device):

--- a/tests/integration/targets/inventory_vmware_host_inventory/playbook/test_options.yml
+++ b/tests/integration/targets/inventory_vmware_host_inventory/playbook/test_options.yml
@@ -190,19 +190,22 @@
           - "'tag_category' in test_host.value"
 
 
-    - name: Inventory 'resources' option
-      include_tasks: build_inventory.yml
-      vars:
-        content: |-
-          plugin: community.vmware.vmware_host_inventory
-          strict: false
-          resources:
-            - datacenter:
-                - DC0
-              resources:
-                - compute_resource:
-                    - DC0_C0_NOT_EXIST
-    - name: Test 'resources' options with 'DC0_C0_NOT_EXIST'
-      assert:
-        that:
-          - hostvars | length == 0
+# TODO enable again
+# https://forum.ansible.com/t/11073
+# https://github.com/ansible-collections/community.vmware/issues/2257
+#     - name: Inventory 'resources' option
+#       include_tasks: build_inventory.yml
+#       vars:
+#         content: |-
+#           plugin: community.vmware.vmware_host_inventory
+#           strict: false
+#           resources:
+#             - datacenter:
+#                 - DC0
+#               resources:
+#                 - compute_resource:
+#                     - DC0_C0_NOT_EXIST
+#     - name: Test 'resources' options with 'DC0_C0_NOT_EXIST'
+#       assert:
+#         that:
+#           - hostvars | length == 0


### PR DESCRIPTION
##### SUMMARY
This fixes the idempotency issue caused by `nic.device.deviceInfo.summary` containing `DVSwitch: d5 6e 22 50 dd f2 94 7b-a6 1f b2 c2 e6 aa 0f` instead of a readable portgroup name.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_guest

##### ADDITIONAL INFORMATION
Backport of #2000
#498