### PR TITLE
vmware_guest_network add error rise and improve O(folder) description

### DIFF
--- a/plugins/modules/vmware_guest_network.py
+++ b/plugins/modules/vmware_guest_network.py
@@ -639,6 +639,10 @@ class PyVmomiHelper(PyVmomi):
     def _get_nic_info(self):
         rv = {'network_info': []}
         vm_obj = self.get_vm()
+
+        if not vm_obj:
+            self.module.fail_json(msg='could not find vm: {0}'.format(self.params['name']))
+
         nic_info, nic_obj_lst = self._get_nics_from_vm(vm_obj)
 
         rv['network_info'] = nic_info


### PR DESCRIPTION
##### SUMMARY
Raise an error when vm_obj not found and improve vmware_guest_network documentation. O(folder) does not work when O(datacenter) is set by default or incorrectly. This behavior is now documented.

##### ISSUE TYPE
- Docs Pull Request
- Bugfix Pull Request


##### COMPONENT NAME
vmware_guest_network.py

##### ADDITIONAL INFORMATION

The module searches for the VM using def get_vm(self).
If name is in self.params, it loops through all VMs:
```py
            objects = self.get_managed_objects_properties(vim_type=vim.VirtualMachine, properties=['name'])
            vms = []

            for temp_vm_object in objects:
                if (
                    len(temp_vm_object.propSet) == 1
                    and unquote(temp_vm_object.propSet[0].val) == self.params["name"]
                ):
                    vms.append(temp_vm_object.obj)
```
When multiple VMs are found, it checks:
```py
                for vm in vms:

                    # Check if user has provided same path as virtual machine
                    actual_vm_folder_path = self.get_vm_path(content=self.content, vm_name=vm)
                    if not actual_vm_folder_path.startswith("%s%s" % (dcpath, user_defined_dc)):
                        continue
                    if user_desired_path in actual_vm_folder_path:
                        vm_obj = vm
                        break
```
This code selects the first matching VM, which is not ideal, but changing this behavior is out of scope for this PR.
It checks if not actual_vm_folder_path.startswith("%s%s" % (dcpath, user_defined_dc)). Without a correct O(datacenter) value, it skips the VMs.



In my scenario, I had O(folder) specified and multiple VMs with the same name in different folders. O(datacenter) was left at its default value because it was not documented as required.

As a result, find_vm() returned None, and finally get_nics_from_vm() raised an error: AttributeError: 'NoneType' object has no attribute 'config'.
