### PR TITLE
Deprecate plugin_utils.inventory

### DIFF
--- a/changelogs/fragments/2304-deprecate-plugin_utils.yml
+++ b/changelogs/fragments/2304-deprecate-plugin_utils.yml
@@ -1,0 +1,3 @@
+deprecated_features:
+  - plugin_utils.inventory - this plugin util is deprecated and will be removed in community.vmware 7.0.0
+    (https://github.com/ansible-collections/community.vmware/pull/2304).


### PR DESCRIPTION
##### SUMMARY
Deeprecate the inventory plugins (#2283) means we can also get rid of `ansible_collections.community.vmware.plugins.plugin_utils.inventory` / `plugins/plugin_utils/inventory.py`.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugin_utils/inventory.py

##### ADDITIONAL INFORMATION
#2283