### PR TITLE
[DNM] Test data tagging

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -83,6 +83,7 @@ jobs:
           - stable-2.18
         # - devel
           - milestone
+          - refs/pull/84621/head
     runs-on: ubuntu-latest
 
     steps:
@@ -132,6 +133,7 @@ jobs:
           - stable-2.18
         # - devel
           - milestone
+          - refs/pull/84621/head
 
     steps:
       - name: >-

--- a/plugins/modules/vmware_vswitch.py
+++ b/plugins/modules/vmware_vswitch.py
@@ -253,6 +253,8 @@ from ansible_collections.community.vmware.plugins.module_utils._argument_spec im
 from ansible.module_utils._text import to_native
 
 
+# Meaningless diff with no code changes to trigger CI
+
 class VMwareHostVirtualSwitch(PyVmomi):
     def __init__(self, module):
         super(VMwareHostVirtualSwitch, self).__init__(module)


### PR DESCRIPTION
DO NOT MERGE!

Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1900

Replacement for / follow-up to #2352

Trying to run the `community.vmware` jobs with the data tagging PR (ansible/ansible#84621).

Note to myself: [This](https://github.com/ansible-collections/community.general/pull/9833/files#diff-2061d2675ad59dc75b2892a0a098a2cc32fc01911feaecabfe2fd02e3497d957) link and [this](https://github.com/ansible-collections/community.general/blob/b894dd0aacdba7f3d407b9ebeeb582c270e88e94/tests/unit/plugins/modules/conftest.py#L5-L35) one. Also [this one](https://forum.ansible.com/t/41678/4).