### PR TITLE
Fix #2325

### DIFF
--- a/plugins/modules/vmware_vm_vss_dvs_migrate.py
+++ b/plugins/modules/vmware_vm_vss_dvs_migrate.py
@@ -56,6 +56,7 @@ from ansible_collections.community.vmware.plugins.module_utils.vmware import (
 
 class VMwareVmVssDvsMigrate(PyVmomi):
     def __init__(self, module):
+        super(VMwareVmVssDvsMigrate, self).__init__(module)
         self.vm = None
         self.vm_name = module.params['vm_name']
         self.dvportgroup_name = module.params['dvportgroup_name']


### PR DESCRIPTION
##### SUMMARY
Looks like I forgot to call the `super()` / parent constructor in #2325 :-/

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_vm_vss_dvs_migrate

##### ADDITIONAL INFORMATION
Missing integration test :-/