### PR TITLE
Stop using connect_to_api

### DIFF
--- a/changelogs/fragments/2372-stop_using_connect_to_api.yml
+++ b/changelogs/fragments/2372-stop_using_connect_to_api.yml
@@ -2,4 +2,5 @@ minor_changes:
   - vmware_guest_cross_vc_clone - Stop using ``connect_to_api``
     (https://github.com/ansible-collections/community.vmware/pull/2372).
   - vmware_guest_instant_clone - Stop using ``connect_to_api``
+  - vcenter_extension - Stop using ``connect_to_api``
     (https://github.com/ansible-collections/community.vmware/pull/2372).

--- a/changelogs/fragments/2372-stop_using_connect_to_api.yml
+++ b/changelogs/fragments/2372-stop_using_connect_to_api.yml
@@ -9,3 +9,6 @@ minor_changes:
     (https://github.com/ansible-collections/community.vmware/pull/2372).
   - vcenter_extension - Stop using ``connect_to_api``
     (https://github.com/ansible-collections/community.vmware/pull/2372).
+deprecated_features:
+  - module_utils.vmware - Deprecate ``connect_to_api``
+    (https://github.com/ansible-collections/community.vmware/pull/2372).

--- a/changelogs/fragments/2372-stop_using_connect_to_api.yml
+++ b/changelogs/fragments/2372-stop_using_connect_to_api.yml
@@ -2,5 +2,8 @@ minor_changes:
   - vmware_guest_cross_vc_clone - Stop using ``connect_to_api``
     (https://github.com/ansible-collections/community.vmware/pull/2372).
   - vmware_guest_instant_clone - Stop using ``connect_to_api``
+    (https://github.com/ansible-collections/community.vmware/pull/2372).
+  - vmware_vsan_cluster - Stop using ``connect_to_api``
+    (https://github.com/ansible-collections/community.vmware/pull/2372).
   - vcenter_extension - Stop using ``connect_to_api``
     (https://github.com/ansible-collections/community.vmware/pull/2372).

--- a/changelogs/fragments/2372-stop_using_connect_to_api.yml
+++ b/changelogs/fragments/2372-stop_using_connect_to_api.yml
@@ -1,3 +1,5 @@
 minor_changes:
+  - vmware_guest_cross_vc_clone - Stop using ``connect_to_api``
+    (https://github.com/ansible-collections/community.vmware/pull/2372).
   - vmware_guest_instant_clone - Stop using ``connect_to_api``
     (https://github.com/ansible-collections/community.vmware/pull/2372).

--- a/changelogs/fragments/2372-stop_using_connect_to_api.yml
+++ b/changelogs/fragments/2372-stop_using_connect_to_api.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - vmware_guest_instant_clone - Stop using ``connect_to_api``
+    (https://github.com/ansible-collections/community.vmware/pull/2372).

--- a/changelogs/fragments/2372-stop_using_connect_to_api.yml
+++ b/changelogs/fragments/2372-stop_using_connect_to_api.yml
@@ -3,6 +3,8 @@ minor_changes:
     (https://github.com/ansible-collections/community.vmware/pull/2372).
   - vmware_guest_instant_clone - Stop using ``connect_to_api``
     (https://github.com/ansible-collections/community.vmware/pull/2372).
+  - vmware_vm_inventory - Stop using ``connect_to_api``
+    (https://github.com/ansible-collections/community.vmware/pull/2372).
   - vmware_vsan_cluster - Stop using ``connect_to_api``
     (https://github.com/ansible-collections/community.vmware/pull/2372).
   - vcenter_extension - Stop using ``connect_to_api``

--- a/plugins/inventory/vmware_vm_inventory.py
+++ b/plugins/inventory/vmware_vm_inventory.py
@@ -529,8 +529,8 @@ class BaseVMwareInventory:
             username=self.username,
             password=self.password,
             port=self.port, validate_certs=self.validate_certs,
-            httpProxyHost=self.proxy_host,
-            httpProxyPort=self.proxy_port)
+            http_proxy_host=self.proxy_host,
+            http_proxy_port=self.proxy_port)
 
         return pyvmomi_client.si, pyvmomi_client.content
 

--- a/plugins/inventory/vmware_vm_inventory.py
+++ b/plugins/inventory/vmware_vm_inventory.py
@@ -461,7 +461,7 @@ except ImportError:
 
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
 from ansible.parsing.yaml.objects import AnsibleVaultEncryptedUnicode
-from ansible_collections.community.vmware.plugins.module_utils.vmware import connect_to_api
+from ansible_collections.community.vmware.plugins.module_utils.clients._vmware import PyvmomiClient
 
 
 class BaseVMwareInventory:
@@ -524,10 +524,15 @@ class BaseVMwareInventory:
         Returns: connection object
 
         """
-        return connect_to_api(module=None, disconnect_atexit=True, return_si=True,
-                              hostname=self.hostname, username=self.username, password=self.password,
-                              port=self.port, validate_certs=self.validate_certs, httpProxyHost=self.proxy_host,
-                              httpProxyPort=self.proxy_port)
+        pyvmomi_client = PyvmomiClient(
+            hostname=self.hostname,
+            username=self.username,
+            password=self.password,
+            port=self.port, validate_certs=self.validate_certs,
+            httpProxyHost=self.proxy_host,
+            httpProxyPort=self.proxy_port)
+
+        return pyvmomi_client.si, pyvmomi_client.content
 
     def check_requirements(self):
         """ Check all requirements for this inventory are satisfied"""

--- a/plugins/module_utils/vmware.py
+++ b/plugins/module_utils/vmware.py
@@ -8,7 +8,6 @@
 
 __metaclass__ = type
 
-import atexit
 import ansible.module_utils.common._collections_compat as collections_compat
 import json
 import os
@@ -25,18 +24,8 @@ from ansible_collections.community.vmware.plugins.module_utils.clients._vmware i
 from random import randint
 
 
-REQUESTS_IMP_ERR = None
-try:
-    # requests is required for exception handling of the ConnectionError
-    import requests
-    HAS_REQUESTS = True
-except ImportError:
-    REQUESTS_IMP_ERR = traceback.format_exc()
-    HAS_REQUESTS = False
-
 PYVMOMI_IMP_ERR = None
 try:
-    from pyVim import connect
     from pyVmomi import vim, vmodl, VmomiSupport
     HAS_PYVMOMI = True
 except ImportError:
@@ -673,109 +662,6 @@ def vmware_argument_spec():
     return base_argument_spec()
 
 
-def connect_to_api(module, disconnect_atexit=True, return_si=False, hostname=None, username=None, password=None, port=None, validate_certs=None,
-                   httpProxyHost=None, httpProxyPort=None):
-    if module:
-        if not hostname:
-            hostname = module.params['hostname']
-        if not username:
-            username = module.params['username']
-        if not password:
-            password = module.params['password']
-        if not httpProxyHost:
-            httpProxyHost = module.params.get('proxy_host')
-        if not httpProxyPort:
-            httpProxyPort = module.params.get('proxy_port')
-        if not port:
-            port = module.params.get('port', 443)
-        if not validate_certs:
-            validate_certs = module.params['validate_certs']
-
-    def _raise_or_fail(msg):
-        if module is not None:
-            module.fail_json(msg=msg)
-        raise ApiAccessError(msg)
-
-    if not hostname:
-        _raise_or_fail(msg="Hostname parameter is missing."
-                       " Please specify this parameter in task or"
-                       " export environment variable like 'export VMWARE_HOST=ESXI_HOSTNAME'")
-
-    if not username:
-        _raise_or_fail(msg="Username parameter is missing."
-                       " Please specify this parameter in task or"
-                       " export environment variable like 'export VMWARE_USER=ESXI_USERNAME'")
-
-    if not password:
-        _raise_or_fail(msg="Password parameter is missing."
-                       " Please specify this parameter in task or"
-                       " export environment variable like 'export VMWARE_PASSWORD=ESXI_PASSWORD'")
-
-    if validate_certs and not hasattr(ssl, 'SSLContext'):
-        _raise_or_fail(msg='pyVim does not support changing verification mode with python < 2.7.9. Either update '
-                           'python or use validate_certs=false.')
-    elif validate_certs:
-        ssl_context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
-        ssl_context.verify_mode = ssl.CERT_REQUIRED
-        ssl_context.check_hostname = True
-        ssl_context.load_default_certs()
-    elif hasattr(ssl, 'SSLContext'):
-        ssl_context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
-        ssl_context.verify_mode = ssl.CERT_NONE
-        ssl_context.check_hostname = False
-    else:  # Python < 2.7.9 or RHEL/Centos < 7.4
-        ssl_context = None
-
-    service_instance = None
-
-    connect_args = dict(
-        host=hostname,
-        port=port,
-    )
-    if ssl_context:
-        connect_args.update(sslContext=ssl_context)
-
-    msg_suffix = ''
-    try:
-        if httpProxyHost:
-            msg_suffix = " [proxy: %s:%d]" % (httpProxyHost, httpProxyPort)
-            connect_args.update(httpProxyHost=httpProxyHost, httpProxyPort=httpProxyPort)
-            smart_stub = connect.SmartStubAdapter(**connect_args)
-            session_stub = connect.VimSessionOrientedStub(smart_stub, connect.VimSessionOrientedStub.makeUserLoginMethod(username, password))
-            service_instance = vim.ServiceInstance('ServiceInstance', session_stub)
-        else:
-            connect_args.update(user=username, pwd=password)
-            service_instance = connect.SmartConnect(**connect_args)
-    except vim.fault.InvalidLogin as invalid_login:
-        msg = "Unable to log on to vCenter or ESXi API at %s:%s " % (hostname, port)
-        _raise_or_fail(msg="%s as %s: %s" % (msg, username, invalid_login.msg) + msg_suffix)
-    except vim.fault.NoPermission as no_permission:
-        _raise_or_fail(msg="User %s does not have required permission"
-                           " to log on to vCenter or ESXi API at %s:%s : %s" % (username, hostname, port, no_permission.msg))
-    except (requests.ConnectionError, ssl.SSLError) as generic_req_exc:
-        _raise_or_fail(msg="Unable to connect to vCenter or ESXi API at %s on TCP/%s: %s" % (hostname, port, generic_req_exc))
-    except vmodl.fault.InvalidRequest as invalid_request:
-        # Request is malformed
-        msg = "Failed to get a response from server %s:%s " % (hostname, port)
-        _raise_or_fail(msg="%s as request is malformed: %s" % (msg, invalid_request.msg) + msg_suffix)
-    except Exception as generic_exc:
-        msg = "Unknown error while connecting to vCenter or ESXi API at %s:%s" % (hostname, port) + msg_suffix
-        _raise_or_fail(msg="%s : %s" % (msg, generic_exc))
-
-    if service_instance is None:
-        msg = "Unknown error while connecting to vCenter or ESXi API at %s:%s" % (hostname, port)
-        _raise_or_fail(msg=msg + msg_suffix)
-
-    # Disabling atexit should be used in special cases only.
-    # Such as IP change of the ESXi host which removes the connection anyway.
-    # Also removal significantly speeds up the return of the module
-    if disconnect_atexit:
-        atexit.register(connect.Disconnect, service_instance)
-    if return_si:
-        return service_instance, service_instance.RetrieveContent()
-    return service_instance.RetrieveContent()
-
-
 def get_all_objs(content, vimtype, folder=None, recurse=True):
     if not folder:
         folder = content.rootFolder
@@ -1036,9 +922,6 @@ def quote_obj_name(object_name=None):
 class PyVmomi(PyvmomiClient):
     def __init__(self, module):
         self.module = module
-        if not HAS_REQUESTS:
-            module.fail_json(msg=missing_required_lib('requests'),
-                             exception=REQUESTS_IMP_ERR)
 
         if not HAS_PYVMOMI:
             module.fail_json(msg=missing_required_lib('PyVmomi'),

--- a/plugins/module_utils/vmware.py
+++ b/plugins/module_utils/vmware.py
@@ -8,6 +8,7 @@
 
 __metaclass__ = type
 
+import atexit
 import ansible.module_utils.common._collections_compat as collections_compat
 import json
 import os
@@ -24,8 +25,18 @@ from ansible_collections.community.vmware.plugins.module_utils.clients._vmware i
 from random import randint
 
 
+REQUESTS_IMP_ERR = None
+try:
+    # requests is required for exception handling of the ConnectionError
+    import requests
+    HAS_REQUESTS = True
+except ImportError:
+    REQUESTS_IMP_ERR = traceback.format_exc()
+    HAS_REQUESTS = False
+
 PYVMOMI_IMP_ERR = None
 try:
+    from pyVim import connect
     from pyVmomi import vim, vmodl, VmomiSupport
     HAS_PYVMOMI = True
 except ImportError:
@@ -662,6 +673,109 @@ def vmware_argument_spec():
     return base_argument_spec()
 
 
+def connect_to_api(module, disconnect_atexit=True, return_si=False, hostname=None, username=None, password=None, port=None, validate_certs=None,
+                   httpProxyHost=None, httpProxyPort=None):
+    if module:
+        if not hostname:
+            hostname = module.params['hostname']
+        if not username:
+            username = module.params['username']
+        if not password:
+            password = module.params['password']
+        if not httpProxyHost:
+            httpProxyHost = module.params.get('proxy_host')
+        if not httpProxyPort:
+            httpProxyPort = module.params.get('proxy_port')
+        if not port:
+            port = module.params.get('port', 443)
+        if not validate_certs:
+            validate_certs = module.params['validate_certs']
+
+    def _raise_or_fail(msg):
+        if module is not None:
+            module.fail_json(msg=msg)
+        raise ApiAccessError(msg)
+
+    if not hostname:
+        _raise_or_fail(msg="Hostname parameter is missing."
+                       " Please specify this parameter in task or"
+                       " export environment variable like 'export VMWARE_HOST=ESXI_HOSTNAME'")
+
+    if not username:
+        _raise_or_fail(msg="Username parameter is missing."
+                       " Please specify this parameter in task or"
+                       " export environment variable like 'export VMWARE_USER=ESXI_USERNAME'")
+
+    if not password:
+        _raise_or_fail(msg="Password parameter is missing."
+                       " Please specify this parameter in task or"
+                       " export environment variable like 'export VMWARE_PASSWORD=ESXI_PASSWORD'")
+
+    if validate_certs and not hasattr(ssl, 'SSLContext'):
+        _raise_or_fail(msg='pyVim does not support changing verification mode with python < 2.7.9. Either update '
+                           'python or use validate_certs=false.')
+    elif validate_certs:
+        ssl_context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
+        ssl_context.verify_mode = ssl.CERT_REQUIRED
+        ssl_context.check_hostname = True
+        ssl_context.load_default_certs()
+    elif hasattr(ssl, 'SSLContext'):
+        ssl_context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
+        ssl_context.verify_mode = ssl.CERT_NONE
+        ssl_context.check_hostname = False
+    else:  # Python < 2.7.9 or RHEL/Centos < 7.4
+        ssl_context = None
+
+    service_instance = None
+
+    connect_args = dict(
+        host=hostname,
+        port=port,
+    )
+    if ssl_context:
+        connect_args.update(sslContext=ssl_context)
+
+    msg_suffix = ''
+    try:
+        if httpProxyHost:
+            msg_suffix = " [proxy: %s:%d]" % (httpProxyHost, httpProxyPort)
+            connect_args.update(httpProxyHost=httpProxyHost, httpProxyPort=httpProxyPort)
+            smart_stub = connect.SmartStubAdapter(**connect_args)
+            session_stub = connect.VimSessionOrientedStub(smart_stub, connect.VimSessionOrientedStub.makeUserLoginMethod(username, password))
+            service_instance = vim.ServiceInstance('ServiceInstance', session_stub)
+        else:
+            connect_args.update(user=username, pwd=password)
+            service_instance = connect.SmartConnect(**connect_args)
+    except vim.fault.InvalidLogin as invalid_login:
+        msg = "Unable to log on to vCenter or ESXi API at %s:%s " % (hostname, port)
+        _raise_or_fail(msg="%s as %s: %s" % (msg, username, invalid_login.msg) + msg_suffix)
+    except vim.fault.NoPermission as no_permission:
+        _raise_or_fail(msg="User %s does not have required permission"
+                           " to log on to vCenter or ESXi API at %s:%s : %s" % (username, hostname, port, no_permission.msg))
+    except (requests.ConnectionError, ssl.SSLError) as generic_req_exc:
+        _raise_or_fail(msg="Unable to connect to vCenter or ESXi API at %s on TCP/%s: %s" % (hostname, port, generic_req_exc))
+    except vmodl.fault.InvalidRequest as invalid_request:
+        # Request is malformed
+        msg = "Failed to get a response from server %s:%s " % (hostname, port)
+        _raise_or_fail(msg="%s as request is malformed: %s" % (msg, invalid_request.msg) + msg_suffix)
+    except Exception as generic_exc:
+        msg = "Unknown error while connecting to vCenter or ESXi API at %s:%s" % (hostname, port) + msg_suffix
+        _raise_or_fail(msg="%s : %s" % (msg, generic_exc))
+
+    if service_instance is None:
+        msg = "Unknown error while connecting to vCenter or ESXi API at %s:%s" % (hostname, port)
+        _raise_or_fail(msg=msg + msg_suffix)
+
+    # Disabling atexit should be used in special cases only.
+    # Such as IP change of the ESXi host which removes the connection anyway.
+    # Also removal significantly speeds up the return of the module
+    if disconnect_atexit:
+        atexit.register(connect.Disconnect, service_instance)
+    if return_si:
+        return service_instance, service_instance.RetrieveContent()
+    return service_instance.RetrieveContent()
+
+
 def get_all_objs(content, vimtype, folder=None, recurse=True):
     if not folder:
         folder = content.rootFolder
@@ -922,6 +1036,9 @@ def quote_obj_name(object_name=None):
 class PyVmomi(PyvmomiClient):
     def __init__(self, module):
         self.module = module
+        if not HAS_REQUESTS:
+            module.fail_json(msg=missing_required_lib('requests'),
+                             exception=REQUESTS_IMP_ERR)
 
         if not HAS_PYVMOMI:
             module.fail_json(msg=missing_required_lib('PyVmomi'),

--- a/plugins/modules/vcenter_extension.py
+++ b/plugins/modules/vcenter_extension.py
@@ -124,8 +124,8 @@ except ImportError:
 import datetime
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.community.vmware.plugins.module_utils.vmware import connect_to_api
 from ansible_collections.community.vmware.plugins.module_utils._argument_spec import base_argument_spec
+from ansible_collections.community.vmware.plugins.module_utils.clients._vmware import PyvmomiClient
 
 
 def main():
@@ -166,8 +166,14 @@ def main():
     visible = module.params['visible']
     thumbprint = module.params['ssl_thumbprint']
 
-    content = connect_to_api(module, False)
-    em = content.extensionManager
+    pyvmomi_client = PyvmomiClient(
+        hostname=module.params.get('hostname'),
+        username=module.params.get('username'),
+        password=module.params.get('password'),
+        port=module.params.get('port'),
+        validate_certs=module.params.get('validate_certs')
+    )
+    em = pyvmomi_client.content.extensionManager
     key_check = em.FindExtension(extension_key)
     results = dict(changed=False, installed=dict())
 

--- a/plugins/modules/vmware_guest_cross_vc_clone.py
+++ b/plugins/modules/vmware_guest_cross_vc_clone.py
@@ -198,13 +198,13 @@ from ansible_collections.community.vmware.plugins.module_utils.vmware import (
     find_datastore_by_name,
     find_folder_by_name,
     find_vm_by_name,
-    connect_to_api,
     gather_vm_facts,
     find_obj,
     find_resource_pool_by_name,
     wait_for_task,
 )
 from ansible_collections.community.vmware.plugins.module_utils._argument_spec import base_argument_spec
+from ansible_collections.community.vmware.plugins.module_utils.clients._vmware import PyvmomiClient
 try:
     from pyVmomi import vim
 except ImportError:
@@ -231,13 +231,13 @@ class CrossVCCloneManager(PyVmomi):
         # query for the vm in destination vc
         # get the host and datastore info
         # get the power status of the newly cloned vm
-        self.destination_content = connect_to_api(
-            self.module,
+        pyvmomi_client = PyvmomiClient(
             hostname=self.destination_vcenter,
             username=self.destination_vcenter_username,
             password=self.destination_vcenter_password,
             port=self.destination_vcenter_port,
             validate_certs=self.destination_vcenter_validate_certs)
+        self.destination_content = pyvmomi_client.content
         info = {}
         vm_obj = find_vm_by_name(content=self.destination_content, vm_name=vm)
         if vm_obj is None:
@@ -277,13 +277,13 @@ class CrossVCCloneManager(PyVmomi):
             self.module.fail_json(msg="Failed to find the VM/template with %s" % vm_id)
 
         # connect to destination VC
-        self.destination_content = connect_to_api(
-            self.module,
+        pyvmomi_client = PyvmomiClient(
             hostname=self.destination_vcenter,
             username=self.destination_vcenter_username,
             password=self.destination_vcenter_password,
             port=self.destination_vcenter_port,
             validate_certs=self.destination_vcenter_validate_certs)
+        self.destination_content = pyvmomi_client.content
 
         # Check if vm name already exists in the destination VC
         vm = find_vm_by_name(content=self.destination_content, vm_name=self.params['destination_vm_name'])

--- a/plugins/modules/vmware_vsan_cluster.py
+++ b/plugins/modules/vmware_vsan_cluster.py
@@ -59,10 +59,9 @@ except ImportError:
     HAS_PYVMOMI = False
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.community.vmware.plugins.module_utils.vmware import (
-    HAS_PYVMOMI, connect_to_api, get_all_objs,
-    wait_for_task)
+from ansible_collections.community.vmware.plugins.module_utils.vmware import (get_all_objs, wait_for_task)
 from ansible_collections.community.vmware.plugins.module_utils._argument_spec import base_argument_spec
+from ansible_collections.community.vmware.plugins.module_utils.clients._vmware import PyvmomiClient
 
 
 def create_vsan_cluster(host_system, new_cluster_uuid):
@@ -101,7 +100,14 @@ def main():
     new_cluster_uuid = module.params['cluster_uuid']
 
     try:
-        content = connect_to_api(module, False)
+        pyvmomi_client = PyvmomiClient(
+            hostname=module.params.get('hostname'),
+            username=module.params.get('username'),
+            password=module.params.get('password'),
+            port=module.params.get('port'),
+            validate_certs=module.params.get('validate_certs')
+        )
+        content = pyvmomi_client.content
         host = get_all_objs(content, [vim.HostSystem])
         if not host:
             module.fail_json(msg="Unable to locate Physical Host.")

--- a/tests/integration/targets/inventory_vmware_host_inventory/aliases
+++ b/tests/integration/targets/inventory_vmware_host_inventory/aliases
@@ -1,0 +1,3 @@
+cloud/vcenter
+needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/inventory_vmware_host_inventory/playbook/build_inventory.yml
+++ b/tests/integration/targets/inventory_vmware_host_inventory/playbook/build_inventory.yml
@@ -1,0 +1,23 @@
+---
+  - name: Set inventory content
+    copy:
+      dest: "{{ lookup('env', 'INVENTORY_DIR') }}/tmp.vmware.yml"
+      content: |
+        {{ content }}
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        port: '{{ vcenter_port|default('443') }}'
+        validate_certs: {{ vmware_validate_certs|default('no') }}
+    changed_when: false
+    check_mode: false
+
+  - meta: refresh_inventory
+
+  - debug:
+      msg: "{{ hostvars }}"
+
+  - name: Refresh test_host
+    set_fact:
+      test_host: "{{ hostvars | dict2items | first }}"
+    when: hostvars | length >= 1

--- a/tests/integration/targets/inventory_vmware_host_inventory/playbook/build_inventory_with_cache.yml
+++ b/tests/integration/targets/inventory_vmware_host_inventory/playbook/build_inventory_with_cache.yml
@@ -1,0 +1,14 @@
+---
+- hosts: localhost
+  tasks:
+    - name: Inventory with 'cache' option
+      include_tasks: build_inventory.yml
+      vars:
+        content: |-
+          plugin: community.vmware.vmware_host_inventory
+          strict: false
+          cache: true
+          properties:
+            - name
+            - summary.runtime.powerState
+            - customValue

--- a/tests/integration/targets/inventory_vmware_host_inventory/playbook/build_inventory_without_cache.yml
+++ b/tests/integration/targets/inventory_vmware_host_inventory/playbook/build_inventory_without_cache.yml
@@ -1,0 +1,14 @@
+---
+- hosts: localhost
+  tasks:
+    - name: Inventory without 'cache' option
+      include_tasks: build_inventory.yml
+      vars:
+        content: |-
+          plugin: community.vmware.vmware_host_inventory
+          strict: true
+          cache: false
+          properties:
+            - name
+            - summary.runtime.powerState
+            - customValue

--- a/tests/integration/targets/inventory_vmware_host_inventory/playbook/install_dependencies.yml
+++ b/tests/integration/targets/inventory_vmware_host_inventory/playbook/install_dependencies.yml
@@ -1,0 +1,7 @@
+---
+- name: Install dependencies
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - pip:
+        name: toml

--- a/tests/integration/targets/inventory_vmware_host_inventory/playbook/prepare_vmware.yml
+++ b/tests/integration/targets/inventory_vmware_host_inventory/playbook/prepare_vmware.yml
@@ -1,0 +1,17 @@
+---
+- name: Prepare VMware folders for testing dynamic inventory folder support
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/vmware:
+      hostname: '{{ vcenter_hostname }}'
+      username: '{{ vcenter_username }}'
+      password: '{{ vcenter_password }}'
+      port: "{{ vcenter_port|default('443') }}"
+      validate_certs: "{{ vmware_validate_certs|default('no') }}"
+  tasks:
+    - import_role:
+        name: ../prepare_vmware_tests
+      vars:
+        setup_attach_host: true
+        setup_datastore: true

--- a/tests/integration/targets/inventory_vmware_host_inventory/playbook/test_inventory_cache.yml
+++ b/tests/integration/targets/inventory_vmware_host_inventory/playbook/test_inventory_cache.yml
@@ -1,0 +1,51 @@
+---
+- name: Test inventory cache
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - find:
+        paths: "{{ lookup('env', 'ANSIBLE_CACHE_PLUGIN_CONNECTION') }}"
+        patterns: "community.vmware.vmware_host_inventory*"
+      register: result
+
+    - name: Cache directory exist
+      fail:
+        msg:  Cache not found. Please debug.
+      when: result.matched|int == 0
+      ignore_errors: true
+
+    - when: result.matched|int == 0
+      meta: end_play
+
+    - set_fact:
+        cached_groups: "{{groups}}"
+        cached_hostvars: "{{hostvars}}"
+
+    - meta: refresh_inventory
+
+    - name: 'Compare groups'
+      fail:
+        msg: "{{ item.key }} not found in cached groups. Please debug."
+      when: cached_groups[item.key] is not defined
+      loop:  "{{ q('dict', groups) }}"
+      loop_control:
+        label: "{{ item.key }}"
+
+    - name: 'Compare hosts'
+      fail:
+        msg: "{{ item.key }} not found in cached hosts. Please debug."
+      when: cached_hostvars[item.key] is not defined
+      loop:  "{{ q('dict', hostvars) }}"
+      loop_control:
+        label: "{{ item.key }}"
+
+    - set_fact:
+        test_host: "{{ hostvars | dict2items | first }}"
+
+    - name: 'Compare hostvars'
+      fail:
+        msg: "{{ item.key }} not found in cached hostvars. Please debug."
+      when: cached_hostvars[test_host.key][item.key] is not defined
+      loop:  "{{ q('dict', test_host.value) }}"
+      loop_control:
+        label: "{{ item.key }}"

--- a/tests/integration/targets/inventory_vmware_host_inventory/playbook/test_options.yml
+++ b/tests/integration/targets/inventory_vmware_host_inventory/playbook/test_options.yml
@@ -1,0 +1,211 @@
+---
+- name: Test Hostnames option
+  hosts: localhost
+  tasks:
+    - name: Inventory with 'hostnames' option
+      include_tasks: build_inventory.yml
+      vars:
+        content: |-
+          plugin: community.vmware.vmware_host_inventory
+          strict: false
+          with_nested_properties: false
+          properties:
+            - runtime.powerState
+          hostnames:
+            - 'skip_undefined_empty_none_var'
+            - 'runtime.powerState'
+
+    - name: Test properties option are populate
+      assert:
+        that:
+          - "'runtime.powerState' in test_host.value"
+
+    - name: Test hostnames option
+      assert:
+        that:
+          - test_host.key == (test_host.value['runtime.powerState'])
+
+    - name: Inventory with 'config' root properties
+      include_tasks: build_inventory.yml
+      vars:
+        content: |-
+          plugin: community.vmware.vmware_host_inventory
+          strict: false
+          with_nested_properties: false
+          properties:
+            - config.lockdownMode
+            - name
+            - summary
+    - name: Test properties(config) option are populate
+      assert:
+        that:
+          - "'name' in test_host.value"
+          - "'summary.runtime.powerState' in test_host.value"
+          - "'config.lockdownMode' in test_host.value"
+
+    - name: Inventory with 'with_path' option
+      include_tasks: build_inventory.yml
+      vars:
+        content: |-
+          plugin: community.vmware.vmware_host_inventory
+          strict: false
+          with_path: true
+          properties:
+          - name
+          - summary.runtime.powerState
+    - name: Test path option
+      assert:
+        that:
+          - "'path' in test_host.value"
+
+    - name: Inventory with rooted 'with_path' option
+      include_tasks: build_inventory.yml
+      vars:
+        content: |-
+          plugin: community.vmware.vmware_host_inventory
+          strict: false
+          with_path: my_center
+    - name: Test path option with rooted path
+      assert:
+        that:
+          - "'path' in test_host.value"
+          - "'my_center' in test_host.value.group_names"
+
+    - name: Inventory 'with_nested_properties' option
+      include_tasks: build_inventory.yml
+      vars:
+        content: |-
+          plugin: community.vmware.vmware_host_inventory
+          strict: false
+          properties:
+            - name
+            - summary.runtime.powerState
+            - config.lockdownMode
+          with_nested_properties: true
+    - name: Test 'with_nested_properties' option
+      assert:
+        that:
+          - test_host.value.config.lockdownMode is defined
+
+
+    - name: Inventory 'sanitize_property_name' option
+      include_tasks: build_inventory.yml
+      vars:
+        content: |-
+          plugin: community.vmware.vmware_host_inventory
+          strict: false
+          properties:
+            - name
+            - summary.runtime.powerState
+            - config.lockdownMode
+          with_sanitized_property_name: true
+    - name: Test 'with_nested_properties' option
+      assert:
+        that:
+          - test_host.value.config_lockdown_mode is defined
+
+
+    - name: Inventory 'Constructable' options - keyed_groups
+      include_tasks: build_inventory.yml
+      vars:
+        content: |-
+          plugin: community.vmware.vmware_host_inventory
+          strict: false
+          with_nested_properties: true
+          properties:
+            - name
+            - summary.runtime.powerState
+            - config.lockdownMode
+          keyed_groups:
+            - key: 'config.lockdownMode'
+              separator: ''
+    - name: Test 'Constructable' options - keyed_groups
+      assert:
+        that:
+          - "'lockdownDisabled' in test_host.value.group_names"
+
+
+    - name: Inventory filters options
+      include_tasks: build_inventory.yml
+      vars:
+        content: |-
+          plugin: community.vmware.vmware_host_inventory
+          strict: false
+          with_nested_properties: true
+          properties:
+            - name
+            - summary.runtime.powerState
+          filters:
+            - summary.runtime.powerState == "poweredOn"
+
+    - debug:
+        msg: "{{ test_host.value.groups }}"
+
+    - name: Test filters options
+      assert:
+        that:
+          - "test_host.key in test_host.value.groups.all"
+
+
+    - name: Inventory 'Constructable' options - compose, groups
+      include_tasks: build_inventory.yml
+      vars:
+        content: |-
+          plugin: community.vmware.vmware_host_inventory
+          strict: false
+          with_nested_properties: true
+          properties:
+            - name
+            - summary.runtime.powerState
+          compose:
+            ansible_host: 'name'
+            composed_var: 'name'
+          groups:
+            my_hosts: true
+    - name: Test 'Constructable' options - compose, groups
+      assert:
+        that:
+          - "'my_hosts' in test_host.value.group_names"
+          - "'ansible_host' in test_host.value"
+          - "'composed_var' in test_host.value"
+          - test_host.value.composed_var == test_host.value.name
+
+
+    - name: Inventory 'with_tag' option
+      include_tasks: build_inventory.yml
+      vars:
+        content: |-
+          plugin: community.vmware.vmware_host_inventory
+          strict: false
+          with_nested_properties: true
+          with_tags: true
+          properties:
+            - name
+            - summary.runtime.powerState
+    - name: Test 'with_tags' options
+      assert:
+        that:
+          - "'tags' in test_host.value"
+          - "'categories' in test_host.value"
+          - "'tag_category' in test_host.value"
+
+
+# TODO enable again
+# https://forum.ansible.com/t/11073
+# https://github.com/ansible-collections/community.vmware/issues/2257
+#     - name: Inventory 'resources' option
+#       include_tasks: build_inventory.yml
+#       vars:
+#         content: |-
+#           plugin: community.vmware.vmware_host_inventory
+#           strict: false
+#           resources:
+#             - datacenter:
+#                 - DC0
+#               resources:
+#                 - compute_resource:
+#                     - DC0_C0_NOT_EXIST
+#     - name: Test 'resources' options with 'DC0_C0_NOT_EXIST'
+#       assert:
+#         that:
+#           - hostvars | length == 0

--- a/tests/integration/targets/inventory_vmware_host_inventory/playbook/test_vmware_host_inventory.yml
+++ b/tests/integration/targets/inventory_vmware_host_inventory/playbook/test_vmware_host_inventory.yml
@@ -1,0 +1,18 @@
+# Test code for the vmware host dynamic plugin module
+# Copyright: (c) 2021, Abhijeet Kasurde <akasurde@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+---
+- name: Test VMware Host Dynamic Inventory Plugin
+  hosts: localhost
+  tasks:
+    - name: Check that there is 'all' group present in inventory
+      assert:
+        that:
+          - "'all' in groups"
+
+    - name: Check if Hostname and other details are populated in hostvars
+      assert:
+        that:
+        - hostvars[item].name is defined
+      with_items: "{{  groups['all'] }}"

--- a/tests/integration/targets/inventory_vmware_host_inventory/runme.sh
+++ b/tests/integration/targets/inventory_vmware_host_inventory/runme.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -eux
+
+# Envs
+export ANSIBLE_PYTHON_INTERPRETER=${ANSIBLE_TEST_PYTHON_INTERPRETER:-$(command -v python)}
+export ANSIBLE_INVENTORY_ENABLED="community.vmware.vmware_host_inventory,host_list,ini"
+export ANSIBLE_CACHE_PLUGIN_CONNECTION="${PWD}/inventory_cache"
+export ANSIBLE_CACHE_PLUGIN="jsonfile"
+
+export INVENTORY_DIR="${PWD}/_test/hosts"
+mkdir -p "${INVENTORY_DIR}" 2>/dev/null
+touch "${INVENTORY_DIR}/empty.vmware.yml"
+
+cleanup() {
+    echo "Cleanup"
+    if [ -d "${ANSIBLE_CACHE_PLUGIN_CONNECTION}" ]; then
+        echo "Removing ${ANSIBLE_CACHE_PLUGIN_CONNECTION}"
+        rm -rf "${ANSIBLE_CACHE_PLUGIN_CONNECTION}"
+    fi
+
+    if [ -d "${INVENTORY_DIR}" ]; then
+        echo "Removing ${INVENTORY_DIR}"
+        rm -rf "${INVENTORY_DIR}"
+    fi
+
+    unset ANSIBLE_INVENTORY_ENABLED
+    unset ANSIBLE_CACHE_PLUGIN ANSIBLE_CACHE_PLUGIN_CONNECTION
+    unset INVENTORY_DIR
+
+    echo "Done"
+}
+
+trap cleanup INT TERM EXIT
+
+# Prepare tests
+ansible-playbook playbook/prepare_vmware.yml "$@"
+
+# Test Cache
+# Cache requires jsonfile
+# ansible-playbook playbook/build_inventory_with_cache.yml "$@"
+# ansible-inventory -i "${INVENTORY_DIR}" --list
+# ansible-playbook -i "${INVENTORY_DIR}" playbook/test_inventory_cache.yml "$@"
+
+# Test YAML and TOML
+ansible-playbook playbook/install_dependencies.yml "$@"
+ansible-playbook playbook/build_inventory_without_cache.yml "$@"
+ansible-inventory -i "${INVENTORY_DIR}" --list --yaml 1>/dev/null
+if ${ANSIBLE_PYTHON_INTERPRETER} -m pip list 2>/dev/null | grep toml >/dev/null 2>&1; then
+    ansible-inventory -i "${INVENTORY_DIR}" --list --toml 1>/dev/null
+fi
+
+# Test playbook with the given inventory
+ansible-playbook -i "${INVENTORY_DIR}" playbook/test_vmware_host_inventory.yml "$@"
+
+# Test options
+ansible-playbook -i "${INVENTORY_DIR}" playbook/test_options.yml "$@"

--- a/tests/integration/targets/inventory_vmware_vm_inventory/aliases
+++ b/tests/integration/targets/inventory_vmware_vm_inventory/aliases
@@ -1,0 +1,2 @@
+cloud/vcenter
+needs/target/prepare_vmware_tests

--- a/tests/integration/targets/inventory_vmware_vm_inventory/playbook/build_inventory.yml
+++ b/tests/integration/targets/inventory_vmware_vm_inventory/playbook/build_inventory.yml
@@ -1,0 +1,20 @@
+---
+  - name: Set inventory content
+    copy:
+      dest: "{{ lookup('env', 'INVENTORY_DIR') }}/tmp.vmware.yml"
+      content: |
+        {{ content }}
+        hostname: '{{ vcenter_hostname }}'
+        username: '{{ vcenter_username }}'
+        password: '{{ vcenter_password }}'
+        port: '{{ vcenter_port|default('443') }}'
+        validate_certs: {{ vmware_validate_certs|default('no') }}
+    changed_when: false
+    check_mode: false
+
+  - meta: refresh_inventory
+
+  - name: Refresh test_host
+    set_fact:
+      test_host: "{{ hostvars | dict2items | first}}"
+    when: hostvars | length > 1

--- a/tests/integration/targets/inventory_vmware_vm_inventory/playbook/build_inventory_with_cache.yml
+++ b/tests/integration/targets/inventory_vmware_vm_inventory/playbook/build_inventory_with_cache.yml
@@ -1,0 +1,11 @@
+---
+- hosts: localhost
+  tasks:
+    - name: Inventory with 'cache' option
+      include_tasks: build_inventory.yml
+      vars:
+        content: |-
+          plugin: community.vmware.vmware_vm_inventory
+          strict: false
+          cache: true
+          properties: [all]

--- a/tests/integration/targets/inventory_vmware_vm_inventory/playbook/build_inventory_without_cache.yml
+++ b/tests/integration/targets/inventory_vmware_vm_inventory/playbook/build_inventory_without_cache.yml
@@ -1,0 +1,12 @@
+---
+- hosts: localhost
+  tasks:
+
+    - name: Inventory with 'cache' option
+      include_tasks: build_inventory.yml
+      vars:
+        content: |-
+          plugin: community.vmware.vmware_vm_inventory
+          strict: false
+          cache: false
+          properties: [all]

--- a/tests/integration/targets/inventory_vmware_vm_inventory/playbook/install_dependencies.yml
+++ b/tests/integration/targets/inventory_vmware_vm_inventory/playbook/install_dependencies.yml
@@ -1,0 +1,7 @@
+---
+- name: Install dependencies
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - pip:
+        name: toml

--- a/tests/integration/targets/inventory_vmware_vm_inventory/playbook/prepare_vmware.yml
+++ b/tests/integration/targets/inventory_vmware_vm_inventory/playbook/prepare_vmware.yml
@@ -1,0 +1,18 @@
+---
+- name: Prepare VMware folders for testing dynamic inventory folder support
+  hosts: localhost
+  gather_facts: false
+  module_defaults:
+    group/vmware:
+      hostname: '{{ vcenter_hostname }}'
+      username: '{{ vcenter_username }}'
+      password: '{{ vcenter_password }}'
+      port: "{{ vcenter_port|default('443') }}"
+      validate_certs: "{{ vmware_validate_certs|default('no') }}"
+  tasks:
+    - import_role:
+        name: ../prepare_vmware_tests
+      vars:
+        setup_attach_host: true
+        setup_datastore: true
+        setup_virtualmachines: true

--- a/tests/integration/targets/inventory_vmware_vm_inventory/playbook/test_inventory_cache.yml
+++ b/tests/integration/targets/inventory_vmware_vm_inventory/playbook/test_inventory_cache.yml
@@ -1,0 +1,51 @@
+---
+- name: Test inventory cache
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - find:
+        paths: "{{ lookup('env', 'ANSIBLE_CACHE_PLUGIN_CONNECTION') }}"
+        patterns: "community.vmware.vmware_vm_inventory*"
+      register: result
+
+    - name: Cache directory exist
+      fail:
+        msg:  Cache not found. Please debug.
+      when: result.matched|int == 0
+      ignore_errors: true
+
+    - when: result.matched|int == 0
+      meta: end_play
+
+    - set_fact:
+        cached_groups: "{{groups}}"
+        cached_hostvars: "{{hostvars}}"
+
+    - meta: refresh_inventory
+
+    - name: 'Compare groups'
+      fail:
+        msg: "{{ item.key }} not found in cached groups. Please debug."
+      when: cached_groups[item.key] is not defined
+      loop:  "{{ q('dict', groups) }}"
+      loop_control:
+        label: "{{ item.key }}"
+
+    - name: 'Compare hosts'
+      fail:
+        msg: "{{ item.key }} not found in cached hosts. Please debug."
+      when: cached_hostvars[item.key] is not defined
+      loop:  "{{ q('dict', hostvars) }}"
+      loop_control:
+        label: "{{ item.key }}"
+
+    - set_fact:
+        test_host: "{{ hostvars | dict2items | first }}"
+
+    - name: 'Compare hostvars'
+      fail:
+        msg: "{{ item.key }} not found in cached hostvars. Please debug."
+      when: cached_hostvars[test_host.key][item.key] is not defined
+      loop:  "{{ q('dict', test_host.value) }}"
+      loop_control:
+        label: "{{ item.key }}"

--- a/tests/integration/targets/inventory_vmware_vm_inventory/playbook/test_options.yml
+++ b/tests/integration/targets/inventory_vmware_vm_inventory/playbook/test_options.yml
@@ -1,0 +1,332 @@
+---
+- name: Test Hostnames option
+  hosts: localhost
+  tasks:
+
+    - name: Inventory with 'hostnames' option
+      include_tasks: build_inventory.yml
+      vars:
+        content: |-
+          plugin: community.vmware.vmware_vm_inventory
+          strict: false
+          with_nested_properties: false
+          properties:
+            - config.name
+            - runtime.powerState
+          hostnames:
+            - 'skip_undefined_empty_none_var'
+            - 'config.name + "_" + runtime.powerState'
+    - name: Test properties option are populate
+      assert:
+        that:
+          - "'config.name' in test_host.value"
+          - "'runtime.powerState' in test_host.value"
+          - "'name' not in test_host.value"
+    - name: Test hostnames option
+      assert:
+        that:
+          - test_host.key == (test_host.value['config.name'] + "_" + test_host.value['runtime.powerState'])
+
+
+    - name: Inventory with 'all' properties
+      include_tasks: build_inventory.yml
+      vars:
+        content: |-
+          plugin: community.vmware.vmware_vm_inventory
+          strict: false
+          with_nested_properties: false
+          properties: ['all']
+    - name: Test properties(all) option are populate
+      assert:
+        that:
+          - "'name' in test_host.value"
+          - "'config.name' in test_host.value"
+
+
+    - name: Inventory with 'config' root properties
+      include_tasks: build_inventory.yml
+      vars:
+        content: |-
+          plugin: community.vmware.vmware_vm_inventory
+          strict: false
+          with_nested_properties: false
+          properties:
+            - config
+    - name: Test properties(config) option are populate
+      assert:
+        that:
+          - "'name' not in test_host.value"
+          - "'config.name' in test_host.value"
+
+
+    - name: Inventory with 'with_path' option
+      include_tasks: build_inventory.yml
+      vars:
+        content: |-
+          plugin: community.vmware.vmware_vm_inventory
+          strict: false
+          with_path: true
+    - name: Test path option
+      assert:
+        that:
+          - "'path' in test_host.value"
+
+    - name: Inventory with rooted 'with_path' option
+      include_tasks: build_inventory.yml
+      vars:
+        content: |-
+          plugin: community.vmware.vmware_vm_inventory
+          strict: false
+          with_path: my_center
+    - name: Test path option with rooted path
+      assert:
+        that:
+          - "'path' in test_host.value"
+          - "'my_center' in test_host.value.group_names"
+
+    - name: Inventory 'with_nested_properties' option
+      include_tasks: build_inventory.yml
+      vars:
+        content: |-
+          plugin: community.vmware.vmware_vm_inventory
+          strict: false
+          properties:
+            - config.name
+            - config.uuid
+          with_nested_properties: true
+    - name: Test 'with_nested_properties' option
+      assert:
+        that:
+          - test_host.value.config.name is defined
+
+
+    - name: Inventory 'sanitize_property_name' option
+      include_tasks: build_inventory.yml
+      vars:
+        content: |-
+          plugin: community.vmware.vmware_vm_inventory
+          strict: false
+          properties:
+            - config.name
+            - config.uuid
+            - runtime.powerState
+
+          with_nested_properties: false
+          with_sanitized_property_name: true
+    - name: Test 'with_nested_properties' option
+      assert:
+        that:
+          - test_host.value.runtime_power_state is defined
+
+
+    - name: Inventory 'Constructable' options - keyed_groups
+      include_tasks: build_inventory.yml
+      vars:
+        content: |-
+          plugin: community.vmware.vmware_vm_inventory
+          strict: false
+          with_nested_properties: true
+          properties:
+            - config.name
+            - config.uuid
+            - config.guestId
+            - runtime.powerState
+          keyed_groups:
+            - key: 'config.guestId'
+              separator: ''
+            - key: 'runtime.powerState'
+              separator: ''
+    - name: Test 'Constructable' options - keyed_groups
+      assert:
+        that:
+          - "'poweredOff' in test_host.value.group_names"
+
+
+    - name: Inventory filters options
+      include_tasks: build_inventory.yml
+      vars:
+        content: |-
+          plugin: community.vmware.vmware_vm_inventory
+          strict: false
+          with_nested_properties: true
+          properties:
+            - config.name
+            - runtime.powerState
+          filters:
+            - runtime.powerState == "poweredOff"
+          hostnames:
+            - config.name
+    - name: Test filters options
+      assert:
+        that:
+          - "'DC0_H0_VM0' in test_host.value.groups.all"
+
+
+    - name: Inventory 'Constructable' options - compose, groups
+      include_tasks: build_inventory.yml
+      vars:
+        content: |-
+          plugin: community.vmware.vmware_vm_inventory
+          strict: false
+          with_nested_properties: true
+          properties:
+            - config.uuid
+            - config.guestId
+            - runtime.powerState
+            - config.name
+          compose:
+            ansible_host: 'config.name'
+            composed_var: 'config.name'
+          groups:
+            VMs: true
+          keyed_groups:
+            - key: 'config.guestId'
+              separator: ''
+            - key: 'runtime.powerState'
+              separator: ''
+    - name: Test 'Constructable' options - compose, groups
+      assert:
+        that:
+          - "'VMs' in test_host.value.group_names"
+          - "'poweredOff' in test_host.value.group_names"
+          - "'ansible_host' in test_host.value"
+          - "'composed_var' in test_host.value"
+          - test_host.value.ansible_host == test_host.value.config.name
+          - test_host.value.composed_var == test_host.value.config.name
+
+
+    - name: Inventory 'with_tag' option
+      include_tasks: build_inventory.yml
+      vars:
+        content: |-
+          plugin: community.vmware.vmware_vm_inventory
+          strict: false
+          with_nested_properties: true
+          with_tags: true
+          properties:
+            - config.name
+            - config.uuid
+            - config.guestId
+            - runtime.powerState
+    - name: Test 'with_tags' options
+      assert:
+        that:
+          - "'tags' in test_host.value"
+          - "'categories' in test_host.value"
+          - "'tag_category' in test_host.value"
+
+
+    - name: Inventory with binary values (https://github.com/ansible/awx/issues/7052)
+      include_tasks: build_inventory.yml
+      vars:
+        content: |-
+          plugin: community.vmware.vmware_vm_inventory
+          strict: false
+          with_nested_properties: true
+          properties:
+            - config.vmxConfigChecksum
+            - config.name
+            - summary.runtime.powerState
+          hostnames:
+            - config.name
+    - name: Test filters options
+      assert:
+        that:
+          - "'DC0_H0_VM0' in test_host.value.groups.all"
+          - test_host.value.config.name is defined
+          - test_host.value.config.vmxConfigChecksum is defined
+
+
+    - name: Inventory 'resources' option
+      include_tasks: build_inventory.yml
+      vars:
+        content: |-
+          plugin: community.vmware.vmware_vm_inventory
+          strict: false
+          with_nested_properties: false
+          hostnames:
+            - config.name
+          properties:
+            - config.name
+          resources:
+            - datacenter:
+                - DC0
+              resources:
+                - compute_resource:
+                    - DC0_C0
+    - name: Test 'resources' options
+      assert:
+        that:
+          - "'DC0_C0_RP0_VM0' in hostvars"
+
+    - name: Inventory 'resources' option
+      include_tasks: build_inventory.yml
+      vars:
+        content: |-
+          plugin: community.vmware.vmware_vm_inventory
+          strict: false
+          with_nested_properties: false
+          hostnames:
+            - config.name
+          properties:
+            - config.name
+          resources:
+            - datacenter:
+                - DC0
+              resources:
+                - compute_resource:
+                    - DC0_C0
+                    - DC0_C0_NOT_EXIST
+    - name: Test 'resources' options with 'DC0_C0' and 'DC0_C0_NOT_EXIST'
+      assert:
+        that:
+          - "'DC0_C0_RP0_VM0' in hostvars"
+
+    - name: Inventory 'resources' option
+      include_tasks: build_inventory.yml
+      vars:
+        content: |-
+          plugin: community.vmware.vmware_vm_inventory
+          strict: false
+          with_nested_properties: false
+          hostnames:
+            - config.name
+          properties:
+            - config.name
+          resources:
+            - datacenter:
+                - DC0
+              resources:
+                - compute_resource:
+                    - DC0_C0
+            - datacenter:
+                - DC0
+              resources:
+                - compute_resource:
+                    - DC0_C0_NOT_EXIST
+    - name: Test 'resources' options with 'DC0_C0' and 'DC0_C0_NOT_EXIST' using two 'datacenter'
+      assert:
+        that:
+          - "'DC0_C0_RP0_VM0' in hostvars"
+
+    - name: Inventory 'resources' option
+      include_tasks: build_inventory.yml
+      vars:
+        content: |-
+          plugin: community.vmware.vmware_vm_inventory
+          strict: false
+          with_nested_properties: false
+          hostnames:
+            - config.name
+          properties:
+            - config.name
+          resources:
+            - datacenter:
+                - DC0
+              resources:
+                - compute_resource:
+                    - DC0_C0_NOT_EXIST
+    - name: Test 'resources' options with 'DC0_C0_NOT_EXIST'
+      assert:
+        that:
+          - hostvars | length == 0

--- a/tests/integration/targets/inventory_vmware_vm_inventory/playbook/test_vmware_vm_inventory.yml
+++ b/tests/integration/targets/inventory_vmware_vm_inventory/playbook/test_vmware_vm_inventory.yml
@@ -1,0 +1,18 @@
+# Test code for the vmware guest dynamic plugin module
+# Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+---
+- name: Test VMware Guest Dynamic Inventroy Plugin
+  hosts: localhost
+  tasks:
+    - name: Check that there is 'all' group present in inventory
+      assert:
+        that:
+          - "'all' in groups"
+
+    - name: Check if Hostname and other details are populated in hostvars
+      assert:
+        that:
+        - hostvars[item].name is defined
+      with_items: "{{  groups['all'] }}"

--- a/tests/integration/targets/inventory_vmware_vm_inventory/runme.sh
+++ b/tests/integration/targets/inventory_vmware_vm_inventory/runme.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -eux
+
+# Envs
+export ANSIBLE_PYTHON_INTERPRETER=${ANSIBLE_TEST_PYTHON_INTERPRETER:-$(command -v python)}
+export ANSIBLE_INVENTORY_ENABLED="community.vmware.vmware_vm_inventory,host_list,ini"
+export ANSIBLE_CACHE_PLUGIN_CONNECTION="${PWD}/inventory_cache"
+export ANSIBLE_CACHE_PLUGIN="jsonfile"
+
+export INVENTORY_DIR="${PWD}/_test/hosts"
+mkdir -p "${INVENTORY_DIR}" 2>/dev/null
+touch "${INVENTORY_DIR}/empty.vmware.yml"
+
+cleanup() {
+    echo "Cleanup"
+    if [ -d "${ANSIBLE_CACHE_PLUGIN_CONNECTION}" ]; then
+        echo "Removing ${ANSIBLE_CACHE_PLUGIN_CONNECTION}"
+        rm -rf "${ANSIBLE_CACHE_PLUGIN_CONNECTION}"
+    fi
+
+    if [ -d "${INVENTORY_DIR}" ]; then
+        echo "Removing ${INVENTORY_DIR}"
+        rm -rf "${INVENTORY_DIR}"
+    fi
+
+    unset ANSIBLE_INVENTORY_ENABLED
+    unset ANSIBLE_CACHE_PLUGIN ANSIBLE_CACHE_PLUGIN_CONNECTION
+    unset INVENTORY_DIR
+
+    echo "Done"
+}
+
+trap cleanup INT TERM EXIT
+
+# Prepare tests
+ansible-playbook playbook/prepare_vmware.yml "$@"
+
+# Test Cache
+# Cache requires jsonfile
+ansible-playbook playbook/build_inventory_with_cache.yml "$@"
+ansible-inventory -i "${INVENTORY_DIR}" --list 1>/dev/null
+ansible-playbook -i "${INVENTORY_DIR}" playbook/test_inventory_cache.yml "$@"
+
+# Test YAML and TOML
+ansible-playbook playbook/install_dependencies.yml "$@"
+ansible-playbook playbook/build_inventory_without_cache.yml "$@"
+ansible-inventory -i "${INVENTORY_DIR}" --list --yaml 1>/dev/null
+if ${ANSIBLE_PYTHON_INTERPRETER} -m pip list 2>/dev/null | grep toml >/dev/null 2>&1; then
+    ansible-inventory -i "${INVENTORY_DIR}" --list --toml 1>/dev/null
+fi
+
+# # Test playbook with the given inventory
+ansible-playbook -i "${INVENTORY_DIR}" playbook/test_vmware_vm_inventory.yml "$@"
+
+# Test options
+ansible-playbook -i "${INVENTORY_DIR}" playbook/test_options.yml "$@"

--- a/tests/integration/targets/vmware_vm_inventory/aliases
+++ b/tests/integration/targets/vmware_vm_inventory/aliases
@@ -1,0 +1,2 @@
+cloud/vcenter
+zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_vm_inventory/ansible.cfg
+++ b/tests/integration/targets/vmware_vm_inventory/ansible.cfg
@@ -1,0 +1,9 @@
+[defaults]
+roles_path = ..
+
+[inventory]
+enable_plugins = community.vmware.vmware_vm_inventory
+cache = False
+#cache = True
+#cache_plugin = jsonfile
+#cache_connection = inventory_cache

--- a/tests/integration/targets/vmware_vm_inventory/prepare_environment.yml
+++ b/tests/integration/targets/vmware_vm_inventory/prepare_environment.yml
@@ -1,0 +1,57 @@
+---
+- hosts: localhost
+  module_defaults:
+    group/vmware:
+      hostname: '{{ vcenter_hostname }}'
+      username: '{{ vcenter_username }}'
+      password: '{{ vcenter_password }}'
+      port: "{{ vcenter_port|default('443') }}"
+      validate_certs: "{{ vmware_validate_certs|default('no') }}"
+  tasks:
+    - import_role:
+        name: prepare_vmware_tests
+      vars:
+        setup_attach_host: true
+        setup_datastore: true
+
+    - name: Create VM
+      vmware_guest:
+        hostname: "{{ vcenter_hostname }}"
+        username: "{{ vcenter_username }}"
+        password: "{{ vcenter_password }}"
+        datacenter: "{{ dc1 }}"
+        validate_certs: false
+        name: test_vm1
+        folder: vm
+        esxi_hostname: "{{ esxi1 }}"
+        state: powered-on
+        guest_id: debian8_64Guest
+        disk:
+        - size_gb: 1
+          type: thin
+          datastore: local
+        cdrom:
+        - controller_number: 0
+          unit_number: 0
+          type: iso
+          iso_path: "[{{ ro_datastore }}] fedora.iso"
+        hardware:
+          # vmware_guest_disk need vmx-13 to reconfigure the disks
+          version: 13
+          memory_mb: 1024
+          num_cpus: 1
+          scsi: paravirtual
+      register: vm_create
+
+    - copy:
+        dest: vmware.yaml
+        content: |
+          plugin: community.vmware.vmware_vm_inventory
+          strict: false
+          hostname: {{ vcenter_hostname }}
+          username: {{ vcenter_username }}
+          password: "{{ vcenter_password }}"
+          validate_certs: false
+          with_tags: true
+          hostnames:
+            - config.name

--- a/tests/integration/targets/vmware_vm_inventory/runme.sh
+++ b/tests/integration/targets/vmware_vm_inventory/runme.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2086,SC2048
+set -eux
+export ANSIBLE_CONFIG=ansible.cfg
+ansible-playbook prepare_environment.yml $*
+ansible-inventory --list -i vmware.yaml
+exec ansible-playbook -i vmware.yaml test_inventory.yml $*

--- a/tests/integration/targets/vmware_vm_inventory/test_inventory.yml
+++ b/tests/integration/targets/vmware_vm_inventory/test_inventory.yml
@@ -1,0 +1,10 @@
+# Test code for the vmware guest dynamic plugin module
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+---
+- hosts: localhost
+  tasks:
+    - assert:
+        that:
+            - "{{ groups['debian8_64Guest'] | length }} == 1"
+            - hostvars['test_vm1'] is defined

--- a/tests/unit/module_utils/test_vmware.py
+++ b/tests/unit/module_utils/test_vmware.py
@@ -6,7 +6,6 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-import sys
 import pytest
 
 from unittest import mock
@@ -102,13 +101,8 @@ def fake_ansible_module():
     return ret
 
 
-def fake_connect_to_api(module, return_si=None):
-    return None, mock.Mock()
-
-
 testdata = [
     ('HAS_PYVMOMI', 'PyVmomi'),
-    ('HAS_REQUESTS', 'requests'),
 ]
 
 
@@ -121,17 +115,6 @@ def test_lib_loading_failure(monkeypatch, fake_ansible_module, key, libname):
     error_str = 'Failed to import the required Python library (%s)' % libname
     fake_ansible_module.fail_json.assert_called_once()
     assert error_str in fake_ansible_module.fail_json.call_args[1]['msg']
-
-
-@pytest.mark.skipif(sys.version_info < (2, 7), reason="requires python2.7 and greater")
-@pytest.mark.parametrize("params, msg", test_data, ids=test_ids)
-def test_required_params(request, params, msg, fake_ansible_module):
-    """ Test if required params are correct or not"""
-    fake_ansible_module.params = params
-    with pytest.raises(FailJsonException):
-        vmware_module_utils.connect_to_api(fake_ansible_module)
-    fake_ansible_module.fail_json.assert_called_once()
-    # TODO: assert msg in fake_ansible_module.fail_json.call_args[1]['msg']
 
 
 @pytest.mark.parametrize("test_options, test_current_options, test_truthy_strings_as_bool", [


### PR DESCRIPTION
##### SUMMARY
I think we should get rid of `ansible_collections.community.plugins.module_utils.vmware.connect_to_api` in favor of using `ansible_collections.vmware.vmware.plugins.module_utils.clients.pyvmomi.PyvmomiClient` in the long run.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_guest_cross_vc_clone
vmware_guest_instant_clone
vmware_vm_inventory
vmware_vsan_cluster
vcenter_extension

##### ADDITIONAL INFORMATION
#2349
ansible-collections/vmware.vmware#147