### PR TITLE
Add support for VCF license keys

### DIFF
--- a/changelogs/fragments/2451-vcenter_license_vcf_support.yml
+++ b/changelogs/fragments/2451-vcenter_license_vcf_support.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - vcenter_license - Add support for VCF license keys. (https://github.com/ansible-collections/community.vmware/pull/2451)

--- a/plugins/modules/vcenter_license.py
+++ b/plugins/modules/vcenter_license.py
@@ -182,6 +182,12 @@ def main():
         module.fail_json(msg="vcenter_license is meant for vCenter, hostname %s "
                              "is not vCenter server." % module.params.get('hostname'))
 
+    allowed_license_names = [
+        pyv.content.about.name,
+        'vCenter Server',
+        'vSphere 8 Enterprise Plus for VCF',
+    ]
+
     lm = pyv.content.licenseManager
 
     result['licenses'] = pyv.list_keys(lm.licenses)
@@ -228,7 +234,7 @@ def main():
                 if 'esx' not in key.editionKey:
                     module.warn('License key "%s" edition "%s" is not suitable for ESXi server' % (license, key.editionKey))
             # backward compatibility - check if it's is a vCenter licence key
-            elif pyv.content.about.name in key.name or 'vCenter Server' in key.name:
+            elif any(name in key.name for name in allowed_license_names):
                 entityId = pyv.content.about.instanceUuid
 
         # if we have found a cluster, an esxi or a vCenter object we try to assign the licence


### PR DESCRIPTION
##### SUMMARY
Currently, the `vcenter_license` module does not support assigning vSphere VCF keys to vCenter servers. The vSphere 8 VCF keys include support vCenter Server 8.0U2 and above (https://knowledge.broadcom.com/external/article/319282/vmware-cloud-foundation-and-vsphere-foun.html)

This PR adds support for an array lookup to aid in future instances like this.

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
`vcenter_license`

##### ADDITIONAL INFORMATION
MInimal reproduction;
~~~ yaml
    - name: License vCenter
      community.vmware.vcenter_license:
        hostname: "{{ vcenter_hostname }}"
        username: "{{ vcenter_username }}"
        password: "{{ vcenter_password }}"
        validate_certs: false
        license: "{{ vmware_license_key }}"
        state: present
~~~

Currently results in:
~~~ shell
ok: [localhost] => {
    "changed": false,
    "diff": {},
    "invocation": {
        "module_args": {
            "cluster_name": null,
            "datacenter": null,
            "esxi_hostname": null,
            "hostname": "vcenter_foo",
            "labels": {
                "source": "ansible"
            },
            "license": "xxxxxx-xxxx-foo",
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "port": 443,
            "proxy_host": null,
            "proxy_port": null,
            "state": "present",
            "username": "administrator@vsphere.local",
            "validate_certs": false
        }
    },
    "licenses": [
        "xxxxxx-xxxx-foo"
    ]
}
~~~

The key is added, but never assigned.

My change:
~~~ shell
changed: [localhost] => {
    "changed": true,
    "diff": {},
    "invocation": {
        "module_args": {
            "cluster_name": null,
            "datacenter": null,
            "esxi_hostname": null,
            "hostname": "vcenter_foo",
            "labels": {
                "source": "ansible"
            },
            "license": "xxxxxx-xxxx-foo",
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "port": 443,
            "proxy_host": null,
            "proxy_port": null,
            "state": "present",
            "username": "administrator@vsphere.local",
            "validate_certs": false
        }
    },
    "licenses": [
        "xxxxxx-xxxx-foo"
    ]
}
~~~
