### PR TITLE
vmware_vmotion: Fix same resource pool name

### DIFF
--- a/changelogs/fragments/1719-vmotion-same_resource_pool_name.yml
+++ b/changelogs/fragments/1719-vmotion-same_resource_pool_name.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - vmware_vmotion - Fix issue with same resource pool name on different clusters
+    (https://github.com/ansible-collections/community.vmware/issues/1719).

--- a/plugins/modules/vmware_vmotion.py
+++ b/plugins/modules/vmware_vmotion.py
@@ -174,7 +174,7 @@ from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.vmware.plugins.module_utils.vmware import (
     PyVmomi, find_hostsystem_by_name,
     find_vm_by_id, find_datastore_by_name,
-    find_resource_pool_by_name,
+    find_resource_pool_by_cluster,
     find_datacenter_by_name,
     find_cluster_by_name, get_all_objs,
     wait_for_task, TaskError)
@@ -392,8 +392,8 @@ class VmotionManager(PyVmomi):
         dest_resourcepool = self.params.get('destination_resourcepool', None)
         self.resourcepool_object = None
         if dest_resourcepool:
-            self.resourcepool_object = find_resource_pool_by_name(content=self.content,
-                                                                  resource_pool_name=dest_resourcepool)
+            self.resourcepool_object = find_resource_pool_by_cluster(content=self.content,
+                                                                     resource_pool_name=dest_resourcepool)
             if self.resourcepool_object is None:
                 self.module.fail_json(msg="Unable to find destination resource pool object for %s" % dest_resourcepool)
         elif not dest_resourcepool and self.host_object:


### PR DESCRIPTION
Fixes #1719

##### SUMMARY
Fix issue with same resource pool name on different clusters.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_vmotion

##### ADDITIONAL INFORMATION
