### PR TITLE
[WIP] stable-5.x: Replace ansible.module_utils.six

### DIFF
--- a/changelogs/fragments/2495-drop_ansible.module_utils.six.yml
+++ b/changelogs/fragments/2495-drop_ansible.module_utils.six.yml
@@ -1,0 +1,2 @@
+major_changes:
+  - Replace ``ansible.module_utils.six`` (https://github.com/ansible-collections/community.vmware/pull/2495).

--- a/plugins/httpapi/vmware.py
+++ b/plugins/httpapi/vmware.py
@@ -21,7 +21,7 @@ import json
 
 from ansible.module_utils.basic import to_text
 from ansible.errors import AnsibleConnectionFailure
-from ansible.module_utils.six.moves.urllib.error import HTTPError
+from urllib.error import HTTPError
 from ansible.plugins.httpapi import HttpApiBase
 from ansible.module_utils.connection import ConnectionError
 

--- a/plugins/module_utils/vmware.py
+++ b/plugins/module_utils/vmware.py
@@ -46,7 +46,7 @@ except ImportError:
 from ansible.module_utils._text import to_text, to_native
 from ansible.module_utils.six import integer_types, iteritems, string_types, raise_from
 from ansible.module_utils.basic import missing_required_lib
-from ansible.module_utils.six.moves.urllib.parse import unquote
+from urllib.parse import unquote
 from ansible_collections.community.vmware.plugins.module_utils._argument_spec import base_argument_spec
 
 

--- a/plugins/modules/vmware_cfg_backup.py
+++ b/plugins/modules/vmware_cfg_backup.py
@@ -89,7 +89,7 @@ from ansible_collections.community.vmware.plugins.module_utils.vmware import get
 from ansible_collections.community.vmware.plugins.module_utils._argument_spec import base_argument_spec
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import open_url
-from ansible.module_utils.six.moves.urllib.error import HTTPError
+from urllib.error import HTTPError
 from ansible.module_utils._text import to_native
 
 

--- a/plugins/modules/vmware_cluster_info.py
+++ b/plugins/modules/vmware_cluster_info.py
@@ -185,7 +185,7 @@ except ImportError:
     pass
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six.moves.urllib.parse import unquote
+from urllib.parse import unquote
 from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, find_datacenter_by_name, find_cluster_by_name, get_parent_datacenter
 from ansible_collections.community.vmware.plugins.module_utils._argument_spec import base_argument_spec
 from ansible_collections.community.vmware.plugins.module_utils.vmware_rest_client import VmwareRestClient

--- a/plugins/modules/vmware_deploy_ovf.py
+++ b/plugins/modules/vmware_deploy_ovf.py
@@ -223,7 +223,7 @@ from threading import Thread
 from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.six import string_types
-from ansible.module_utils.six.moves.urllib.request import Request, urlopen
+from urllib.request import Request, urlopen
 from ansible.module_utils.urls import generic_urlparse, open_url, urlparse, urlunparse
 from ansible_collections.community.vmware.plugins.module_utils.vmware import (
     find_all_networks_by_name,

--- a/plugins/modules/vmware_dvs_portgroup_find.py
+++ b/plugins/modules/vmware_dvs_portgroup_find.py
@@ -86,7 +86,7 @@ except ImportError:
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi
 from ansible_collections.community.vmware.plugins.module_utils._argument_spec import base_argument_spec
-from ansible.module_utils.six.moves.urllib.parse import unquote
+from urllib.parse import unquote
 
 
 class DVSPortgroupFindManager(PyVmomi):

--- a/plugins/modules/vmware_dvs_portgroup_info.py
+++ b/plugins/modules/vmware_dvs_portgroup_info.py
@@ -153,7 +153,7 @@ from ansible_collections.community.vmware.plugins.module_utils.vmware import (
     get_all_objs,
     find_dvs_by_name)
 from ansible_collections.community.vmware.plugins.module_utils._argument_spec import base_argument_spec
-from ansible.module_utils.six.moves.urllib.parse import unquote
+from urllib.parse import unquote
 
 
 class DVSPortgroupInfoManager(PyVmomi):

--- a/plugins/modules/vmware_guest_screenshot.py
+++ b/plugins/modules/vmware_guest_screenshot.py
@@ -128,7 +128,7 @@ except ImportError:
     pass
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six.moves.urllib.parse import urlencode, quote
+from urllib.parse import urlencode, quote
 from ansible.module_utils._text import to_native
 from ansible.module_utils.urls import open_url
 from ansible_collections.community.vmware.plugins.module_utils.vmware import PyVmomi, wait_for_task, get_parent_datacenter

--- a/plugins/modules/vsphere_copy.py
+++ b/plugins/modules/vsphere_copy.py
@@ -118,7 +118,7 @@ import socket
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six.moves.urllib.parse import urlencode, quote
+from urllib.parse import urlencode, quote
 from ansible.module_utils._text import to_native
 from ansible.module_utils.urls import open_url
 from ansible_collections.community.vmware.plugins.module_utils._argument_spec import base_argument_spec

--- a/plugins/modules/vsphere_file.py
+++ b/plugins/modules/vsphere_file.py
@@ -108,8 +108,8 @@ RETURN = r'''
 import socket
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six.moves.urllib.error import HTTPError
-from ansible.module_utils.six.moves.urllib.parse import quote, urlencode
+from urllib.error import HTTPError
+from urllib.parse import quote, urlencode
 from ansible.module_utils.urls import open_url
 from ansible.module_utils._text import to_native
 from ansible_collections.community.vmware.plugins.module_utils._argument_spec import base_argument_spec


### PR DESCRIPTION
##### SUMMARY
Backport of #2495:

It looks like `ansible.module_utils.six` will be deprecated in ansible-core 2.20.0 (ansible/ansible#85934). Since we / the PyPI packages we use don't support Python 2 anymore, I think we can use the Python standard library equivalents instead.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/httpapi/vmware.py plugins/module_utils/vmware.py
plugins/modules/vmware_cfg_backup.py
plugins/modules/vmware_cluster_info.py
plugins/modules/vmware_deploy_ovf.py
plugins/modules/vmware_dvs_portgroup_find.py
plugins/modules/vmware_dvs_portgroup_info.py
plugins/modules/vmware_guest_screenshot.py
plugins/modules/vsphere_copy.py
plugins/modules/vsphere_file.py

##### ADDITIONAL INFORMATION
#2472
#2479
https://forum.ansible.com/t/44616