### PR TITLE
Deprecate vmware_guest_snapshot

### DIFF
--- a/.github/workflows/extra-docs-linting.yml
+++ b/.github/workflows/extra-docs-linting.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install dependent collections
         run: >
           ansible-galaxy collection install
-          'vmware.vmware>=1.10.0'
+          'vmware.vmware>=2.0.0'
 
       - name: Run collection docs linter
         run: antsibull-docs lint-collection-docs . --plugin-docs --skip-rstcheck

--- a/changelogs/fragments/2467-deprecate-vmware_guest_snapshot.yml
+++ b/changelogs/fragments/2467-deprecate-vmware_guest_snapshot.yml
@@ -1,0 +1,3 @@
+deprecated_features:
+  - vmware_guest_snapshot - the module has been deprecated and will be removed in community.vmware 8.0.0
+    (https://github.com/ansible-collections/community.vmware/pull/2467).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -233,6 +233,10 @@ plugin_routing:
       deprecation:
         removal_version: 7.0.0
         warning_text: Use vmware.vmware.vm_powerstate instead.
+    vmware_guest_snapshot:
+      deprecation:
+        removal_version: 8.0.0
+        warning_text: Use vmware.vmware.vm_snapshot instead.
     vmware_host:
       deprecation:
         removal_version: 7.0.0

--- a/plugins/modules/vmware_guest_snapshot.py
+++ b/plugins/modules/vmware_guest_snapshot.py
@@ -13,6 +13,10 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 ---
 module: vmware_guest_snapshot
+deprecated:
+  removed_in: 8.0.0
+  why: This module has been L(moved to vmware.vmware,https://github.com/ansible-collections/vmware.vmware/pull/126)
+  alternative: Use M(vmware.vmware.vm_snapshot) instead.
 short_description: Manages virtual machines snapshots in vCenter
 description:
     - This module can be used to create, delete and update snapshot(s) of the given virtual machine.

--- a/tests/integration/targets/vmware_guest_info/tasks/main.yml
+++ b/tests/integration/targets/vmware_guest_info/tasks/main.yml
@@ -141,7 +141,7 @@
 
 # Testcase 0004: Get details about virtual machines with two snapshots using UUID
 - name: Create first snapshot
-  vmware_guest_snapshot: &vm_snap
+  vmware.vmware.vm_snapshot: &vm_snap
     validate_certs: false
     hostname: "{{ vcenter_hostname }}"
     username: "{{ vcenter_username }}"
@@ -153,7 +153,7 @@
     snapshot_name: snap1
 
 - name: Create second snapshot
-  vmware_guest_snapshot:
+  vmware.vmware.vm_snapshot:
     <<: *vm_snap
     snapshot_name: snap2
 


### PR DESCRIPTION
##### SUMMARY
Deprecate `community.vmware.vmware_guest_snapshot` in favor of `vmware.vmware.vm_snapshot`.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_guest_snapshot

##### ADDITIONAL INFORMATION
ansible-collections/vmware.vmware#126