### PR TITLE
stable-4.x: Restrict pyvmomi to < 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ collections:
 VMware community collection depends on Python 3.9+ and on following third party libraries:
 
 * [`requests`](https://github.com/psf/requests)
-* [`Pyvmomi`](https://github.com/vmware/pyvmomi)
+* [`Pyvmomi`](https://github.com/vmware/pyvmomi) <9.0
 * [`vSphere Automation SDK for Python`](https://github.com/vmware/vsphere-automation-sdk-python/)
 * [`vSAN Management SDK for Python`](https://developer.broadcom.com/sdks/vsan-management-sdk-for-python/latest/)
 

--- a/changelogs/fragments/2415-restrict-pyvmomi.yml
+++ b/changelogs/fragments/2415-restrict-pyvmomi.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - Restrict pyvmomi to compatible versions
+    (https://github.com/ansible-collections/community.vmware/pull/2415).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests
-pyVmomi>=6.7.1
+pyVmomi>=6.7.1,<9.0
 git+https://github.com/vmware/vsphere-automation-sdk-python.git ; python_version >= '2.7'  # Python 2.6 is not supported

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,1 +1,1 @@
-pyvmomi
+pyVmomi>=6.7.1,<9.0


### PR DESCRIPTION
##### SUMMARY
There are some breaking changes in [pyvmomi 9.0](https://github.com/vmware/pyvmomi/releases/tag/v9.0.0.0). I don't think we should try to fix this in 4.x, but restrict support for pyvmomi.

Especially since 4.x will be EOL in a few months. I doesn't make sense to me to use an old version of this collection with the latest pyvmomi.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME

##### ADDITIONAL INFORMATION
#2413
#2414