### PR TITLE
Re-add integration tests for deprecated modules

### DIFF
--- a/tests/integration/targets/vmware_cluster_dpm/aliases
+++ b/tests/integration/targets/vmware_cluster_dpm/aliases
@@ -1,0 +1,4 @@
+cloud/vcenter
+needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_only
+zuul/vmware/govcsim

--- a/tests/integration/targets/vmware_cluster_dpm/tasks/main.yml
+++ b/tests/integration/targets/vmware_cluster_dpm/tasks/main.yml
@@ -1,0 +1,62 @@
+# Test code for the vmware_cluster module.
+# Copyright: (c) 2017, Abhijeet Kasurde <akasurde@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- import_role:
+    name: prepare_vmware_tests
+
+# Setup: Create test cluster
+- name: Create test cluster
+  vmware.vmware.cluster:
+    validate_certs: false
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter_name: "{{ dc1 }}"
+    cluster_name: test_cluster_dpm
+    state: present
+
+# Testcase 0001: Enable DPM
+- name: Enable DPM
+  vmware_cluster_dpm:
+    validate_certs: false
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter_name: "{{ dc1 }}"
+    cluster_name: test_cluster_dpm
+    enable_dpm: true
+  register: cluster_dpm_result_0001
+
+- name: Ensure DPM is enabled
+  assert:
+    that:
+        - "{{ cluster_dpm_result_0001.changed == true }}"
+
+# Testcase 0002: Disable DPM
+- name: Disable DPM
+  vmware_cluster_dpm:
+    validate_certs: false
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter_name: "{{ dc1 }}"
+    cluster_name: test_cluster_dpm
+    enable_dpm: false
+  register: cluster_dpm_result_0002
+
+- name: Ensure DPM is disabled
+  assert:
+    that:
+        - "{{ cluster_dpm_result_0002.changed == true }}"
+
+# Delete test cluster
+- name: Delete test cluster
+  vmware.vmware.cluster:
+    validate_certs: false
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter_name: "{{ dc1 }}"
+    cluster_name: test_cluster_dpm
+    state: absent

--- a/tests/integration/targets/vmware_cluster_ha/aliases
+++ b/tests/integration/targets/vmware_cluster_ha/aliases
@@ -1,0 +1,3 @@
+cloud/vcenter
+needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_only

--- a/tests/integration/targets/vmware_cluster_ha/tasks/main.yml
+++ b/tests/integration/targets/vmware_cluster_ha/tasks/main.yml
@@ -1,0 +1,303 @@
+# Test code for the vmware_cluster module.
+# Copyright: (c) 2017, Abhijeet Kasurde <akasurde@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- import_role:
+    name: prepare_vmware_tests
+
+# Setup: Create test cluster
+- name: Create test cluster
+  vmware.vmware.cluster:
+    validate_certs: false
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter_name: "{{ dc1 }}"
+    cluster_name: test_cluster_ha
+    state: present
+
+- name: Enable HA
+  vmware_cluster_ha:
+    validate_certs: false
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter_name: "{{ dc1 }}"
+    cluster_name: test_cluster_ha
+    enable: true
+  register: enable_ha_result
+
+- name: Ensure HA is enabled
+  assert:
+    that:
+      - enable_ha_result.changed
+
+- name: Disable HA
+  vmware_cluster_ha:
+    validate_certs: false
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter_name: "{{ dc1 }}"
+    cluster_name: test_cluster_ha
+    enable: false
+  register: disable_ha_result
+
+- name: Ensure HA is disabled
+  assert:
+    that:
+      - disable_ha_result.changed
+
+- name: Change APD response to "restartAggressive" (check-mode)
+  vmware_cluster_ha: &change_apd_response
+    validate_certs: false
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter_name: "{{ dc1 }}"
+    cluster_name: test_cluster_ha
+    enable: true
+    apd_response: 'restartAggressive'
+  check_mode: true
+  register: change_apd_response_check
+
+- assert:
+    that:
+      - change_apd_response_check.changed
+
+- name: Change APD response to "restartAggressive"
+  vmware_cluster_ha: *change_apd_response
+  register: change_apd_response
+
+- assert:
+    that:
+      - change_apd_response.changed
+
+- name: Change APD response to "restartAggressive" again (idempotency)
+  vmware_cluster_ha: *change_apd_response
+  register: change_apd_response_again
+
+- assert:
+    that:
+      - not change_apd_response_again.changed
+
+- name: Change APD response back to default
+  vmware_cluster_ha:
+    validate_certs: false
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter_name: "{{ dc1 }}"
+    cluster_name: test_cluster_ha
+    enable: true
+
+- name: Change PDL response to "restartAggressive" (check-mode)
+  vmware_cluster_ha: &change_pdl_response
+    validate_certs: false
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter_name: "{{ dc1 }}"
+    cluster_name: test_cluster_ha
+    enable: true
+    pdl_response: 'restartAggressive'
+  check_mode: true
+  register: change_pdl_response_check
+
+- assert:
+    that:
+      - change_pdl_response_check.changed
+
+- name: Change PDL response to "restartAggressive"
+  vmware_cluster_ha: *change_pdl_response
+  register: change_pdl_response
+
+- assert:
+    that:
+      - change_pdl_response.changed
+
+- name: Change PDL response to "restartAggressive" again
+  vmware_cluster_ha: *change_pdl_response
+  register: change_pdl_response_again
+
+- assert:
+    that:
+      - not change_pdl_response_again.changed
+
+- name: Change PDL response back to default
+  vmware_cluster_ha:
+    validate_certs: false
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter_name: "{{ dc1 }}"
+    cluster_name: test_cluster_ha
+    enable: true
+
+- name: Enable Slot based Admission Control
+  vmware_cluster_ha:
+    validate_certs: false
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter_name: "{{ dc1 }}"
+    cluster_name: test_cluster_ha
+    enable: true
+    slot_based_admission_control:
+      failover_level: 1
+  register: enable_slot_based_admission_control_result
+
+- name: Ensure Admission Cotrol is enabled
+  assert:
+    that:
+      - enable_slot_based_admission_control_result.changed
+
+- name: Enable Cluster resource Percentage based Admission Control
+  vmware_cluster_ha:
+    validate_certs: false
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter_name: "{{ dc1 }}"
+    cluster_name: test_cluster_ha
+    enable: true
+    reservation_based_admission_control:
+      auto_compute_percentages: false
+      failover_level: 1
+      cpu_failover_resources_percent: 33
+      memory_failover_resources_percent: 33
+  register: enable_percentage_based_admission_control_result
+
+- name: Ensure Admission Cotrol is enabled
+  assert:
+    that:
+      - enable_percentage_based_admission_control_result.changed
+
+- name: Set Isolation Response to powerOff
+  vmware_cluster_ha:
+    validate_certs: false
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter_name: "{{ dc1 }}"
+    cluster_name: test_cluster_ha
+    enable: true
+    host_isolation_response: 'powerOff'
+  register: isolation_response_poweroff_result
+
+- name: Ensure Isolation Response is enabled
+  assert:
+    that:
+      - isolation_response_poweroff_result.changed
+
+- name: Set Isolation Response to shutdown
+  vmware_cluster_ha:
+    validate_certs: false
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter_name: "{{ dc1 }}"
+    cluster_name: test_cluster_ha
+    enable: true
+    host_isolation_response: 'shutdown'
+  register: isolation_response_shutdown_result
+
+- name: Ensure Isolation Response is enabled
+  assert:
+    that:
+      - isolation_response_shutdown_result.changed
+
+- name: Change advanced setting "number of heartbeat datastores" (check-mode)
+  vmware_cluster_ha: &change_num_heartbeat_ds
+    validate_certs: false
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter_name: "{{ dc1 }}"
+    cluster_name: test_cluster_ha
+    enable: true
+    advanced_settings:
+        'das.heartbeatDsPerHost': '4'
+  check_mode: true
+  register: change_num_heartbeat_ds_check
+
+- assert:
+    that:
+      - change_num_heartbeat_ds_check.changed
+
+- name: Change advanced setting "number of heartbeat datastores"
+  vmware_cluster_ha: *change_num_heartbeat_ds
+  register: change_num_heartbeat_ds
+
+- assert:
+    that:
+      - change_num_heartbeat_ds.changed
+
+- name: Change advanced setting "number of heartbeat datastores" again
+  vmware_cluster_ha: *change_num_heartbeat_ds
+  register: change_num_heartbeat_ds_again
+
+- assert:
+    that:
+      - not change_num_heartbeat_ds_again.changed
+
+- name: Change advanced setting "das.includeFTcomplianceChecks" (check-mode)
+  vmware_cluster_ha: &change_includeFTcomplianceChecks
+    validate_certs: false
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter_name: "{{ dc1 }}"
+    cluster_name: test_cluster_ha
+    enable: true
+    advanced_settings:
+        'das.includeFTcomplianceChecks': 'False'
+  check_mode: true
+  register: change_includeFTcomplianceChecks_check
+
+- assert:
+    that:
+      - change_includeFTcomplianceChecks_check.changed
+
+- name: Change advanced setting "das.includeFTcomplianceChecks"
+  vmware_cluster_ha: *change_includeFTcomplianceChecks
+  register: change_includeFTcomplianceChecks
+
+- assert:
+    that:
+      - change_includeFTcomplianceChecks.changed
+
+- name: Change advanced setting "das.includeFTcomplianceChecks" again
+  vmware_cluster_ha: *change_includeFTcomplianceChecks
+  register: change_includeFTcomplianceChecks_again
+
+- assert:
+    that:
+      - not change_includeFTcomplianceChecks_again.changed
+
+- name: Disable HA
+  vmware_cluster_ha:
+    validate_certs: false
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter_name: "{{ dc1 }}"
+    cluster_name: test_cluster_ha
+    enable: false
+  register: disable_ha_result
+
+- name: Ensure HA is disabled
+  assert:
+    that:
+      - disable_ha_result.changed
+
+# Delete test cluster
+- name: Delete test cluster
+  vmware.vmware.cluster:
+    validate_certs: false
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    datacenter_name: "{{ dc1 }}"
+    cluster_name: test_cluster_ha
+    state: absent

--- a/tests/integration/targets/vmware_cluster_info/aliases
+++ b/tests/integration/targets/vmware_cluster_info/aliases
@@ -1,0 +1,3 @@
+cloud/vcenter
+needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_only

--- a/tests/integration/targets/vmware_cluster_info/tasks/main.yml
+++ b/tests/integration/targets/vmware_cluster_info/tasks/main.yml
@@ -1,0 +1,194 @@
+# Test code for the vmware_cluster_info module.
+# Copyright: (c) 2018, Abhijeet Kasurde <akasurde@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- import_role:
+    name: prepare_vmware_tests
+
+- &vc_all_data
+  name: gather info about all clusters in the given datacenter
+  vmware_cluster_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    datacenter: "{{ dc1 }}"
+  register: all_cluster_result
+
+- &ensure_vc_all_data
+  name: ensure info are gathered for all clusters
+  assert:
+    that:
+        - all_cluster_result.clusters
+        - not all_cluster_result.changed
+
+- name: ensure info are all defined
+  assert:
+    that:
+      - all_cluster_result.clusters[item].datacenter is defined
+      - all_cluster_result.clusters[item].hosts is defined
+      - all_cluster_result.clusters[item].enable_ha is defined
+      - all_cluster_result.clusters[item].ha_failover_level is defined
+      - all_cluster_result.clusters[item].ha_vm_monitoring is defined
+      - all_cluster_result.clusters[item].ha_host_monitoring is defined
+      - all_cluster_result.clusters[item].ha_admission_control_enabled is defined
+      - all_cluster_result.clusters[item].ha_restart_priority is defined
+      - all_cluster_result.clusters[item].ha_vm_tools_monitoring is defined
+      - all_cluster_result.clusters[item].ha_vm_min_up_time is defined
+      - all_cluster_result.clusters[item].ha_vm_max_failures is defined
+      - all_cluster_result.clusters[item].ha_vm_max_failure_window is defined
+      - all_cluster_result.clusters[item].ha_vm_failure_interval is defined
+      - all_cluster_result.clusters[item].enabled_drs is defined
+      - all_cluster_result.clusters[item].drs_enable_vm_behavior_overrides is defined
+      - all_cluster_result.clusters[item].drs_default_vm_behavior is defined
+      - all_cluster_result.clusters[item].drs_vmotion_rate is defined
+      - all_cluster_result.clusters[item].enabled_vsan is defined
+      - all_cluster_result.clusters[item].vsan_auto_claim_storage is defined
+      - all_cluster_result.clusters[item].tags is defined
+      - all_cluster_result.clusters[item].resource_summary is defined
+      - all_cluster_result.clusters[item].moid is defined
+  loop: "{{ all_cluster_result.clusters.keys() }}"
+
+- <<: *vc_all_data
+  name: Gather info about all clusters in the given datacenter in check mode
+  check_mode: true
+
+- debug: msg=all_cluster_result
+
+- <<: *ensure_vc_all_data
+  name: Ensure info is gathered for all clusters in check mode
+
+- &vc_cluster_data
+  name: Gather info about the given cluster
+  vmware_cluster_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    cluster_name: "{{ ccr1 }}"
+  register: cluster_result
+
+- &ensure_vc_cluster_data
+  name: Ensure info are gathered for the given cluster
+  assert:
+    that:
+        - cluster_result.clusters
+        - not cluster_result.changed
+
+- <<: *vc_cluster_data
+  name: Gather info about the given cluster in check mode
+  check_mode: true
+
+- <<: *ensure_vc_cluster_data
+  name: Ensure info is gathered for the given cluster in check mode
+
+- name: Gather info about all clusters in the given datacenter with properties
+  vmware_cluster_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    datacenter: "{{ dc1 }}"
+    schema: vsphere
+    properties:
+      - name
+      - configuration.dasConfig.enabled
+      - summary.totalCpu
+  register: all_cluster_result
+
+- name: Ensure info are gathered for all clusters with properteis
+  assert:
+    that:
+      - all_cluster_result.clusters
+      - all_cluster_result.clusters[item].name == item
+      - all_cluster_result.clusters[item].configuration.dasConfig.enabled is defined
+      - all_cluster_result.clusters[item].summary.totalCpu is defined
+      - not all_cluster_result.changed
+  loop: "{{ all_cluster_result.clusters.keys() }}"
+
+- name: Gather info about the given cluster with properties
+  vmware_cluster_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    cluster_name: "{{ ccr1 }}"
+    schema: vsphere
+    properties:
+      - name
+      - configuration.dasConfig.enabled
+      - summary.totalCpu
+  register: cluster_result
+
+- name: Ensure info are gathered for the given cluster with properties
+  assert:
+    that:
+      - cluster_result.clusters
+      - cluster_result.clusters[item].name == item
+      - cluster_result.clusters[item].configuration.dasConfig.enabled is defined
+      - cluster_result.clusters[item].summary.totalCpu is defined
+      - not cluster_result.changed
+  loop: "{{ cluster_result.clusters.keys() }}"
+
+# Disabled until we get a fix for https://github.com/ansible-collections/vmware/issues/301
+# - import_role:
+#    name: prepare_vmware_tests
+#   vars:
+#    setup_category: true
+#    setup_tag: true
+
+# - name: Apply tag to cluster
+#   vmware_tag_manager:
+#    hostname: "{{ vcenter_hostname }}"
+#    username: "{{ vcenter_username }}"
+#    password: "{{ vcenter_password }}"
+#    validate_certs: false
+#    tag_names:
+#      - '{{ cluster_category }}:{{ cluster_tag }}'
+#    state: present
+#    object_name: '{{ ccr1 }}'
+#    object_type: ClusterComputeResource
+
+# - name: Get info about cluster
+#   vmware_cluster_info:
+#    hostname: "{{ vcenter_hostname }}"
+#    username: "{{ vcenter_username }}"
+#    password: "{{ vcenter_password }}"
+#    validate_certs: false
+#    show_tag: true
+#    cluster_name: "{{ ccr1 }}"
+#   register: cluster_info
+
+# - assert:
+#    that:
+#      - cluster_info is defined
+#      - cluster_info.clusters[ccr1].tags is defined
+
+- name: "Prepare a cluster name with character to be URL-encoded"
+  vmware.vmware.cluster:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    datacenter_name: "{{ dc1 }}"
+    cluster_name: 'Cluster/\%'
+    state: present
+  register: prepare_cluster_url_encoded_result
+
+- assert:
+    that:
+      - prepare_cluster_url_encoded_result.changed is sameas true
+
+- name: "Gather information about all datacenter"
+  vmware_cluster_info:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    datacenter: "{{ dc1 }}"
+  register: all_cluster_result
+
+- name: "Ensure URL-encoded cluster name"
+  assert:
+    that:
+      - all_cluster_result.clusters['Cluster/\%']

--- a/tests/integration/targets/vmware_content_deploy_template/aliases
+++ b/tests/integration/targets/vmware_content_deploy_template/aliases
@@ -1,0 +1,4 @@
+cloud/vcenter
+unsupported
+needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_content_deploy_template/tasks/main.yml
+++ b/tests/integration/targets/vmware_content_deploy_template/tasks/main.yml
@@ -1,0 +1,35 @@
+# Test code for the deploy VM from content library template.
+# Copyright: (c) 2019, Pavan Bidkar <pbidkar@vmware.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_datacenter: true
+
+- &deploy_vm_from_content_library_template
+  vmware_content_deploy_template:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    template: '{{ test_vm_temp }}'
+    datastore: '{{ rw_datastore }}'
+    datacenter: '{{ dc1 }}'
+    folder: '{{ f0 }}'
+    host: '{{ esx1 }}'
+    name: 'test_content_deploy_vm'
+    state: poweredon
+    validate_certs: false
+  register: template_deploy
+
+- name: Check VM deployed successfully
+  assert:
+    that:
+      - template_deploy.changed
+
+- <<: *deploy_vm_from_content_library_template
+  name: Deploy VM from template again
+
+- name: Check VM with same name is deployed
+  assert:
+    that:
+      - not template_deploy.changed

--- a/tests/integration/targets/vmware_host/aliases
+++ b/tests/integration/targets/vmware_host/aliases
@@ -1,0 +1,3 @@
+cloud/vcenter
+needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_2esxi

--- a/tests/integration/targets/vmware_host/tasks/main.yml
+++ b/tests/integration/targets/vmware_host/tasks/main.yml
@@ -1,0 +1,253 @@
+# Test code for the vmware_host module.
+# Copyright: (c) 2017, Abhijeet Kasurde <akasurde@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Testcase: Add Host
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_attach_host: true
+
+# NOTE: prepare_vmware_tests should have already done that
+- name: Add first ESXi Host to vCenter
+  vmware_host:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    datacenter_name: '{{ dc1 }}'
+    cluster_name: '{{ ccr1 }}'
+    esxi_hostname: '{{ esxi1 }}'
+    esxi_username: '{{ esxi_user }}'
+    esxi_password: '{{ esxi_password }}'
+    state: present
+    validate_certs: false
+  register: readd_host_result
+
+- name: Add first ESXi Host to vCenter (again)
+  vmware_host:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    datacenter_name: '{{ dc1 }}'
+    cluster_name: '{{ ccr1 }}'
+    esxi_hostname: '{{ esxi1 }}'
+    esxi_username: '{{ esxi_user }}'
+    esxi_password: '{{ esxi_password }}'
+    state: present
+    validate_certs: false
+  register: readd_host_result
+
+- name: ensure precend task didn't changed anything
+  assert:
+    that:
+      - not ( readd_host_result is changed)
+
+- name: add second host via add_or_reconnect
+  vmware_host:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: '{{ esxi2 }}'
+    esxi_username: '{{ esxi_user }}'
+    esxi_password: '{{ esxi_password }}'
+    datacenter_name: "{{ dc1 }}"
+    cluster_name: "{{ ccr1 }}"
+    state: add_or_reconnect
+  register: add_or_reconnect_host_result
+- name: ensure host system is present
+  assert:
+    that:
+      - add_or_reconnect_host_result is changed
+
+- name: disconnect host 2
+  vmware_host:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: '{{ esxi2 }}'
+    datacenter_name: "{{ dc1 }}"
+    cluster_name: "{{ ccr1 }}"
+    fetch_ssl_thumbprint: false
+    state: absent
+
+- name: remove host again
+  vmware_host:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: '{{ esxi2 }}'
+    datacenter_name: "{{ dc1 }}"
+    cluster_name: "{{ ccr1 }}"
+    state: absent
+  register: reremove_host_result
+- name: ensure precend task didn't changed anything
+  assert:
+    that:
+      - not ( reremove_host_result is changed)
+
+
+## Testcase: Add Host to folder
+- name: Create host folder
+  vcenter_folder:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    datacenter: "{{ dc1 }}"
+    folder_name: "Staging"
+    folder_type: host
+    state: present
+  register: folder_results
+
+- debug: msg="{{ folder_results }}"
+
+- name: ensure folder is present
+  assert:
+    that:
+      - folder_results.changed
+
+- name: Add host to folder in check mode
+  vmware_host:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: '{{ esxi2 }}'
+    esxi_username: '{{ esxi_user }}'
+    esxi_password: '{{ esxi_password }}'
+    datacenter_name: "{{ dc1 }}"
+    folder_name: "/{{ dc1 }}/host/Staging"
+    state: present
+  register: add_host_to_folder_result
+  check_mode: true
+
+- name: ensure host system is not present
+  assert:
+    that:
+      - add_host_to_folder_result is changed
+
+- name: Add host to folder
+  vmware_host:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: '{{ esxi2 }}'
+    esxi_username: '{{ esxi_user }}'
+    esxi_password: '{{ esxi_password }}'
+    datacenter_name: "{{ dc1 }}"
+    folder_name: "/{{ dc1 }}/host/Staging"
+    state: present
+  register: add_host_to_folder_result
+
+- name: ensure host system is present
+  assert:
+    that:
+      - add_host_to_folder_result is changed
+
+- name: reconnect host
+  vmware_host:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    esxi_hostname: '{{ esxi2 }}'
+    esxi_username: '{{ esxi_user }}'
+    esxi_password: '{{ esxi_password }}'
+    datacenter_name: "{{ dc1 }}"
+    cluster_name: "{{ ccr1 }}"
+    state: reconnect
+  register: reconnect_host_result
+
+- name: ensure host system has been reconnected
+  assert:
+    that:
+      - reconnect_host_result is changed
+      # it would be a good idea to check the events on the host to see the reconnect
+      # https://github.com/vmware/govmomi/blob/master/govc/USAGE.md#events
+      # "govc events ..." need to be callable from
+      # https://github.com/ansible/vcenter-test-container/flask_control.py
+
+## Testcase: Disconnect Host
+- name: disconnect host with check_mode
+  vmware_host:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    datacenter: "{{ dc1 }}"
+    cluster: "{{ ccr1 }}"
+    esxi_hostname: '{{ esxi1 }}'
+    state: disconnected
+  check_mode: true
+  register: disconnect_host_check_mode_result
+
+- name: ensure to occur the changed
+  assert:
+    that:
+      - disconnect_host_check_mode_result.changed is true
+
+- name: disconnect host
+  vmware_host:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    datacenter: "{{ dc1 }}"
+    cluster: "{{ ccr1 }}"
+    esxi_hostname: '{{ esxi1 }}'
+    state: disconnected
+  register: disconnect_host_result
+
+- name: ensure host system has been disconnected
+  assert:
+    that:
+      - disconnect_host_result.changed is true
+
+- name: disconnect host(idempotency)
+  vmware_host:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    datacenter: "{{ dc1 }}"
+    cluster: "{{ ccr1 }}"
+    esxi_hostname: '{{ esxi1 }}'
+    state: disconnected
+  register: disconnect_host_idempotency_result
+
+- name: ensure not to occur the changed
+  assert:
+    that:
+      - disconnect_host_idempotency_result.changed is false
+
+- name: disconnect host with check_mode again
+  vmware_host:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    datacenter: "{{ dc1 }}"
+    cluster: "{{ ccr1 }}"
+    esxi_hostname: '{{ esxi1 }}'
+    state: disconnected
+  check_mode: true
+  register: disconnect_host_check_mode_again_result
+
+- name: ensure not to occur the changed
+  assert:
+    that:
+      - disconnect_host_check_mode_again_result.changed is false
+
+- name: reconnect host
+  vmware_host:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    validate_certs: false
+    datacenter: "{{ dc1 }}"
+    cluster: "{{ ccr1 }}"
+    esxi_hostname: '{{ esxi1 }}'
+    state: reconnect

--- a/tests/integration/targets/vmware_maintenancemode/aliases
+++ b/tests/integration/targets/vmware_maintenancemode/aliases
@@ -1,0 +1,3 @@
+cloud/vcenter
+needs/target/prepare_vmware_tests
+zuul/vmware/vcenter_1esxi

--- a/tests/integration/targets/vmware_maintenancemode/tasks/main.yml
+++ b/tests/integration/targets/vmware_maintenancemode/tasks/main.yml
@@ -1,0 +1,76 @@
+# Test code for the vmware_guest_maintenancemode module.
+# Copyright: (c) 2017, Abhijeet Kasurde <akasurde@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+- import_role:
+    name: prepare_vmware_tests
+  vars:
+    setup_attach_host: true
+
+
+- name: Enter maintenance mode
+  vmware_maintenancemode:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    state: present
+    esxi_hostname: '{{ esxi1 }}'
+    validate_certs: false
+  register: test_result_0001
+
+- debug: var=test_result_0001
+
+- name: assert that changes were made
+  assert:
+    that:
+      - test_result_0001 is changed
+
+- name: Enter maintenance mode again
+  vmware_maintenancemode:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    state: present
+    esxi_hostname: '{{ esxi1 }}'
+    validate_certs: false
+  register: test_result_0002
+
+- debug: var=test_result_0002
+
+- name: assert that no changes were made
+  assert:
+    that:
+      - not (test_result_0002 is changed)
+
+- name: Exit maintenance mode
+  vmware_maintenancemode:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    state: absent
+    esxi_hostname: '{{ esxi1 }}'
+    validate_certs: false
+  register: test_result_0003
+
+- debug: var=test_result_0003
+
+- name: assert that changes were made
+  assert:
+    that:
+      - test_result_0003 is changed
+
+- name: Exit maintenance mode again
+  vmware_maintenancemode:
+    hostname: "{{ vcenter_hostname }}"
+    username: "{{ vcenter_username }}"
+    password: "{{ vcenter_password }}"
+    state: absent
+    esxi_hostname: '{{ esxi1 }}'
+    validate_certs: false
+  register: test_result_0004
+
+- debug: var=test_result_0004
+
+- name: assert that no changes were made
+  assert:
+    that:
+      - not (test_result_0004 is changed)


### PR DESCRIPTION
##### SUMMARY
I think it's been a bad idea to remove the integration tests just because the modules have been deprecated. Let's keep them while the modules itself are still there.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_cluster_dpm #2217
vmware_cluster_ha #2321
vmware_cluster_info #2260
vmware_content_deploy_ovf_template #2332
vmware_host #2337
vmware_maintenancemode #2293

##### ADDITIONAL INFORMATION
Re-adding the tests for the inventory plugins (#2283) will be done in #2372.

I didn't remove any integration tests for

- vcenter_folder (#2340)
- vmware_cluster (#2143)
- vmware_cluster_drs (#2136)
- vmware_cluster_drs_recommendations (#2218)
- vmware_cluster_vcls (#2156)
- vmware_content_library_manager (#2345).