### PR TITLE
Fix: All plays should be named

### DIFF
--- a/tools/prepare_release.yml
+++ b/tools/prepare_release.yml
@@ -1,6 +1,8 @@
-- hosts: localhost
+- name: Prepare release
+  hosts: localhost
   tasks:
     - name: Generate version
+      when: version is not defined
       block:
         - name: Get the next release version
           ansible.builtin.shell: git tag --sort=-creatordate --merged|head -n1|perl -pe 's/(\d+\.)(\d+)\.\d+/"$1" . ($2+1) . ".0"/e'
@@ -9,7 +11,6 @@
         - name: Set the release version
           ansible.builtin.set_fact:
             version: "{{ result.stdout }}"
-      when: version is not defined
 
     - name: Create release branch
       ansible.builtin.shell: git checkout -b "prepare_{{ version }}_release"

--- a/tools/unset_version.yml
+++ b/tools/unset_version.yml
@@ -1,4 +1,5 @@
-- hosts: localhost
+- name: Unset version
+  hosts: localhost
   tasks:
     - name: Get version
       block:


### PR DESCRIPTION
##### SUMMARY
Fix `All plays should be named`. Also fix `You can improve the task key order to: name, when, block`.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tools/prepare_release.yml
tools/unset_version.yml

##### ADDITIONAL INFORMATION
```
WARNING: tools/prepare_release.yml:1: name[play][/]: All plays should be named.
WARNING: tools/prepare_release.yml:3: key-order[task][/]: You can improve the task key order to: name, when, block
WARNING: tools/unset_version.yml:1: name[play][/]: All plays should be named.
```

[ansible-galaxy-importer](https://ansible.softwarefactory-project.io/zuul/build/2d31c68f843d4b86ac15065a4f215341)