### PR TITLE
Remove unnecessary sanity test ignores

### DIFF
--- a/tests/sanity/ignore-2.17.txt
+++ b/tests/sanity/ignore-2.17.txt
@@ -1,4 +1,0 @@
-plugins/modules/vmware_deploy_ovf.py replace-urlopen!skip
-plugins/modules/vmware_deploy_ovf.py use-argspec-type-path!skip
-scripts/inventory/vmware_inventory.py pep8!skip
-tests/unit/mock/loader.py pep8!skip

--- a/tests/sanity/ignore-2.18.txt
+++ b/tests/sanity/ignore-2.18.txt
@@ -1,4 +1,0 @@
-plugins/modules/vmware_deploy_ovf.py replace-urlopen!skip
-plugins/modules/vmware_deploy_ovf.py use-argspec-type-path!skip
-scripts/inventory/vmware_inventory.py pep8!skip
-tests/unit/mock/loader.py pep8!skip


### PR DESCRIPTION
##### SUMMARY
Since we don't support Ansible-core < 2.19.0 in 6.x, we don't need those ignores anymore.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
tests/sanity/ignore-2.17.txt
tests/sanity/ignore-2.18.txt

##### ADDITIONAL INFORMATION