### PR TITLE
5.0.0: Remove ansible.module_utils.six.PY2 from vsphere_file

### DIFF
--- a/changelogs/fragments/2476-remove-ansible.module_utils.six.PY2.yml
+++ b/changelogs/fragments/2476-remove-ansible.module_utils.six.PY2.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - vsphere_file - Remove ``ansible.module_utils.six.PY2``
+    (https://github.com/ansible-collections/community.vmware/pull/2476).

--- a/plugins/modules/vsphere_file.py
+++ b/plugins/modules/vsphere_file.py
@@ -106,10 +106,8 @@ RETURN = r'''
 '''
 
 import socket
-import sys
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six import PY2
 from ansible.module_utils.six.moves.urllib.error import HTTPError
 from ansible.module_utils.six.moves.urllib.parse import quote, urlencode
 from ansible.module_utils.urls import open_url
@@ -181,9 +179,6 @@ def main():
     except Exception as e:
         module.fail_json(msg=to_native(e), errno=dir(e), reason=to_native(e), **result)
 
-    if PY2:
-        sys.exc_clear()  # Avoid false positive traceback in fail_json() on Python 2
-
     status = r.getcode()
     if status == 200:
         exists = True
@@ -213,9 +208,6 @@ def main():
                 module.fail_json(msg=to_native(e), errno=e[0], reason=to_native(e), **result)
             except Exception as e:
                 module.fail_json(msg=to_native(e), errno=e[0], reason=to_native(e), **result)
-
-            if PY2:
-                sys.exc_clear()  # Avoid false positive traceback in fail_json() on Python 2
 
             result['reason'] = r.msg
             result['status'] = r.getcode()
@@ -253,9 +245,6 @@ def main():
             except Exception as e:
                 module.fail_json(msg=to_native(e), errno=e[0], reason=to_native(e), **result)
 
-            if PY2:
-                sys.exc_clear()  # Avoid false positive traceback in fail_json() on Python 2
-
             result['reason'] = r.msg
             result['status'] = r.getcode()
             if result['status'] != 201:
@@ -272,9 +261,6 @@ def main():
                 module.fail_json(msg=to_native(e), errno=e[0], reason=to_native(e), **result)
             except Exception as e:
                 module.fail_json(msg=to_native(e), errno=e[0], reason=to_native(e), **result)
-
-            if PY2:
-                sys.exc_clear()  # Avoid false positive traceback in fail_json() on Python 2
 
             status = r.getcode()
             if status != 204:
@@ -313,9 +299,6 @@ def main():
                 module.fail_json(msg=to_native(e), errno=e[0], reason=to_native(e), **result)
             except Exception as e:
                 module.fail_json(msg=to_native(e), errno=e[0], reason=to_native(e), **result)
-
-            if PY2:
-                sys.exc_clear()  # Avoid false positive traceback in fail_json() on Python 2
 
             result['reason'] = r.msg
             result['status'] = r.getcode()


### PR DESCRIPTION
Backport of #2475

##### SUMMARY
Version 5 doesn't support any ansible-core release that still supports Python 2, so let's get rid of `ansible.module_utils.six.PY2`.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vsphere_file

##### ADDITIONAL INFORMATION
There's already a sanity test about this in devel, so we will run into this sooner or later anyway: #2472.