### PR TITLE
Deprecate unused methods / functions

### DIFF
--- a/changelogs/fragments/2311-deprecate-unsed-methods-and-functions.yml
+++ b/changelogs/fragments/2311-deprecate-unsed-methods-and-functions.yml
@@ -1,0 +1,15 @@
+deprecated_features:
+  - vmware_rest_client - get_folder_by_name is deprecated and will be removed in community.vmware 7.0.0
+    (https://github.com/ansible-collections/community.vmware/pull/2311).
+  - vm_device_helper.py - is_nvdimm_controller is deprecated and will be removed in community.vmware 7.0.0
+    (https://github.com/ansible-collections/community.vmware/pull/2311).
+  - vm_device_helper.py - is_nvdimm_device is deprecated and will be removed in community.vmware 7.0.0
+    (https://github.com/ansible-collections/community.vmware/pull/2311).
+  - vmware - find_host_portgroup_by_name is deprecated and will be removed in community.vmware 7.0.0
+    (https://github.com/ansible-collections/community.vmware/pull/2311).
+  - vmware - network_exists_by_name is deprecated and will be removed in community.vmware 7.0.0
+    (https://github.com/ansible-collections/community.vmware/pull/2311).
+  - vmware - vmdk_disk_path_split is deprecated and will be removed in community.vmware 7.0.0
+    (https://github.com/ansible-collections/community.vmware/pull/2311).
+  - vmware - find_vmdk_file is deprecated and will be removed in community.vmware 7.0.0
+    (https://github.com/ansible-collections/community.vmware/pull/2311).


### PR DESCRIPTION
##### SUMMARY
It looks like this stuff is defined bot not used anywhere:

```shell
~/github/community.vmware$ egrep -r '(is_nvdimm_controller|is_nvdimm_device|find_host_portgroup_by_name|find_host_portgroup_by_name|network_exists_by_name|vmdk_disk_path_split|find_vmdk_file|get_folder_by_name)' plugins/
plugins/module_utils/vmware_rest_client.py:    def get_folder_by_name(self, datacenter_name, folder_name):
plugins/module_utils/vm_device_helper.py:    def is_nvdimm_controller(device):
plugins/module_utils/vm_device_helper.py:    def is_nvdimm_device(device):
plugins/module_utils/vmware.py:def find_host_portgroup_by_name(host, portgroup_name):
plugins/module_utils/vmware.py:    def find_host_portgroup_by_name(host, portgroup_name):
plugins/module_utils/vmware.py:    def network_exists_by_name(self, network_name=None):
plugins/module_utils/vmware.py:    def vmdk_disk_path_split(self, vmdk_path):
plugins/module_utils/vmware.py:    def find_vmdk_file(self, datastore_obj, vmdk_fullpath, vmdk_filename, vmdk_folder):
~/github/community.vmware$
```

So let's simplify the code base by deprecating and finally removing this code.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/module_utils/vm_device_helper.py
plugins/module_utils/vmware.py
plugins/module_utils/vmware_rest_client.py

##### ADDITIONAL INFORMATION
#2308