### PR TITLE
6.0.0: ansible-core / vmware.vmware requirements

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -79,8 +79,8 @@ jobs:
           # consider dropping testing against EOL versions and versions you don't support.
         # - stable-2.15
         # - stable-2.16
-          - stable-2.17
-          - stable-2.18
+        # - stable-2.17
+        # - stable-2.18
           - stable-2.19
         # - devel
           - milestone
@@ -129,8 +129,8 @@ jobs:
           # consider dropping testing against EOL versions and versions you don't support.
         # - stable-2.15
         # - stable-2.16
-          - stable-2.17
-          - stable-2.18
+        # - stable-2.17
+        # - stable-2.18
           - stable-2.19
         # - devel
           - milestone

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The collection includes the VMware modules and plugins supported by Ansible VMwa
 
 ## Ansible version compatibility
 
-This collection has been tested against following Ansible versions: **>=2.17.0**.
+This collection has been tested against following Ansible versions: **>=2.19.0**.
 
 Plugins and modules within a collection may be tested with only specific Ansible versions.
 A collection may contain metadata that identifies these versions.

--- a/changelogs/fragments/6.0.0_ansible-core_vmware.vmware-requirements.yml
+++ b/changelogs/fragments/6.0.0_ansible-core_vmware.vmware-requirements.yml
@@ -1,0 +1,3 @@
+breaking_changes:
+  - Removed support for ansible-core < 2.19.0.
+  - Removed support for vmware.vmware < 2.0.0.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -18,7 +18,7 @@ tags:
   - vmware
   - virtualization
 dependencies:
-  vmware.vmware: ">=1.10.0,<3.0.0"
+  vmware.vmware: ">=2.0.0"
 repository: https://github.com/ansible-collections/community.vmware.git
 homepage: https://github.com/ansible-collections/community.vmware
 issues: https://github.com/ansible-collections/community.vmware/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,5 +1,5 @@
 ---
-requires_ansible: '>=2.17.0'
+requires_ansible: '>=2.19.0'
 
 action_groups:
   vmware:


### PR DESCRIPTION
6.0.0 won't support ansible-core < 2.19.0 or vmware.vmware < 2.0.0.