### PR TITLE
Deprecate host_version_at_least

### DIFF
--- a/changelogs/fragments/2303-deprecate-host_version_at_least.yml
+++ b/changelogs/fragments/2303-deprecate-host_version_at_least.yml
@@ -1,0 +1,3 @@
+deprecated_features:
+  - module_utils.vmware - host_version_at_least is deprecated and will be removed in community.vmware 7.0.0
+    (https://github.com/ansible-collections/community.vmware/pull/2303).


### PR DESCRIPTION
##### SUMMARY
There's a method `host_version_at_least`:

https://github.com/ansible-collections/community.vmware/blob/1fe4061bb83751d6221dd3dd3f37ae420da835cf/plugins/module_utils/vmware.py#L1453-L1473

It looks like the only place this is used is here:

https://github.com/ansible-collections/community.vmware/blob/1fe4061bb83751d6221dd3dd3f37ae420da835cf/plugins/modules/vmware_export_ovf.py#L247-L249

Since 6.7.0 is already EOL, I think we don't need this anymore and can remove it. But I think we should deprecate this first, just in case that someone uses this from the `vmware` module util.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware