### PR TITLE
prepare 5.3.0 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,14 @@ community.vmware Release Notes
 
 This changelog describes changes after version 4.7.0.
 
+v5.3.0
+======
+
+Deprecated Features
+-------------------
+
+- vmware_cluster_info - the module has been deprecated and will be removed in community.vmware 7.0.0 (https://github.com/ansible-collections/community.vmware/pull/2260).
+
 v5.2.0
 ======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -103,3 +103,11 @@ releases:
       name: vmware_drs_override
       namespace: ''
     release_date: '2024-11-30'
+  5.3.0:
+    changes:
+      deprecated_features:
+      - vmware_cluster_info - the module has been deprecated and will be removed in
+        community.vmware 7.0.0 (https://github.com/ansible-collections/community.vmware/pull/2260).
+    fragments:
+    - 2260-deprecate-vmware_cluster_info.yml
+    release_date: '2024-12-03'

--- a/changelogs/fragments/2260-deprecate-vmware_cluster_info.yml
+++ b/changelogs/fragments/2260-deprecate-vmware_cluster_info.yml
@@ -1,3 +1,0 @@
-deprecated_features:
-  - vmware_cluster_info - the module has been deprecated and will be removed in community.vmware 7.0.0
-    (https://github.com/ansible-collections/community.vmware/pull/2260).

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -5,7 +5,7 @@ name: vmware
 # https://github.com/ansible-network/releases/tree/master/ansible_releases/cmd
 # A script based on https://pypi.org/project/pbr/ will generate the version
 # key. The version value depends on the tag or the last git tag.
-version: null
+version: 5.3.0
 readme: README.md
 authors:
   - Ansible (https://github.com/ansible)

--- a/plugins/modules/vmware_guest_sendkey.py
+++ b/plugins/modules/vmware_guest_sendkey.py
@@ -389,6 +389,9 @@ def main():
         ]
     )
 
+    if module.params['folder']:
+        module.params['folder'] = module.params['folder'].rstrip('/')
+
     pyv = PyVmomiHelper(module)
     vm = pyv.get_vm()
     if not vm:


### PR DESCRIPTION
##### SUMMARY
Here is a little change to address an error while performing the `sendkeys` module and including a leading slash in the `folder` option. It results as the module not being able to fetch the machine name, hence stopping the playbook and throwing an error instead.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_guest_sendkey

##### ADDITIONAL INFORMATION
To reproduce the issue, try executing the vmware_guest_sendkey module and including a folder with a leading slash. It throws an error.
Remove the leading slash to fix it.