### PR TITLE
Fixing issue on changing "disk_mode" #2096

### DIFF
--- a/plugins/modules/vmware_guest_disk.py
+++ b/plugins/modules/vmware_guest_disk.py
@@ -745,6 +745,14 @@ class PyVmomiHelper(PyVmomi):
                                             disk_spec = self.get_ioandshares_diskconfig(disk_spec, disk)
                                         disk_spec.device.capacityInKB = disk['size']
                                         disk_change = True
+                                
+                                # If disk is not vpmem we check if there is a change in disk mode
+                                if disk['disk_type'] != 'vpmemdisk' and disk['disk_mode'] != disk_spec.device.backing.diskMode:
+                                    # set the operation to edit so that it knows to keep other settings
+                                    disk_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.edit
+                                    disk_spec = self.get_ioandshares_diskconfig(disk_spec, disk)
+                                    disk_spec.device.backing.diskMode = disk['disk_mode']
+                                    disk_change = True
 
                                 if disk_change:
                                     self.config_spec.deviceChange.append(disk_spec)


### PR DESCRIPTION
##### SUMMARY
Fixing issue on changing "disk_mode" #2096. 
As reported in the issue trying to change the disk_mode on an existing vm disk. If the disk is "independent_persistent" and I want to change it to "persistent" no change will be made. Other combinations also won't work.

I edited the vmware_guest_disk.py for including the disk_mode change in the VM reconfiguration if the disk_mode parameter is changing from the existing one.




##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
community.vmware.vmware_guest_disk

##### ADDITIONAL INFORMATION
Please note I've just made a small change that still requires you to pass to the module at least the following information:

```---
- name: VMware Change Disk Mode
  hosts: localhost
  tasks:
  - name: Change disk mode for virtual machine using name
    community.vmware.vmware_guest_disk:
      hostname: "{{ vcenter_hostname }}"
      username: "{{ vcenter_username }}"
      password: "{{ vcenter_password }}"
      datacenter: "{{ vcenter_dc }}"
      name: "{{ vm_name }}"
      validate_certs: false
      disk:
        - controller_number: "{{ vm_disk_controller_number }}"
          unit_number: "{{ vm_disk_unit_number }}"
          disk_mode: "persistent" 
          size_kb: "{{ vm_disk_size_kb }}"
    delegate_to: localhost
    register: disk_facts

```

```
