### PR TITLE
Bump vmware.vmware requirement to 2.5.0

### DIFF
--- a/.github/workflows/extra-docs-linting.yml
+++ b/.github/workflows/extra-docs-linting.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install dependent collections
         run: >
           ansible-galaxy collection install
-          'vmware.vmware>=2.0.0'
+          'vmware.vmware>=2.5.0'
 
       - name: Run collection docs linter
         run: antsibull-docs lint-collection-docs . --plugin-docs --skip-rstcheck

--- a/changelogs/fragments/2503-vmware.vmware-2.5.0.yml
+++ b/changelogs/fragments/2503-vmware.vmware-2.5.0.yml
@@ -1,0 +1,3 @@
+major_changes:
+  - Bump required ``vmware.vmware`` collection version to 2.5.0
+    (https://github.com/ansible-collections/community.vmware/pull/2503).

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -18,7 +18,7 @@ tags:
   - vmware
   - virtualization
 dependencies:
-  vmware.vmware: ">=2.0.0"
+  vmware.vmware: ">=2.5.0"
 repository: https://github.com/ansible-collections/community.vmware.git
 homepage: https://github.com/ansible-collections/community.vmware
 issues: https://github.com/ansible-collections/community.vmware/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc

--- a/plugins/module_utils/vmware.py
+++ b/plugins/module_utils/vmware.py
@@ -1050,8 +1050,8 @@ class PyVmomi(PyvmomiClient):
                              password=module.params['password'],
                              port=module.params['port'],
                              validate_certs=module.params['validate_certs'],
-                             http_proxy_host=module.params['proxy_host'],
-                             http_proxy_port=module.params['proxy_port'])
+                             proxy_host=module.params['proxy_host'],
+                             proxy_port=module.params['proxy_port'])
         except ApiAccessError as aae:
             module.fail_json(msg=str(aae))
         self.params = module.params


### PR DESCRIPTION
##### SUMMARY
Bump vmware.vmware requirement to 2.5.0.

The changes to plugins/module_utils/vmware.py should make sure we're compatible with vmware.vmware 3.0.0: ansible-collections/vmware.vmware#262

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/module_utils/vmware.py

##### ADDITIONAL INFORMATION
ansible-collections/vmware.vmware#261