### PR TITLE
 Fix failing VM when nested resource pool is used

### DIFF
--- a/plugins/module_utils/vmware.py
+++ b/plugins/module_utils/vmware.py
@@ -1703,7 +1703,7 @@ class PyVmomi(PyvmomiClient):
         # Clean the path and split into components
         path = resource_pool_path.strip('/')
         path_parts = [part for part in path.split('/') if part]
-        
+
         # If path starts with cluster name, remove it from path_parts
         if path_parts and cluster and hasattr(cluster, 'name') and path_parts[0] == cluster.name:
             path_parts = path_parts[1:]


### PR DESCRIPTION
##### SUMMARY
This change implements possibility to  specify cluster and nested resource pool  during VM creation from ova file.
When this solution is applied  then resource pool can be specified in several ways:

-     just name of resource pool. For example: child-resource-pool. It will work, but there is a limitation if you have same RP names on same cluster in different parent resource pools. In that case it will put it to first occurrence
-     path to resource pool from cluster level For example: /cl01/parent-resource-pool/child-resource-pool
-     path to resource pool from first parent level. For example: /parent-resource-pool/child-resource-pool

Closes-Bug: #2491

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
community.vmware.vmware_deploy_ovf

##### ADDITIONAL INFORMATION
