### PR TITLE
vmware_object_role_permission: Document vCenter level permissions

### DIFF
--- a/changelogs/fragments/2374-vmware_object_role_permission.yml
+++ b/changelogs/fragments/2374-vmware_object_role_permission.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - minor_changes - Document setting permissions on vCenter level
+    (https://github.com/ansible-collections/community.vmware/pull/2374).

--- a/plugins/modules/vmware_object_role_permission.py
+++ b/plugins/modules/vmware_object_role_permission.py
@@ -21,7 +21,7 @@ author:
 - Joseph Andreatta (@vmwjoseph)
 notes:
     - The login user must have the appropriate rights to administer permissions.
-    - To set permissions on vCenter (not global!) level use O(object_type) "Folder" and O(object_name) "rootFolder".
+    - To set permissions on vCenter (not global!) level use O(object_type=Folder) and O(object_name=rootFolder).
     - Permissions for a distributed switch must be defined and managed on either the datacenter or a folder containing the switch.
 options:
   role:

--- a/plugins/modules/vmware_object_role_permission.py
+++ b/plugins/modules/vmware_object_role_permission.py
@@ -21,6 +21,7 @@ author:
 - Joseph Andreatta (@vmwjoseph)
 notes:
     - The login user must have the appropriate rights to administer permissions.
+    - To set permissions on vCenter (not global!) level use O(object_type) "Folder" and O(object_name) "rootFolder".
     - Permissions for a distributed switch must be defined and managed on either the datacenter or a folder containing the switch.
 options:
   role:


### PR DESCRIPTION
##### SUMMARY
This is a follow-up to #2348 to document how to set permissions on the vCenter level.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_object_role_permission