### PR TITLE
Deprecate vmware_guest_powerstate

### DIFF
--- a/changelogs/fragments/2398-deprecate-vmware_guest_powerstate.yml
+++ b/changelogs/fragments/2398-deprecate-vmware_guest_powerstate.yml
@@ -1,0 +1,3 @@
+deprecated_features:
+  - vmware_guest_powerstate - the module has been deprecated and will be removed in community.vmware 7.0.0
+    (https://github.com/ansible-collections/community.vmware/pull/2398).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -234,6 +234,10 @@ plugin_routing:
       deprecation:
         removal_version: 7.0.0
         warning_text: Use vmware.vmware.local_content_library and vmware.vmware.subscribed_content_library instead.
+    vmware_guest_powerstate:
+      deprecation:
+        removal_version: 7.0.0
+        warning_text: Use vmware.vmware.vm_powerstate instead.
     vmware_host:
       deprecation:
         removal_version: 7.0.0

--- a/plugins/modules/vmware_guest_powerstate.py
+++ b/plugins/modules/vmware_guest_powerstate.py
@@ -12,6 +12,10 @@ __metaclass__ = type
 DOCUMENTATION = r"""
 ---
 module: vmware_guest_powerstate
+deprecated:
+  removed_in: 7.0.0
+  why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+  alternative: Use M(vmware.vmware.vm_powerstate) instead.
 short_description: Manages power states of virtual machines in vCenter
 description:
 - Power on / Power off / Restart a virtual machine.

--- a/tests/integration/targets/vmware_guest_disk_info/tasks/main.yml
+++ b/tests/integration/targets/vmware_guest_disk_info/tasks/main.yml
@@ -33,7 +33,8 @@
     - name: VM Network
 
 - name: set state to poweron the first VM
-  vmware_guest_powerstate:
+  vmware.vmware.vm_powerstate:
+    datacenter: "{{ dc1 }}"
     validate_certs: false
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"

--- a/tests/integration/targets/vmware_guest_instant_clone/tasks/main.yml
+++ b/tests/integration/targets/vmware_guest_instant_clone/tasks/main.yml
@@ -74,12 +74,13 @@
         - instant_clone_from_vm_when_cluster_is_specified is changed
 
 - name: set state to poweroff the Cloned VM
-  community.vmware.vmware_guest_powerstate:
+  vmware.vmware.vm_powerstate:
     validate_certs: false
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     name: "cloned_vm_from_vm_cluster"
+    datacenter: "{{ dc1 }}"
     folder: "{{ f0 }}"
     state: powered-off
   register: poweroff_instant_clone_from_vm_when_cluster
@@ -120,11 +121,12 @@
         - instant_clone_from_vm_optional_arguments is changed
 
 - name: set state to poweroff the Cloned VM
-  community.vmware.vmware_guest_powerstate:
+  vmware.vmware.vm_powerstate:
     validate_certs: false
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
+    datacenter: "{{ dc1 }}"
     name: "cloned_vm_from_vm_optional"
     state: powered-off
   register: poweroff_instant_clone_from_vm_optional_arguments
@@ -167,12 +169,13 @@
         - instant_clone_from_vm_moid is changed
 
 - name: set state to poweroff the Cloned VM
-  community.vmware.vmware_guest_powerstate:
+  vmware.vmware.vm_powerstate:
     validate_certs: false
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     name: "Instant_cloned_test"
+    datacenter: "{{ dc1 }}"
     folder: "{{ f0 }}"
     state: powered-off
   register: poweroff_instant_clone_from_vm_moid
@@ -216,12 +219,13 @@
         - instant_clone_from_vm_instance_uuid is changed
 
 - name: set state to poweroff the Cloned VM
-  community.vmware.vmware_guest_powerstate:
+  vmware.vmware.vm_powerstate:
     validate_certs: false
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     name: "Instant_cloned_instance_uuid"
+    datacenter: "{{ dc1 }}"
     folder: "{{ f0 }}"
     state: powered-off
   register: poweroff_instant_clone_from_vm_instance_uuid
@@ -264,12 +268,13 @@
         - instant_clone_from_vm_uuid is changed
 
 - name: set state to poweroff the VM
-  community.vmware.vmware_guest_powerstate:
+  vmware.vmware.vm_powerstate:
     validate_certs: false
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     name: Instant_cloned_uuid
+    datacenter: "{{ dc1 }}"
     folder: "{{ f0 }}"
     state: powered-off
   register: poweroff_instant_clone_from_vm_uuid
@@ -329,13 +334,14 @@
     var: idempotency_check
 
 - name: set state to poweroff the Cloned VM
-  community.vmware.vmware_guest_powerstate:
+  vmware.vmware.vm_powerstate:
     validate_certs: false
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     name: "cloned_vm_from_vm"
     folder: "{{ f0 }}"
+    datacenter: "{{ dc1 }}"
     state: powered-off
   register: poweroff_instant_clone_from_vm_parent
 
@@ -357,12 +363,13 @@
 - debug: var=delete_instant_clone_from_vm_parent
 
 - name: set state to poweroff the parent VM
-  community.vmware.vmware_guest_powerstate:
+  vmware.vmware.vm_powerstate:
     validate_certs: false
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     name: "test_vm1"
+    datacenter: "{{ dc1 }}"
     folder: "{{ f0 }}"
     state: powered-off
   register: poweroff_instant_clone_from_vm_parent

--- a/tests/integration/targets/vmware_guest_register_operation/tasks/main.yml
+++ b/tests/integration/targets/vmware_guest_register_operation/tasks/main.yml
@@ -26,12 +26,12 @@
   set_fact: vm_vmx_file_path="{{ vm_facts.instance.hw_files[0] }}"
 
 - name: Powered off the vm
-  vmware_guest_powerstate:
+  vmware.vmware.vm_powerstate:
+    datacenter: "{{ dc1 }}"
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     validate_certs: false
-    folder: /vm
     name: "{{ virtual_machines[0].name }}"
     state: powered-off
 

--- a/tests/integration/targets/vmware_guest_sendkey/tasks/main.yml
+++ b/tests/integration/targets/vmware_guest_sendkey/tasks/main.yml
@@ -10,7 +10,8 @@
     setup_virtualmachines: true
 
 - name: set state to poweron the first VM
-  vmware_guest_powerstate:
+  vmware.vmware.vm_powerstate:
+    datacenter: "{{ dc1 }}"
     validate_certs: false
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"


### PR DESCRIPTION
##### SUMMARY
Deprecate `community.vmware.vmware_guest_powerstate` in favor of `vmware.vmware.vm_powerstate`.


##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_guest_powerstate

##### ADDITIONAL INFORMATION
ansible-collections/vmware.vmware#114