### PR TITLE
Fix WebHandle to detect range support without relying on 'accept-ranges' header

### DIFF
--- a/changelogs/fragments/fix-webhandle-range-check.yaml
+++ b/changelogs/fragments/fix-webhandle-range-check.yaml
@@ -1,3 +1,3 @@
 bugfixes:
   - vmware_deploy_ovf - Fix detection of HTTP range support in `WebHandle` to support HTTP/2 endpoints like Nexus that do not return `accept-ranges` header
-  (https://github.com/ansible-collections/community.vmware/pull/2399).
+    (https://github.com/ansible-collections/community.vmware/pull/2399).

--- a/changelogs/fragments/fix-webhandle-range-check.yaml
+++ b/changelogs/fragments/fix-webhandle-range-check.yaml
@@ -1,4 +1,3 @@
 bugfixes:
-  - name: Fix detection of HTTP range support in `WebHandle` to support HTTP/2 endpoints like Nexus that do not return `accept-ranges` header.
-    modules:
-      - vmware_deploy_ovf
+  - vmware_deploy_ovf - Fix detection of HTTP range support in `WebHandle` to support HTTP/2 endpoints like Nexus that do not return `accept-ranges` header
+  (https://github.com/ansible-collections/community.vmware/pull/2399).

--- a/changelogs/fragments/fix-webhandle-range-check.yaml
+++ b/changelogs/fragments/fix-webhandle-range-check.yaml
@@ -1,0 +1,4 @@
+bugfixes:
+  - name: Fix detection of HTTP range support in `WebHandle` to support HTTP/2 endpoints like Nexus that do not return `accept-ranges` header.
+    modules:
+      - vmware_deploy_ovf

--- a/plugins/modules/vmware_deploy_ovf.py
+++ b/plugins/modules/vmware_deploy_ovf.py
@@ -249,6 +249,7 @@ def path_exists(value):
         raise ValueError(f"'{value}' is not a valid path")
     return value
 
+
 class WebHandle(object):
     def __init__(self, url):
         self.url = url

--- a/plugins/modules/vmware_deploy_ovf.py
+++ b/plugins/modules/vmware_deploy_ovf.py
@@ -249,7 +249,6 @@ def path_exists(value):
         raise ValueError(f"'{value}' is not a valid path")
     return value
 
-
 class WebHandle(object):
     def __init__(self, url):
         self.url = url
@@ -257,7 +256,6 @@ class WebHandle(object):
         self.ssl_context = None
 
         self.parsed_url = self._parse_url(url)
-
         self.https = self.parsed_url.group('scheme') == 'https://'
 
         if self.https:
@@ -267,16 +265,35 @@ class WebHandle(object):
 
             self.thumbprint = self._get_thumbprint(
                 self.parsed_url.group('hostname'))
-            r = urlopen(url=url, context=self.ssl_context)
+            r = urlopen(Request(url, method="HEAD"), context=self.ssl_context)
         else:
-            r = urlopen(url)
+            r = urlopen(Request(url, method="HEAD"))
+
         if r.code != 200:
             raise FileNotFoundError(url)
         self.headers = self._headers_to_dict(r)
-        if 'accept-ranges' not in self.headers:
-            raise Exception("Site does not accept ranges")
+
+        if 'content-length' not in self.headers:
+            raise Exception("Missing content-length in response")
         self.st_size = int(self.headers['content-length'])
+
+        # Perform a real range test instead of checking 'accept-ranges'
+        if not self._supports_range_request():
+            raise Exception("Site does not support range requests (no valid response to Range header)")
+
         self.offset = 0
+
+    def _supports_range_request(self):
+        req = Request(self.url)
+        req.add_header('Range', 'bytes=0-0')
+        try:
+            if self.ssl_context:
+                r = urlopen(req, context=self.ssl_context)
+            else:
+                r = urlopen(req)
+            return r.status == 206  # Partial Content
+        except Exception:
+            return False
 
     def _parse_url(self, url):
         HTTP_SCHEMA_PATTERN = (
@@ -288,10 +305,8 @@ class WebHandle(object):
 
     def _get_thumbprint(self, hostname):
         pem = ssl.get_server_certificate((hostname, 443))
-        sha1 = hashlib.sha1(
-            ssl.PEM_cert_to_DER_cert(pem)).hexdigest().upper()
+        sha1 = hashlib.sha1(ssl.PEM_cert_to_DER_cert(pem)).hexdigest().upper()
         colon_notion = ':'.join(sha1[i:i + 2] for i in range(0, len(sha1), 2))
-
         return None if sha1 is None else colon_notion
 
     def _headers_to_dict(self, r):


### PR DESCRIPTION
Some HTTP/2 servers, such as Sonatype Nexus, do not send the `accept-ranges` header,
even though they support ranged downloads. This causes `vmware_deploy_ovf.py` to fail
with "Site does not accept ranges", despite the server correctly supporting range requests.

This patch changes the logic to verify range support by sending a `Range: bytes=0-0` header
and checking if the response status is `206 Partial Content`, which is the actual indicator
of support.

This makes the module compatible with modern HTTP/2 servers such as Nexus and S3.

This change is also fully compatible with HTTP/1.1 servers, which respond identically to Range headers.
Thus, the new logic is both more accurate and backward-compatible.

Fixes: None directly, but observed with Nexus 3.x.
