### PR TITLE
vmware_guest: Add typev6 to 'networks' customization check

### DIFF
--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -3046,7 +3046,7 @@ class PyVmomiHelper(PyVmomi):
                 if key == 'type' and nw['type'] == 'dhcp':
                     network_changes = True
                     break
-                if key not in ('device_type', 'mac', 'name', 'vlan', 'type', 'start_connected', 'dvswitch_name'):
+                if key not in ('device_type', 'mac', 'name', 'vlan', 'type', 'typev6', 'start_connected', 'dvswitch_name'):
                     network_changes = True
                     break
 
@@ -3341,7 +3341,7 @@ class PyVmomiHelper(PyVmomi):
         for nw in self.params['networks']:
             for key in nw:
                 # We don't need customizations for these keys
-                if key not in ('device_type', 'mac', 'name', 'vlan', 'type', 'start_connected', 'dvswitch_name'):
+                if key not in ('device_type', 'mac', 'name', 'vlan', 'type', 'typev6', 'start_connected', 'dvswitch_name'):
                     network_changes = True
                     break
         if any(v is not None for v in self.params['customization'].values()) or network_changes or self.params.get('customization_spec'):


### PR DESCRIPTION
##### SUMMARY
The behaviour now is that this specific if-statement always hits because typev6 is missing from it and it's always added by default when you define "networks". This gives unexpected behaviour.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_guest

##### ADDITIONAL INFORMATION
E.g.
```
networks:
  - name: "PORTGROUP_NAME_XYZ"
```

From debug log:
```
"networks": [
  {
     "name": "PORTGROUP_NAME_XYZ",
     "type": "dhcp",
     "typev6": "dhcp"
  }
```