### PR TITLE
vmware_migrate_vmk: Inherit from PyVmomi

### DIFF
--- a/changelogs/fragments/2324-vmware_migrate_vmk.yml
+++ b/changelogs/fragments/2324-vmware_migrate_vmk.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_migrate_vmk - Inherit from / sub-class PyVmomi (https://github.com/ansible-collections/community.vmware/pull/2324).

--- a/plugins/modules/vmware_migrate_vmk.py
+++ b/plugins/modules/vmware_migrate_vmk.py
@@ -82,13 +82,13 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.vmware.plugins.module_utils.vmware import (
     vmware_argument_spec, find_dvs_by_name, find_hostsystem_by_name,
-    connect_to_api, find_dvspg_by_name)
+    PyVmomi, find_dvspg_by_name)
 
 
-class VMwareMigrateVmk(object):
+class VMwareMigrateVmk(PyVmomi):
 
     def __init__(self, module):
-        self.module = module
+        super(VMwareMigrateVmk, self).__init__(module)
         self.host_system = None
         self.migrate_switch_name = self.module.params['migrate_switch_name']
         self.migrate_portgroup_name = self.module.params['migrate_portgroup_name']
@@ -97,7 +97,6 @@ class VMwareMigrateVmk(object):
         self.esxi_hostname = self.module.params['esxi_hostname']
         self.current_portgroup_name = self.module.params['current_portgroup_name']
         self.current_switch_name = self.module.params['current_switch_name']
-        self.content = connect_to_api(module)
 
     def process_state(self):
         try:


### PR DESCRIPTION
##### SUMMARY
It feels wrong that this module uses `vmware.connect_to_api` directly. I think it would be better to inherit from / sub-class `PyVmomi`

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_migrate_vmk

##### ADDITIONAL INFORMATION
#2318