### PR TITLE
Deprecate vcenter_folder

### DIFF
--- a/changelogs/fragments/2340-deprecate-vcenter_folder.yml
+++ b/changelogs/fragments/2340-deprecate-vcenter_folder.yml
@@ -1,0 +1,3 @@
+deprecated_features:
+  - vcenter_folder - the module has been deprecated and will be removed in community.vmware 7.0.0
+    (https://github.com/ansible-collections/community.vmware/pull/2340).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -190,6 +190,10 @@ plugin_routing:
         removal_version: 7.0.0
         warning_text: Use vmware.vmware.vms instead.
   modules:
+    vcenter_folder:
+      deprecation:
+        removal_version: 7.0.0
+        warning_text: Use vmware.vmware.folder instead.
     vmware_cluster:
       deprecation:
         removal_version: 6.0.0

--- a/plugins/modules/vcenter_folder.py
+++ b/plugins/modules/vcenter_folder.py
@@ -12,6 +12,10 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 ---
 module: vcenter_folder
+deprecated:
+  removed_in: 7.0.0
+  why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+  alternative: Use M(vmware.vmware.folder) instead.
 short_description: Manage folders on given datacenter
 description:
 - This module can be used to create, delete, move and rename folder on then given datacenter.

--- a/tests/integration/targets/prepare_vmware_tests/tasks/setup_datacenter.yml
+++ b/tests/integration/targets/prepare_vmware_tests/tasks/setup_datacenter.yml
@@ -4,8 +4,12 @@
     state: present
 
 - name: Create a VM folder on given Datacenter
-  vcenter_folder:
+  vmware.vmware.folder:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
     datacenter: '{{ dc1 }}'
-    folder_name: '{{ f0 }}'
+    relative_path: '{{ f0 }}'
     folder_type: vm
     state: present
+    validate_certs: false

--- a/tests/integration/targets/vmware_datastore_cluster/tasks/main.yml
+++ b/tests/integration/targets/vmware_datastore_cluster/tasks/main.yml
@@ -72,12 +72,12 @@
      - not enable_sdrs_again.changed
 
 - name: Create a datastore folder on given Datacenter
-  vcenter_folder:
+  vmware.vmware.folder:
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
     datacenter: '{{ dc1 }}'
-    folder_name: 'my_datastore_folder'
+    relative_path: 'my_datastore_folder'
     folder_type: datastore
     state: present
     validate_certs: false
@@ -89,7 +89,7 @@
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
     validate_certs: false
-    folder: "{{ my_datastore_folder.result.path }}"
+    folder: '/{{ dc1 }}/datastore/my_datastore_folder'
     datastore_cluster_name: DSC2
     state: present
   register: add_dsc_folder_check
@@ -136,12 +136,12 @@
     - DSC2
 
 - name: Delete the datastore folder
-  vcenter_folder:
+  vmware.vmware.folder:
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
     datacenter: '{{ dc1 }}'
-    folder_name: 'my_datastore_folder'
+    relative_path: 'my_datastore_folder'
     folder_type: datastore
     state: absent
     validate_certs: false

--- a/tests/integration/targets/vmware_dvswitch/tasks/main.yml
+++ b/tests/integration/targets/vmware_dvswitch/tasks/main.yml
@@ -32,17 +32,15 @@
       - dvs_result_0001.changed
 
 - name: Create a network folder on given Datacenter
-  vcenter_folder:
+  vmware.vmware.folder:
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
     datacenter: '{{ dc1 }}'
-    folder_name: network_folder
+    relative_path: network_folder
     folder_type: network
     state: present
     validate_certs: false
-  register:
-    network_folder_result
 
 - name: Add distributed vSwitch using folder
   vmware_dvswitch:
@@ -50,7 +48,7 @@
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
-    folder: "{{ network_folder_result.result.path }}"
+    folder: "/{{ dc1 }}/network/network_folder"
     state: present
     switch_name: dvswitch_0002
     mtu: 9000

--- a/tests/integration/targets/vmware_folder_info/tasks/main.yml
+++ b/tests/integration/targets/vmware_folder_info/tasks/main.yml
@@ -6,25 +6,33 @@
     name: prepare_vmware_tests
 
 - name: create example toplevel folder
-  vcenter_folder:
-    <<: &vcenter_folder_data
-      hostname: "{{ vcenter_hostname }}"
-      username: "{{ vcenter_username }}"
-      password: "{{ vcenter_password }}"
-      datacenter: "{{ dc1 | basename }}"
-      validate_certs: false
-    folder_name: "toplevel"
+  vmware.vmware.folder:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter: "{{ dc1 | basename }}"
+    folder_type: vm
+    validate_certs: false
+    relative_path: "toplevel"
 
 - name: create an example child folder
-  vcenter_folder:
-    <<: *vcenter_folder_data
-    folder_name: "child_folder"
-    parent_folder: "toplevel"
+  vmware.vmware.folder:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter: "{{ dc1 | basename }}"
+    folder_type: vm
+    validate_certs: false
+    relative_path: "toplevel/child_folder"
 
 # Testcase 0001: Get details about folders
 - name: get info about folders
   vmware_folder_info:
-    <<: *vcenter_folder_data
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter: "{{ dc1 | basename }}"
+    validate_certs: false
   register: folder_info_0001
 
 - debug: var=folder_info_0001

--- a/tests/integration/targets/vmware_guest_move/tasks/main.yml
+++ b/tests/integration/targets/vmware_guest_move/tasks/main.yml
@@ -9,16 +9,15 @@
     setup_virtualmachines: true
 
 - name: Create a VM folder on given Datacenter
-  vcenter_folder:
+  vmware.vmware.folder:
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
     datacenter: '{{ dc1 }}'
-    folder_name: 'f1'
+    relative_path: 'f1'
     folder_type: vm
     state: present
     validate_certs: false
-  register: dest_folder
 
 # Testcase 0001: Move vm and get changed status
 - name: Move VM (Changed)
@@ -30,7 +29,7 @@
     datacenter: '{{ dc1 }}'
     name: '{{ virtual_machines[0].name }}'
     # Depends-On: https://github.com/ansible/ansible/pull/55237
-    dest_folder: '{{ dest_folder.result.path }}'
+    dest_folder: '/{{ dc1 }}/vm/f1'
   register: vm_info_0001
 
 
@@ -44,7 +43,7 @@
     password: '{{ vcenter_password }}'
     datacenter: '{{ dc1 }}'
     name: '{{ virtual_machines[0].name }}'
-    dest_folder: '{{ dest_folder.result.path }}'
+    dest_folder: '/{{ dc1 }}/vm/f1'
   register: vm_info_0002
 
 - debug:
@@ -70,12 +69,12 @@
     - vm_move_0003.changed
 
 - name: Delete the f1 VM folder
-  vcenter_folder:
+  vmware.vmware.folder:
     hostname: '{{ vcenter_hostname }}'
     username: '{{ vcenter_username }}'
     password: '{{ vcenter_password }}'
     datacenter: '{{ dc1 }}'
-    folder_name: 'f1'
+    relative_path: 'f1'
     folder_type: vm
     state: absent
     validate_certs: false


### PR DESCRIPTION
##### SUMMARY
Deprecate `community.vmware.vcenter_folder` in favor of `vmware.folder`.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vcenter_folder

##### ADDITIONAL INFORMATION
ansible-collections/vmware.vmware#104