### PR TITLE
Drop unnecessary HAS_PYVMOMI

### DIFF
--- a/changelogs/fragments/2328-drop-HAS_PYVMOMI.yml
+++ b/changelogs/fragments/2328-drop-HAS_PYVMOMI.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vmware_vsan_health_info - Drop unnecessary HAS_PYVMOMI (https://github.com/ansible-collections/community.vmware/pull/2328).

--- a/changelogs/fragments/2328-drop-HAS_PYVMOMI.yml
+++ b/changelogs/fragments/2328-drop-HAS_PYVMOMI.yml
@@ -4,3 +4,4 @@ minor_changes:
   - vmware_migrate_vmk - Drop unnecessary HAS_PYVMOMI (https://github.com/ansible-collections/community.vmware/pull/2328).
   - vmware_host_graphics - Drop unnecessary HAS_PYVMOMI (https://github.com/ansible-collections/community.vmware/pull/2328).
   - vmware_host_lockdown - Drop unnecessary HAS_PYVMOMI (https://github.com/ansible-collections/community.vmware/pull/2328).
+  - vmware_resource_pool - Drop unnecessary HAS_PYVMOMI (https://github.com/ansible-collections/community.vmware/pull/2328).

--- a/changelogs/fragments/2328-drop-HAS_PYVMOMI.yml
+++ b/changelogs/fragments/2328-drop-HAS_PYVMOMI.yml
@@ -3,3 +3,4 @@ minor_changes:
   - vmware_host_lockdown_exceptions - Drop unnecessary HAS_PYVMOMI (https://github.com/ansible-collections/community.vmware/pull/2328).
   - vmware_migrate_vmk - Drop unnecessary HAS_PYVMOMI (https://github.com/ansible-collections/community.vmware/pull/2328).
   - vmware_host_graphics - Drop unnecessary HAS_PYVMOMI (https://github.com/ansible-collections/community.vmware/pull/2328).
+  - vmware_host_lockdown - Drop unnecessary HAS_PYVMOMI (https://github.com/ansible-collections/community.vmware/pull/2328).

--- a/changelogs/fragments/2328-drop-HAS_PYVMOMI.yml
+++ b/changelogs/fragments/2328-drop-HAS_PYVMOMI.yml
@@ -2,3 +2,4 @@ minor_changes:
   - vmware_vsan_health_info - Drop unnecessary HAS_PYVMOMI (https://github.com/ansible-collections/community.vmware/pull/2328).
   - vmware_host_lockdown_exceptions - Drop unnecessary HAS_PYVMOMI (https://github.com/ansible-collections/community.vmware/pull/2328).
   - vmware_migrate_vmk - Drop unnecessary HAS_PYVMOMI (https://github.com/ansible-collections/community.vmware/pull/2328).
+  - vmware_host_graphics - Drop unnecessary HAS_PYVMOMI (https://github.com/ansible-collections/community.vmware/pull/2328).

--- a/changelogs/fragments/2328-drop-HAS_PYVMOMI.yml
+++ b/changelogs/fragments/2328-drop-HAS_PYVMOMI.yml
@@ -1,3 +1,4 @@
 minor_changes:
   - vmware_vsan_health_info - Drop unnecessary HAS_PYVMOMI (https://github.com/ansible-collections/community.vmware/pull/2328).
   - vmware_host_lockdown_exceptions - Drop unnecessary HAS_PYVMOMI (https://github.com/ansible-collections/community.vmware/pull/2328).
+  - vmware_migrate_vmk - Drop unnecessary HAS_PYVMOMI (https://github.com/ansible-collections/community.vmware/pull/2328).

--- a/changelogs/fragments/2328-drop-HAS_PYVMOMI.yml
+++ b/changelogs/fragments/2328-drop-HAS_PYVMOMI.yml
@@ -5,3 +5,4 @@ minor_changes:
   - vmware_host_graphics - Drop unnecessary HAS_PYVMOMI (https://github.com/ansible-collections/community.vmware/pull/2328).
   - vmware_host_lockdown - Drop unnecessary HAS_PYVMOMI (https://github.com/ansible-collections/community.vmware/pull/2328).
   - vmware_resource_pool - Drop unnecessary HAS_PYVMOMI (https://github.com/ansible-collections/community.vmware/pull/2328).
+  - vmware_guest_storage_policy - Drop unnecessary HAS_PYVMOMI (https://github.com/ansible-collections/community.vmware/pull/2328).

--- a/changelogs/fragments/2328-drop-HAS_PYVMOMI.yml
+++ b/changelogs/fragments/2328-drop-HAS_PYVMOMI.yml
@@ -1,2 +1,3 @@
 minor_changes:
   - vmware_vsan_health_info - Drop unnecessary HAS_PYVMOMI (https://github.com/ansible-collections/community.vmware/pull/2328).
+  - vmware_host_lockdown_exceptions - Drop unnecessary HAS_PYVMOMI (https://github.com/ansible-collections/community.vmware/pull/2328).

--- a/plugins/modules/vmware_guest_storage_policy.py
+++ b/plugins/modules/vmware_guest_storage_policy.py
@@ -156,10 +156,8 @@ from ansible.module_utils.basic import missing_required_lib
 PYVMOMI_IMP_ERR = None
 try:
     from pyVmomi import pbm, vim
-    HAS_PYVMOMI = True
 except ImportError:
-    HAS_PYVMOMI = False
-    PYVMOMI_IMP_ERR = traceback.format_exc()
+    pass
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_native
 from ansible_collections.community.vmware.plugins.module_utils.vmware import vmware_argument_spec, wait_for_task
@@ -421,10 +419,6 @@ def run_module():
             ['disk', 'vm_home'],
         ],
     )
-
-    if not HAS_PYVMOMI:
-        module.fail_json(msg=missing_required_lib("pyVmomi"),
-                         exception=PYVMOMI_IMP_ERR)
 
     if module.params['folder']:
         # FindByInventoryPath() does not require an absolute path

--- a/plugins/modules/vmware_host_graphics.py
+++ b/plugins/modules/vmware_host_graphics.py
@@ -85,9 +85,8 @@ results:
 
 try:
     from pyVmomi import vim
-    HAS_PYVMOMI = True
 except ImportError:
-    HAS_PYVMOMI = False
+    pass
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.vmware.plugins.module_utils.vmware import vmware_argument_spec, PyVmomi
@@ -178,9 +177,6 @@ def main():
             ['cluster_name', 'esxi_hostname'],
         ],
     )
-
-    if not HAS_PYVMOMI:
-        module.fail_json(msg='pyvmomi required for this module')
 
     vmware_host_graphics = VMwareHostGraphicSettings(module)
     vmware_host_graphics.ensure()

--- a/plugins/modules/vmware_host_lockdown.py
+++ b/plugins/modules/vmware_host_lockdown.py
@@ -119,9 +119,8 @@ results:
 
 try:
     from pyVmomi import vim
-    HAS_PYVMOMI = True
 except ImportError:
-    HAS_PYVMOMI = False
+    pass
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.vmware.plugins.module_utils.vmware import vmware_argument_spec, PyVmomi
@@ -195,9 +194,6 @@ def main():
             ['cluster_name', 'esxi_hostname'],
         ]
     )
-
-    if not HAS_PYVMOMI:
-        module.fail_json(msg='pyvmomi required for this module')
 
     vmware_lockdown_mgr = VmwareLockdownManager(module)
     vmware_lockdown_mgr.ensure()

--- a/plugins/modules/vmware_host_lockdown_exceptions.py
+++ b/plugins/modules/vmware_host_lockdown_exceptions.py
@@ -84,9 +84,8 @@ results:
 
 try:
     from pyVmomi import vim
-    HAS_PYVMOMI = True
 except ImportError:
-    HAS_PYVMOMI = False
+    pass
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.vmware.plugins.module_utils.vmware import vmware_argument_spec, PyVmomi
@@ -176,9 +175,6 @@ def main():
             ['cluster_name', 'esxi_hostname'],
         ]
     )
-
-    if not HAS_PYVMOMI:
-        module.fail_json(msg='pyvmomi required for this module')
 
     vmware_lockdown_mgr = VmwareLockdownManager(module)
     vmware_lockdown_mgr.ensure()

--- a/plugins/modules/vmware_host_snmp.py
+++ b/plugins/modules/vmware_host_snmp.py
@@ -179,9 +179,8 @@ results:
 
 try:
     from pyVmomi import vim
-    HAS_PYVMOMI = True
 except ImportError:
-    HAS_PYVMOMI = False
+    pass
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, vmware_argument_spec, find_obj
@@ -573,9 +572,6 @@ def main():
         argument_spec=argument_spec,
         supports_check_mode=True,
     )
-
-    if not HAS_PYVMOMI:
-        module.fail_json(msg='pyvmomi required for this module')
 
     host_snmp = VmwareHostSnmp(module)
     host_snmp.ensure()

--- a/plugins/modules/vmware_migrate_vmk.py
+++ b/plugins/modules/vmware_migrate_vmk.py
@@ -75,9 +75,8 @@ EXAMPLES = r'''
 '''
 try:
     from pyVmomi import vim, vmodl
-    HAS_PYVMOMI = True
 except ImportError:
-    HAS_PYVMOMI = False
+    pass
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.vmware.plugins.module_utils.vmware import (
@@ -216,9 +215,6 @@ def main():
                               migrate_vlan_id=dict(required=False, type='int')))
 
     module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=False)
-
-    if not HAS_PYVMOMI:
-        module.fail_json(msg='pyvmomi required for this module')
 
     vmware_migrate_vmk = VMwareMigrateVmk(module)
     vmware_migrate_vmk.process_state()

--- a/plugins/modules/vmware_resource_pool.py
+++ b/plugins/modules/vmware_resource_pool.py
@@ -192,9 +192,8 @@ resource_pool_config:
 
 try:
     from pyVmomi import vim, vmodl
-    HAS_PYVMOMI = True
 except ImportError:
-    HAS_PYVMOMI = False
+    pass
 
 from ansible.module_utils._text import to_native
 from ansible_collections.community.vmware.plugins.module_utils.vmware import get_all_objs, vmware_argument_spec, find_datacenter_by_name, \
@@ -478,9 +477,6 @@ def main():
                                ['cluster', 'esxi_hostname', 'parent_resource_pool'],
                            ],
                            supports_check_mode=True)
-
-    if not HAS_PYVMOMI:
-        module.fail_json(msg='pyvmomi is required for this module')
 
     vmware_rp = VMwareResourcePool(module)
     vmware_rp.process_state()


### PR DESCRIPTION
##### SUMMARY
I think we can drop testing for `pyvmomi` here because it's already been done in the module util / super class.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_vsan_health_info
vmware_host_lockdown_exceptions
vmware_migrate_vmk
vmware_host_graphics
vmware_host_lockdown
vmware_resource_pool
vmware_guest_storage_policy

##### ADDITIONAL INFORMATION
#2327