### PR TITLE
fix: add port number for guest file operation for custom port

### DIFF
--- a/changelogs/fragments/fix_port_vmware_guest_file_operation.yml
+++ b/changelogs/fragments/fix_port_vmware_guest_file_operation.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - vmware_guest_file_operation - Fix to use custom port provided to the module
+    (https://github.com/ansible-collections/community.vmware/pull/2397).

--- a/plugins/connection/vmware_tools.py
+++ b/plugins/connection/vmware_tools.py
@@ -457,8 +457,9 @@ class Connection(ConnectionBase):
         Fix url if connection is a host.
 
         The host part of the URL is returned as '*' if the hostname to be used is the name of the server to which the call was made. For example, if the call is
-        made to esx-svr-1.domain1.com and port 443, and the file is available for download from http://esx-svr-1.domain1.com:443/guestFile?id=1&token=1234, the URL returned may
-        be http://*:443/guestFile?id=1&token=1234. The client replaces the asterisk with the server name on which it invoked the call and 443 with the port number.
+        made to esx-svr-1.domain1.com and port 443, and the file is available for download from http://esx-svr-1.domain1.com:443/guestFile?id=1&token=1234,
+        the URL returned may be http://*:443/guestFile?id=1&token=1234.
+        The client replaces the asterisk with the server name on which it invoked the call and 443 with the port number.
 
         https://code.vmware.com/apis/358/vsphere#/doc/vim.vm.guest.FileManager.FileTransferInformation.html
         """

--- a/plugins/connection/vmware_tools.py
+++ b/plugins/connection/vmware_tools.py
@@ -457,12 +457,12 @@ class Connection(ConnectionBase):
         Fix url if connection is a host.
 
         The host part of the URL is returned as '*' if the hostname to be used is the name of the server to which the call was made. For example, if the call is
-        made to esx-svr-1.domain1.com, and the file is available for download from http://esx-svr-1.domain1.com/guestFile?id=1&token=1234, the URL returned may
-        be http://*/guestFile?id=1&token=1234. The client replaces the asterisk with the server name on which it invoked the call.
+        made to esx-svr-1.domain1.com and port 443, and the file is available for download from http://esx-svr-1.domain1.com:443/guestFile?id=1&token=1234, the URL returned may
+        be http://*:443/guestFile?id=1&token=1234. The client replaces the asterisk with the server name on which it invoked the call and 443 with the port number.
 
         https://code.vmware.com/apis/358/vsphere#/doc/vim.vm.guest.FileManager.FileTransferInformation.html
         """
-        return url.replace("*", self.vmware_host)
+        return url.replace("*", self.vmware_host).replace("443", self.get_option("vmware_port"))
 
     def _fetch_file_from_vm(self, guestFilePath):
         try:

--- a/plugins/modules/vmware_guest_file_operation.py
+++ b/plugins/modules/vmware_guest_file_operation.py
@@ -358,6 +358,7 @@ class VmwareGuestFileManager(PyVmomi):
         vm_username = self.module.params['vm_username']
         vm_password = self.module.params['vm_password']
         hostname = self.module.params['hostname']
+        port = self.module.params['port']
         dest = self.module.params["fetch"]['dest']
         src = self.module.params['fetch']['src']
         creds = vim.vm.guest.NamePasswordAuthentication(username=vm_username, password=vm_password)
@@ -367,7 +368,7 @@ class VmwareGuestFileManager(PyVmomi):
             fileTransferInfo = file_manager.InitiateFileTransferFromGuest(vm=self.vm, auth=creds,
                                                                           guestFilePath=src)
             url = fileTransferInfo.url
-            url = url.replace("*", hostname)
+            url = url.replace("*", hostname).replace("443", port)
             resp, info = urls.fetch_url(self.module, url, method="GET", timeout=self.timeout)
             if info.get('status') != 200 or not resp:
                 self.module.fail_json(msg="Failed to fetch file : %s" % info.get('msg', ''), body=info.get('body', ''))
@@ -401,6 +402,7 @@ class VmwareGuestFileManager(PyVmomi):
         vm_username = self.module.params['vm_username']
         vm_password = self.module.params['vm_password']
         hostname = self.module.params['hostname']
+        port = self.module.params['port']
         overwrite = self.module.params["copy"]["overwrite"]
         dest = self.module.params["copy"]['dest']
         src = self.module.params['copy']['src']
@@ -425,7 +427,7 @@ class VmwareGuestFileManager(PyVmomi):
             url = file_manager.InitiateFileTransferToGuest(vm=self.vm, auth=creds, guestFilePath=dest,
                                                            fileAttributes=file_attributes, overwrite=overwrite,
                                                            fileSize=file_size)
-            url = url.replace("*", hostname)
+            url = url.replace("*", hostname).replace("443", port)
             resp, info = urls.fetch_url(self.module, url, data=data, method="PUT", timeout=self.timeout)
 
             status_code = info["status"]


### PR DESCRIPTION
##### SUMMARY
Url contains fix port number 443 and it is not replaced with the custom port number provided

As per official document custom port is supported 
https://docs.ansible.com/ansible/latest/collections/community/vmware/vmware_guest_file_operation_module.html#parameter-port

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- vmware_tools
- vmware_guest_file_operation

##### ADDITIONAL INFORMATION

