### PR TITLE
Deprecate plugins.httpapi

### DIFF
--- a/changelogs/fragments/2306-deprecate-plugins.httpapi.yml
+++ b/changelogs/fragments/2306-deprecate-plugins.httpapi.yml
@@ -1,0 +1,3 @@
+deprecated_features:
+  - plugins.httpapi - this is deprecated and will be removed in community.vmware 7.0.0
+    (https://github.com/ansible-collections/community.vmware/pull/2306).


### PR DESCRIPTION
##### SUMMARY
I think this isn't used anywhere in the collection. So let's deprecate and finally remove it.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/httpapi/

##### ADDITIONAL INFORMATION
#2305
