### PR TITLE
Update vmware_guest.py docs

### DIFF
--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -526,13 +526,13 @@ options:
             type: str
             description:
             - Name of the portgroup or distributed virtual portgroup for this interface.
-            - Required per entry.
+            - Optional per entry.
             - When specifying distributed virtual portgroup make sure given O(esxi_hostname) or O(cluster) is associated with it.
         vlan:
             type: int
             description:
             - VLAN number for this interface.
-            - Required per entry.
+            - Optional per entry.
         device_type:
             type: str
             description:

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -532,7 +532,7 @@ options:
             type: int
             description:
             - VLAN number for this interface.
-            - Optional per entry.
+            - This is required if C(name) isn't defined.
         device_type:
             type: str
             description:

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -526,7 +526,7 @@ options:
             type: str
             description:
             - Name of the portgroup or distributed virtual portgroup for this interface.
-            - Optional per entry.
+            - This is required if C(vlan) isn't defined.
             - When specifying distributed virtual portgroup make sure given O(esxi_hostname) or O(cluster) is associated with it.
         vlan:
             type: int


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
None of `name` or `vlan` is in fact required. For correct operation either one can be specified.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_guest

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
This cost us about 2 hours of debugging because we thought that vlan is required. When we specified both name and vlan, another network was picked than we specified in name because vlan takes precedence and there was another network available with the same vlan id.
This PR might be worth backporting to all version where this applies.

Relevant code section:
https://github.com/ansible-collections/community.vmware/blob/e249a03c08c30458643e12a7a06c13692bef7a7c/plugins/modules/vmware_guest.py#L1811-L1812

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
