### PR TITLE
vmware_guest speedup module

### DIFF
--- a/changelogs/fragments/2278-vmware_guest.yml
+++ b/changelogs/fragments/2278-vmware_guest.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - vmware_guest - Speedup network search
+    (https://github.com/ansible-collections/community.vmware/pull/2278).

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -1126,7 +1126,7 @@ from ansible_collections.community.vmware.plugins.module_utils.vm_device_helper 
 from ansible_collections.community.vmware.plugins.module_utils.vmware_spbm import SPBM
 
 
-class PyVmomiCache(object):
+class PyVmomiCache(PyVmomi):
     """ This class caches references to objects which are requested multiples times but not modified """
 
     def __init__(self, content, dc_name=None):
@@ -1166,13 +1166,17 @@ class PyVmomiCache(object):
 
         return objects
 
-    def get_network(self, network):
-        network = quote_obj_name(network)
+    def get_network(self, network_name):
+        network_name = quote_obj_name(network_name)
 
-        if network not in self.networks:
-            self.networks[network] = self.find_obj(self.content, [vim.Network], network)
+        if network_name not in self.networks:
+            networks = self.find_network_by_name(network_name)
+            if len(networks) == 1:
+                self.networks[network_name] = networks[0]
+            else:
+                self.networks[network_name] = self.find_obj(self.content, [vim.Network], network_name)
 
-        return self.networks[network]
+        return self.networks[network_name]
 
     def get_cluster(self, cluster):
         if cluster not in self.clusters:
@@ -1978,7 +1982,11 @@ class PyVmomiHelper(PyVmomi):
                     if pg_obj is None:
                         self.module.fail_json(msg="Unable to find distributed port group %s" % network_name)
                 else:
-                    pg_obj = self.cache.find_obj(self.content, [vim.dvs.DistributedVirtualPortgroup], network_name)
+                    networks = self.find_network_by_name(network_name)
+                    if len(networks) == 1:
+                        pg_obj = networks[0]
+                    else:
+                        pg_obj = self.cache.find_obj(self.content, [vim.dvs.DistributedVirtualPortgroup], network_name)
 
                 # TODO: (akasurde) There is no way to find association between resource pool and distributed virtual portgroup
                 # For now, check if we are able to find distributed virtual switch

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -1944,7 +1944,11 @@ class PyVmomiHelper(PyVmomi):
                         nic.device.deviceInfo.summary = network_name
                         nic_change_detected = True
                     else:
-                        pg = find_obj(self.content, [vim.DistributedVirtualPortgroup], network_name)
+                        pgs = self.find_network_by_name(network_name)
+                        if len(pgs) == 1:
+                            pg = pgs[0]
+                        else:
+                            pg = find_obj(self.content, [vim.DistributedVirtualPortgroup], network_name)
                         if pg is None or nic.device.backing.port.portgroupKey != pg.key:
                             nic.device.deviceInfo.summary = network_name
                             nic_change_detected = True


### PR DESCRIPTION
##### SUMMARY
Speedup network search while creating VM using vmware_guest. 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_guest.py

##### ADDITIONAL INFORMATION

vmware_guest network search is slow. It use find_obj() from vmware.py that loop through all objects trying to find correct. I have a lag for 5 mins trying. PyVmomi.network_exists_by_name works much faster.