### PR TITLE
feat(vmware_guest_snapshot): make module compatible with ESXi hosts w…

### DIFF
--- a/plugins/modules/vmware_guest_snapshot.py
+++ b/plugins/modules/vmware_guest_snapshot.py
@@ -13,7 +13,7 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 ---
 module: vmware_guest_snapshot
-short_description: Manages virtual machines snapshots in vCenter
+short_description: Manages virtual machines snapshots
 description:
     - This module can be used to create, delete and update snapshot(s) of the given virtual machine.
 author:
@@ -78,7 +78,7 @@ options:
    datacenter:
      description:
      - Destination datacenter for the deploy operation.
-     required: true
+     required: false
      type: str
    snapshot_name:
      description:
@@ -444,7 +444,7 @@ def main():
         moid=dict(type='str'),
         use_instance_uuid=dict(type='bool', default=False),
         folder=dict(type='str'),
-        datacenter=dict(required=True, type='str'),
+        datacenter=dict(type='str'),
         snapshot_name=dict(type='str'),
         snapshot_id=dict(type='int'),
         description=dict(type='str', default=''),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Due to the current restriction that the `datacenter` paramter is required, the vmware_guest_snapshot module is not compatible with ESXi hosts without vCenter, even though ESXi with license also exposes this API. This PR removes the restriction of requiring the `datacenter` parameter and removes the vCenter part from the module description.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

vmware_guest_snapshot

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

This change was tested against an ESXi 7.0 Update 3 host (with license) without a vCenter.
