### PR TITLE
bugfix storage policy search

### DIFF
--- a/changelogs/fragments/2532-fix-storage-policy-search.yml
+++ b/changelogs/fragments/2532-fix-storage-policy-search.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - vmware_guest_storage_policy - Fix storage policy search to return None if no policies are found, instead of causing an exception.
+    fixes https://github.com/ansible-collections/community.vmware/issues/2527

--- a/plugins/modules/vmware_guest_storage_policy.py
+++ b/plugins/modules/vmware_guest_storage_policy.py
@@ -186,6 +186,8 @@ class SPBM_helper(SPBM):
         if len(profileIds) > 0:
             storageProfiles = profileManager.PbmRetrieveContent(
                 profileIds=profileIds)
+        else:
+            return None
 
         for storageProfile in storageProfiles:
             if storageProfile.name == name:


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/community.vmware/issues/2527

If this module is unable to find a storage profile when searching by name, a variable is accessed before it is defined. This change fixes the issue by returning a `None` object. The module handles this situation with a controlled failure and more helpful error message.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_guest_storage_policy
