### PR TITLE
Drop unused HAS_PYVMOMI

### DIFF
--- a/changelogs/fragments/2327-drop-HAS_PYVMOMI.yml
+++ b/changelogs/fragments/2327-drop-HAS_PYVMOMI.yml
@@ -1,0 +1,6 @@
+minor_changes:
+  - vmware_vsan_health_info - Drop unused HAS_PYVMOMI (https://github.com/ansible-collections/community.vmware/pull/2327).
+  - vmware_guest_tpm - Drop unused HAS_PYVMOMI (https://github.com/ansible-collections/community.vmware/pull/2327).
+  - vcenter_standard_key_provider - Drop unused HAS_PYVMOMI (https://github.com/ansible-collections/community.vmware/pull/2327).
+  - vmware_guest - Drop unused HAS_PYVMOMI (https://github.com/ansible-collections/community.vmware/pull/2327).
+  - vmware_vm_config_option - Drop unused HAS_PYVMOMI (https://github.com/ansible-collections/community.vmware/pull/2327).

--- a/plugins/modules/vcenter_standard_key_provider.py
+++ b/plugins/modules/vcenter_standard_key_provider.py
@@ -178,11 +178,8 @@ key_provider_clusters:
         ]
 '''
 
-HAS_PYVMOMI = False
 try:
     from pyVmomi import vim
-
-    HAS_PYVMOMI = True
 except ImportError:
     pass
 

--- a/plugins/modules/vmware_guest.py
+++ b/plugins/modules/vmware_guest.py
@@ -1104,10 +1104,8 @@ import re
 import time
 import string
 
-HAS_PYVMOMI = False
 try:
     from pyVmomi import vim, vmodl
-    HAS_PYVMOMI = True
 except ImportError:
     pass
 

--- a/plugins/modules/vmware_guest_tpm.py
+++ b/plugins/modules/vmware_guest_tpm.py
@@ -98,10 +98,8 @@ instance:
     sample: None
 '''
 
-HAS_PYVMOMI = False
 try:
     from pyVmomi import vim
-    HAS_PYVMOMI = True
 except ImportError:
     pass
 

--- a/plugins/modules/vmware_vm_config_option.py
+++ b/plugins/modules/vmware_vm_config_option.py
@@ -102,10 +102,8 @@ instance:
     sample: None
 '''
 
-HAS_PYVMOMI = False
 try:
     from pyVmomi import vim
-    HAS_PYVMOMI = True
 except ImportError:
     pass
 

--- a/plugins/modules/vmware_vsan_health_info.py
+++ b/plugins/modules/vmware_vsan_health_info.py
@@ -107,10 +107,8 @@ import traceback
 
 try:
     from pyVmomi import vmodl, VmomiSupport
-    HAS_PYVMOMI = True
 except ImportError:
-    PYVMOMI_IMP_ERR = traceback.format_exc()
-    HAS_PYVMOMI = False
+    pass
 
 VSANPYTHONSDK_IMP_ERR = None
 try:


### PR DESCRIPTION
##### SUMMARY
These modules define `HAS_PYVMOMI`, but it doesn't look like they use it anywhere.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vcenter_standard_key_provider
vmware_guest
vmware_guest_tpm
vmware_vm_config_option
vmware_vsan_health_info