### PR TITLE
[WIP] Prepare integration tests: Substitute vmware.vmware_rest

### DIFF
--- a/tests/integration/targets/prepare_vmware_tests/tasks/teardown.yml
+++ b/tests/integration/targets/prepare_vmware_tests/tasks/teardown.yml
@@ -1,11 +1,16 @@
 ---
 - name: Get a list of all the datacenters
-  vmware.vmware_rest.vcenter_datacenter_info:
-    vcenter_hostname: '{{ vcenter_hostname }}'
-    vcenter_username: '{{ vcenter_username }}'
-    vcenter_password: '{{ vcenter_password }}'
-    vcenter_validate_certs: false
+  community.vmware.vmware_datacenter_info:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    validate_certs: false
   register: existing_datacenters
+
+- name: Debug datacenters
+  debug:
+    var: existing_datacenters
+
 - name: Force delete the existing DC
   vmware.vmware_rest.vcenter_datacenter:
     vcenter_hostname: '{{ vcenter_hostname }}'

--- a/tests/integration/targets/prepare_vmware_tests/tasks/teardown.yml
+++ b/tests/integration/targets/prepare_vmware_tests/tasks/teardown.yml
@@ -12,15 +12,14 @@
     var: existing_datacenters
 
 - name: Force delete the existing DC
-  vmware.vmware_rest.vcenter_datacenter:
-    vcenter_hostname: '{{ vcenter_hostname }}'
-    vcenter_username: '{{ vcenter_username }}'
-    vcenter_password: '{{ vcenter_password }}'
-    vcenter_validate_certs: false
+  community.vmware.vmware_datacenter:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    validate_certs: false
+    datacenter_name: '{{ item.name }}'
     state: absent
-    datacenter: '{{ item.datacenter }}'
-    force: true
-  with_items: "{{ existing_datacenters.value }}"
+  with_items: "{{ existing_datacenters.datacenter_info }}"
   until: _result is succeeded
   retries: 10
   delay: 1

--- a/tests/integration/targets/prepare_vmware_tests/tasks/teardown_with_esxi.yml
+++ b/tests/integration/targets/prepare_vmware_tests/tasks/teardown_with_esxi.yml
@@ -72,12 +72,17 @@
   with_items: "{{ result.value }}"
 
 - name: Get a list of all the datacenters
-  vmware.vmware_rest.vcenter_datacenter_info:
-    vcenter_hostname: '{{ vcenter_hostname }}'
-    vcenter_username: '{{ vcenter_username }}'
-    vcenter_password: '{{ vcenter_password }}'
-    vcenter_validate_certs: false
+  community.vmware.vmware_datacenter_info:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    validate_certs: false
   register: existing_datacenters
+
+- name: Debug datacenters
+  debug:
+    var: existing_datacenters
+
 - name: Force delete the existing DC
   vmware.vmware_rest.vcenter_datacenter:
     vcenter_hostname: '{{ vcenter_hostname }}'

--- a/tests/integration/targets/prepare_vmware_tests/tasks/teardown_with_esxi.yml
+++ b/tests/integration/targets/prepare_vmware_tests/tasks/teardown_with_esxi.yml
@@ -84,15 +84,14 @@
     var: existing_datacenters
 
 - name: Force delete the existing DC
-  vmware.vmware_rest.vcenter_datacenter:
-    vcenter_hostname: '{{ vcenter_hostname }}'
-    vcenter_username: '{{ vcenter_username }}'
-    vcenter_password: '{{ vcenter_password }}'
-    vcenter_validate_certs: false
+  community.vmware.vmware_datacenter:
+    hostname: '{{ vcenter_hostname }}'
+    username: '{{ vcenter_username }}'
+    password: '{{ vcenter_password }}'
+    validate_certs: false
+    datacenter_name: '{{ item.name }}'
     state: absent
-    datacenter: '{{ item.datacenter }}'
-    force: true
-  with_items: "{{ existing_datacenters.value }}"
+  with_items: "{{ existing_datacenters.datacenter_info }}"
   until: _result is succeeded
   retries: 10
   delay: 1


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1905

##### SUMMARY
It looks like preparing the environment for the integration tests fails when testing with ansible-core 2.19 (#2378). It looks like `vmware.vmware_rest` isn't compatible with 2.19 (yet). So we should try and prepare the integration tests without modules from this collection.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tests/integration/targets/prepare_vmware_tests/tasks/*

##### ADDITIONAL INFORMATION
At the end of the day, I think that the root cause is `cloud.common` which is used by `vmware.vmware_rest`: ansible-collections/cloud.common#165