### PR TITLE
Change datastore check to check if the destination_datastore is the "primary" datastore in vmware_vmotion.py

### DIFF
--- a/plugins/modules/vmware_vmotion.py
+++ b/plugins/modules/vmware_vmotion.py
@@ -300,7 +300,7 @@ class VmotionManager(PyVmomi):
                                                                        dest_host_name,
                                                                        "', '".join([ds.name for ds in self.host_object.datastore])))
 
-            if self.vm.runtime.host.name == dest_host_name and dest_datastore in [ds.name for ds in self.vm.datastore]:
+            if self.vm.runtime.host.name == dest_host_name and vm_ds_name == self.datastore_object.name:
                 change_required = False
 
         elif self.host_object and self.datastore_cluster_object:
@@ -335,7 +335,7 @@ class VmotionManager(PyVmomi):
                                                                                     self.cluster_object.datastore])))
 
             if self.vm.runtime.host.name in [host.name for host in self.cluster_hosts] and \
-                    dest_datastore in [ds.name for ds in self.vm.datastore]:
+                    vm_ds_name == self.datastore_object.name:
                 change_required = False
 
         elif self.cluster_object and self.datastore_cluster_object:
@@ -370,7 +370,7 @@ class VmotionManager(PyVmomi):
 
         elif (self.datastore_object and self.host_object is None) or (
                 self.datastore_object and self.cluster_object is None):
-            if self.datastore_object in self.vm.datastore:
+            if vm_ds_name == self.datastore_object.name:
                 # VM is already located on same datastore
                 change_required = False
 


### PR DESCRIPTION
This change enables vMotion storage migration between datastores in the same host even when the destination datastore is technically used by the VM for ISO/media storage, but the VM doesn't actually "live" on that datastore. Before this, trying to do Storage vMotion via the module always returned no changes needed. 

##### SUMMARY
The original logic evaluated idempotency by checking whether the destination datastore was present in vm.datastore. This list includes all datastores referenced by the VM, such as:

- ISO/media datastores

Because of this, the module could incorrectly conclude that no change was required even when the VM’s home datastore differed from the requested destination.

This change updates the comparison logic to use the VM’s actual home datastore derived from:

- vm.config.files.vmPathName

This accurately reflects where the VM “lives” and aligns the module’s behavior with vSphere UI and API semantics. This change does not modify migration behavior itself; we are just tweaking the logic used to determine whether a change is required.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_vmotion

##### ADDITIONAL INFORMATION
`
- name: Rename VM Files and Folders via vMotion Datastore migration  
  community.vmware.vmware_vmotion:
    hostname: "{{ hostvars[inventory_hostname].vsphere_hostname }}"
    username: "{{ hostvars[inventory_hostname].vsphere_username }}"
    validate_certs: "{{ hostvars[inventory_hostname].vsphere_validate_certs }}"
    password: "{{ hostvars[inventory_hostname].vsphere_password }}"
    use_instance_uuid: true
    vm_uuid: "{{ vsphere_instance_uuid }}"
    destination_datastore: "{{ new_vm_datastore }}"
    destination_datacenter: "{{ hostvars[inventory_hostname].vsphere_datacenter  }}"
  delegate_to: localhost
  register: vmotion_info
  environment: # needed for validate_certs = false to apply per notes https://docs.ansible.com/projects/ansible/latest/collections/vmware/vmware/vms_inventory.html#ansible-collections-vmware-vmware-vms-inventory
    REQUESTS_CA_BUNDLE: ""
`

Before
```paste below
2026-01-27 14:14:48,520 p=2662443 u=admin_user n=ansible | ok: [server.domain.tld -> localhost] => changed=false 
  datastore: datastore2
  invocation:
    module_args:
      destination_cluster: null
      destination_datacenter: datacenter0
      destination_datastore: datastore2
      destination_datastore_cluster: null
      destination_host: null
      destination_resourcepool: null
      hostname: vmware_host.domain.tld
      moid: null
      password: VALUE_SPECIFIED_IN_NO_LOG_PARAMETER
      port: 443
      proxy_host: null
      proxy_port: null
      timeout: 3600
      use_instance_uuid: true
      username: vmware_service_account 
      validate_certs: false
      vm_name: null
      vm_uuid: 50070b89-4a09-6038-51f7-ee8ce36bca16
```

After
```
2026-01-28 08:25:14,467 p=2789545 u=admin_user n=ansible | ok: [server.domain.tld -> localhost] => changed=true 
  datastore: datastore2
  invocation:
    module_args:
      destination_cluster: null
      destination_datacenter: datacenter0
      destination_datastore: datastore2
      destination_datastore_cluster: null
      destination_host: null
      destination_resourcepool: null
      hostname: vmware_host.domain.tld
      moid: null
      password: VALUE_SPECIFIED_IN_NO_LOG_PARAMETER
      port: 443
      proxy_host: null
      proxy_port: null
      timeout: 3600
      use_instance_uuid: true
      username: vmware_service_account 
      validate_certs: false
      vm_name: null
      vm_uuid: 50070b89-4a09-6038-51f7-ee8ce36bca16
```
