### PR TITLE
Deprecate vmware_content_library_manager

### DIFF
--- a/changelogs/fragments/2345-deprecate.vmware_content_library_manager.yml
+++ b/changelogs/fragments/2345-deprecate.vmware_content_library_manager.yml
@@ -1,0 +1,3 @@
+deprecated_features:
+  - vmware_content_library_manager - the module has been deprecated and will be removed in community.vmware 7.0.0
+    (https://github.com/ansible-collections/community.vmware/pull/2345).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -230,6 +230,10 @@ plugin_routing:
       deprecation:
         removal_version: 7.0.0
         warning_text: Use vmware.vmware.deploy_content_library_template instead.
+    vmware_content_library_manager:
+      deprecation:
+        removal_version: 7.0.0
+        warning_text: Use vmware.vmware.local_content_library and vmware.vmware.subscribed_content_library instead.
     vmware_host:
       deprecation:
         removal_version: 7.0.0

--- a/plugins/modules/vmware_content_library_manager.py
+++ b/plugins/modules/vmware_content_library_manager.py
@@ -13,6 +13,10 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 ---
 module: vmware_content_library_manager
+deprecated:
+  removed_in: 7.0.0
+  why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+  alternative: Use M(vmware.vmware.local_content_library) and M(vmware.vmware.subscribed_content_library) instead.
 short_description: Create, update and delete VMware content library
 description:
 - Module to manage VMware content Library

--- a/tests/integration/targets/prepare_vmware_tests/tasks/setup_content_library.yml
+++ b/tests/integration/targets/prepare_vmware_tests/tasks/setup_content_library.yml
@@ -1,7 +1,10 @@
 - name: Create Content Library
-  vmware_content_library_manager:
-    library_name: test-content-lib
-    library_description: 'Library created by the prepare_vmware_tests role'
-    library_type: local
-    datastore_name: '{{ rw_datastore }}'
+  vmware.vmware.local_content_library:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    name: test-content-lib
+    description: 'Library created by the prepare_vmware_tests role'
+    datastore: '{{ rw_datastore }}'
+    validate_certs: false
     state: present


### PR DESCRIPTION
##### SUMMARY
Deprecate `community.vmware.vmware_content_library_manager` in favor of `vmware.vmware.local_content_library` and `vmware.vmware.subscribed_content_library`.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_content_library_manager

##### ADDITIONAL INFORMATION
ansible-collections/vmware.vmware#109