### PR TITLE
Don't test for vSphere < 7 anymore

### DIFF
--- a/changelogs/fragments/2326-drop-test-lt7.yml
+++ b/changelogs/fragments/2326-drop-test-lt7.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - vmware_category - Don't test for vSphere < 7 anymore (https://github.com/ansible-collections/community.vmware/pull/2326).
+  - vmware_vc_infraprofile_info - Don't test for vSphere < 7 anymore (https://github.com/ansible-collections/community.vmware/pull/2326).

--- a/plugins/modules/vmware_category.py
+++ b/plugins/modules/vmware_category.py
@@ -154,8 +154,6 @@ category_results:
 
 from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.compat.version import LooseVersion
-from ansible_collections.community.vmware.plugins.module_utils.vmware import connect_to_api
 from ansible_collections.community.vmware.plugins.module_utils.vmware_rest_client import VmwareRestClient
 
 try:
@@ -177,7 +175,6 @@ class VmwareCategory(VmwareRestClient):
         self.global_categories = dict()
         self.category_name = self.params.get('category_name')
         self.get_all_categories()
-        self.content = connect_to_api(self.module, return_si=False)
 
     def ensure_state(self):
         """Manage internal states of categories. """
@@ -236,9 +233,6 @@ class VmwareCategory(VmwareRestClient):
             for obj_type in associable_object_types:
                 lower_obj_type = obj_type.lower()
                 if lower_obj_type == 'all objects':
-                    if LooseVersion(self.content.about.version) < LooseVersion('7'):
-                        break
-
                     for category in list(associable_data.values()):
                         if isinstance(category, list):
                             obj_types_set.extend(category)

--- a/plugins/modules/vmware_vc_infraprofile_info.py
+++ b/plugins/modules/vmware_vc_infraprofile_info.py
@@ -146,20 +146,9 @@ import_profile:
 '''
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.compat.version import LooseVersion
 from ansible_collections.community.vmware.plugins.module_utils.vmware_rest_client import VmwareRestClient
-from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi
 import json
 import time
-
-
-class VcVersionChecker(PyVmomi):
-    def __init__(self, module):
-        super(VcVersionChecker, self).__init__(module)
-
-    def check_vc_version(self):
-        if LooseVersion(self.content.about.version) < LooseVersion('7'):
-            self.module.fail_json(msg="vCenter version is less than 7.0.0 Please specify vCenter with version greater than or equal to 7.0.0")
 
 
 class VcenterProfile(VmwareRestClient):
@@ -244,8 +233,6 @@ def main():
     module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
     result = {'failed': False, 'changed': False}
     vmware_vc_infra_profile = VcenterProfile(module)
-    vmware_vc_version = VcVersionChecker(module)
-    vmware_vc_version.check_vc_version()
 
     if module.params['api'].lower() == "list":
         if module.check_mode:


### PR DESCRIPTION
##### SUMMARY
vSphere versions < 7 have been EOL for some time (1 1/2 years?), so I guess we don't have to test for < 7 anymore.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_category
vmware_vc_infraprofile_info

##### ADDITIONAL INFORMATION
