### PR TITLE
Zuul: disable ansible-doc part of galaxy-importer

### DIFF
--- a/tests/galaxy-importer.cfg
+++ b/tests/galaxy-importer.cfg
@@ -1,0 +1,8 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+[galaxy-importer]
+# This is only needed to make Zuul's third-party-check happy.
+# It is not needed by anything else.
+run_ansible_doc=false


### PR DESCRIPTION
##### SUMMARY
Disable the ansible-doc part of the galaxy-importer run in Zuul jobs / tests.

##### ISSUE TYPE
- CI Pull Request

##### COMPONENT NAME
CI

##### ADDITIONAL INFORMATION
I hope this stops the CI from failing when using doc fragments from another collection (like in #2369).