### PR TITLE
vmware_vmkernel: Improve documentation

### DIFF
--- a/plugins/modules/vmware_vmkernel.py
+++ b/plugins/modules/vmware_vmkernel.py
@@ -65,16 +65,16 @@ options:
         ip_address:
             type: str
             description:
-            - Static IP address.
-            - Required if O(network.type=static).
+            - Static IPv4 address.
+            - Required if O(network.type=static) and O(state=present).
         subnet_mask:
             type: str
             description:
-            - Static netmask required.
-            - Required if O(network.type=static).
+            - Static IPv4 netmask.
+            - Required if O(network.type=static) and O(state=present).
         default_gateway:
             type: str
-            description: Default gateway (Override default gateway for this adapter).
+            description: Default IPv4 gateway (Override default gateway for this adapter).
         tcpip_stack:
             type: str
             description:


### PR DESCRIPTION
##### SUMMARY
Improving the documentation a bit:

1. The options dealing with IP stuff is about **IPv4**.
2. `ip_address` and `subnet_mask` aren't required if [state is absent](https://github.com/ansible-collections/community.vmware/blob/af13893a84614665f6a0b700a468f9b05948c539/plugins/modules/vmware_vmkernel.py#L327-L333).

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
vmware_vmkernel

##### ADDITIONAL INFORMATION
#1740
#2295