### PR TITLE
Fix disk controller type issue and add cpu memory hotadd status

### DIFF
--- a/changelogs/fragments/2428-vmware_vm_config_optiion.yml
+++ b/changelogs/fragments/2428-vmware_vm_config_optiion.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - vmware_vm_config_option - change to use 'disk_ctl_device_type' defined in 'device_helper' and add 'support_cpu_hotadd',
+    'support_memory_hotadd', 'support_for_create' in output.
+    (https://github.com/ansible-collections/community.vmware/pull/2428) 

--- a/plugins/modules/vmware_vm_config_option.py
+++ b/plugins/modules/vmware_vm_config_option.py
@@ -204,7 +204,8 @@ class VmConfigOption(PyVmomi):
                 'support_disk_controller': support_disk_controller,
                 'support_ethernet_card': support_ethernet_card,
                 'support_cpu_hotadd': guest_os_desc[0].supportsCpuHotAdd,
-                'support_memory_hotadd': guest_os_desc[0].supportsMemoryHotAdd
+                'support_memory_hotadd': guest_os_desc[0].supportsMemoryHotAdd,
+                'support_for_create': guest_os_desc[0].supportedForCreate
             }
 
         return guest_os_option_dict

--- a/plugins/modules/vmware_vm_config_option.py
+++ b/plugins/modules/vmware_vm_config_option.py
@@ -118,10 +118,7 @@ class VmConfigOption(PyVmomi):
     def __init__(self, module):
         super(VmConfigOption, self).__init__(module)
         self.device_helper = PyVmomiDeviceHelper(self.module)
-        self.ctl_device_type = self.device_helper.scsi_device_type.copy()
-        self.ctl_device_type.update({'sata': self.device_helper.sata_device_type,
-                                     'nvme': self.device_helper.nvme_device_type}
-                                    )
+        self.ctl_device_type = self.device_helper.disk_ctl_device_type.copy()
         self.ctl_device_type.update(self.device_helper.usb_device_type)
         self.ctl_device_type.update(self.device_helper.nic_device_type)
         self.target_host = None
@@ -205,7 +202,9 @@ class VmConfigOption(PyVmomi):
                 'rec_vram_kb': guest_os_desc[0].vRAMSizeInKB.defaultValue,
                 'support_usb_controller': support_usb_controller,
                 'support_disk_controller': support_disk_controller,
-                'support_ethernet_card': support_ethernet_card
+                'support_ethernet_card': support_ethernet_card,
+                'support_cpu_hotadd': guest_os_desc[0].supportsCpuHotAdd,
+                'support_memory_hotadd': guest_os_desc[0].supportsMemoryHotAdd
             }
 
         return guest_os_option_dict


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
1. change to use `disk_ctl_device_type` defined in device_helper
2. add 'support_cpu_hotadd' and 'support_memory_hotadd' in returned info dict.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_vm_config_option

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
ok: [localhost] => {
    "get_config_options_result": {
        "changed": false,
        "failed": false,
        "instance": {
            "recommended_config_options": {
                "default_cdrom_controller": "sata",
                "default_disk_controller": "paravirtual",
                "default_ethernet": "vmxnet3",
                "default_secure_boot": true,
                "default_usb_controller": "",
                "guest_fullname": "AlmaLinux (64-bit)",
                "guest_id": "almalinux_64Guest",
                "hardware_version": "vmx-21",
                "rec_cpu_cores_per_socket": 1,
                "rec_cpu_socket": 1,
                "rec_disk_mb": 16384,
                "rec_firmware": "efi",
                "rec_memory_mb": 2048,
                "rec_persistent_memory": 8192,
                "rec_vram_kb": 8192,
                "support_cpu_hotadd": true,
                "support_disk_controller": [
                    "paravirtual",
                    "sata",
                    "nvme",
                    "ide"
                ],
                "support_ethernet_card": [
                    "vmxnet3",
                    "e1000e",
                    "sriov",
                    "pvrdma"
                ],
                "support_memory_hotadd": true,
                "support_min_persistent_mem_mb": 4,
                "support_persistent_memory": true,
                "support_secure_boot": true,
                "support_tpm_20": true,
                "support_usb_controller": [
                    "usb2",
                    "usb3"
                ]
            }
        }
    }
}

```
