### PR TITLE
fix(vmware_guest_register_operation): fix vms not being registered in the provided resource_pool

### DIFF
--- a/changelogs/fragments/2453-vmware-guest-register-operation-resource-pool.yaml
+++ b/changelogs/fragments/2453-vmware-guest-register-operation-resource-pool.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_guest_register_operation - Fix module not handling the ``resource_pool`` argument correctly when registering a VM (https://github.com/ansible-collections/community.vmware/pull/2453).

--- a/plugins/modules/vmware_guest_register_operation.py
+++ b/plugins/modules/vmware_guest_register_operation.py
@@ -209,8 +209,8 @@ class VMwareGuestRegisterOperation(PyVmomi):
                 if not cluster_obj:
                     self.module.fail_json(msg="Cannot find the specified cluster name: %s" % self.cluster)
 
-                resource_pool_obj = cluster_obj.resourcePool
-            elif self.resource_pool:
+                resource_pool_obj = cluster_obj.resourcePool # default cluster resource pool
+            if self.resource_pool: # If a resource pool is specified, use it rather than the default cluster resource pool as it is more specific
                 resource_pool_obj = find_resource_pool_by_name(self.content, self.resource_pool)
                 if not resource_pool_obj:
                     self.module.fail_json(msg="Cannot find the specified resource pool: %s" % self.resource_pool)
@@ -268,7 +268,7 @@ def main():
                            ],
                            required_one_of=[
                                ['name', 'uuid'],
-                               ['cluster', 'esxi_hostname']
+                               ['cluster', 'esxi_hostname', 'resource_pool']
                            ],
                            supports_check_mode=True)
 

--- a/plugins/modules/vmware_guest_register_operation.py
+++ b/plugins/modules/vmware_guest_register_operation.py
@@ -209,8 +209,8 @@ class VMwareGuestRegisterOperation(PyVmomi):
                 if not cluster_obj:
                     self.module.fail_json(msg="Cannot find the specified cluster name: %s" % self.cluster)
 
-                resource_pool_obj = cluster_obj.resourcePool # default cluster resource pool
-            if self.resource_pool: # If a resource pool is specified, use it rather than the default cluster resource pool as it is more specific
+                resource_pool_obj = cluster_obj.resourcePool  # default cluster resource pool
+            if self.resource_pool:  # If a resource pool is specified, use it rather than the default cluster resource pool as it is more specific
                 resource_pool_obj = find_resource_pool_by_name(self.content, self.resource_pool)
                 if not resource_pool_obj:
                     self.module.fail_json(msg="Cannot find the specified resource pool: %s" % self.resource_pool)


### PR DESCRIPTION
##### SUMMARY

This module doesn't register vms in the specified resource pool.

When removing the cluster argument, and only using the resource pool such as in the following module documentation example:

```yaml
- name: Register VM in resource pool
  community.vmware.vmware_guest_register_operation:
    hostname: "{{ vcenter_hostname }}"
    username: "{{ vcenter_username }}"
    password: "{{ vcenter_password }}"
    datacenter: "{{ datacenter }}"
    folder: "/vm"
    resource_pool: "{{ resource_pool }}"
    name: "{{ vm_name }}"
    template: false
    path: "[datastore1] vm/vm.vmx"
    state: present

```
 the module cannot run at all.
If the cluster argument is provided additionally as follows :

```diff
 - name: Register VM in resource pool
   community.vmware.vmware_guest_register_operation:
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
     password: "{{ vcenter_password }}"
     datacenter: "{{ datacenter }}"
     folder: "/vm"
+   cluster: blabla
     resource_pool: "{{ resource_pool }}"
     name: "{{ vm_name }}"
     template: false
     path: "[datastore1] vm/vm.vmx"
     state: present

```

The resource_pool argument was completely ignored due to the if / elif construct, and the vm not registered in that resource pool at all, but rather registered in the cluster global default resource pool.

This change allows to : 
- use resource_pool argument only without providing the cluster nor the esxi_hostname
-  Ensures the vm is properly registered in the given resource_pool, even if the cluster argument is provided. (cluster is mutually exclusive with esxi hostname so we never have the case of resource_pool AND esxi_hostname at the same time)

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_guest_register_operation.py


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
