### PR TITLE
add event query file for vmware_guest

### DIFF
--- a/extensions/audit/README.md
+++ b/extensions/audit/README.md
@@ -1,0 +1,1 @@
+This directory, and the event_query.yml file, are used by AAP (RedHat) to capture metadata about certain module usage.

--- a/extensions/audit/event_query.yml
+++ b/extensions/audit/event_query.yml
@@ -1,0 +1,17 @@
+---
+community.vmware.vmware_guest:
+  query: >-
+    .instance | {
+      name: .moid,
+      canonical_facts: {
+        instance_uuid: .instance_uuid,
+        bios_uuid: .hw_product_uuid,
+        moid: .moid,
+        esxi: .hw_esxi_host
+      },
+      facts: {
+        infra_type: "PrivateCloud",
+        infra_bucket: "Compute",
+        device_type: "VM"
+      }
+    }


### PR DESCRIPTION
##### SUMMARY
Adds a query file for the vmware_guest module. This file is only used by AAP to collect metadata about a modules usage. It has no impact on other use cases or modules.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_guest

##### ADDITIONAL INFORMATION
Sorry if this is a bit cryptic, I really dont have a ton more info but am happy to answer any other questions or concerns about the file