### PR TITLE
Remove vmware_guest_powerstate from other modules

### DIFF
--- a/plugins/modules/vmware_guest_instant_clone.py
+++ b/plugins/modules/vmware_guest_instant_clone.py
@@ -19,7 +19,7 @@ short_description: Instant Clone VM
 description:
 - This module can be used for Creating a powered-on Instant Clone of a virtual machine.
 - M(community.vmware.vmware_guest) module is needed for creating a VM with poweredon state which would be used as a parent VM.
-- M(community.vmware.vmware_guest_powerstate) module is also needed to poweroff the instant cloned module.
+- M(vmware.vmware.vm_powerstate) module is also needed to poweroff the instant cloned module.
 - The powered off VM would in turn be deleted by again using M(community.vmware.vmware_guest) module.
 - Thus M(community.vmware.vmware_guest) module is necessary for removing Instant Cloned VM when VMs being created in testing environment.
 - Also GuestOS Customization has now been added with guestinfo_vars parameter.
@@ -161,31 +161,6 @@ EXAMPLES = r'''
     parent_vm: "{{ testvm_1 }}"
     resource_pool: "{{ test_resource_001 }}"
   register: vm_clone
-  delegate_to: localhost
-
-- name: set state to poweroff the Cloned VM
-  community.vmware.vmware_guest_powerstate:
-    validate_certs: false
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    name: "cloned_vm_from_vm_cluster"
-    folder: "{{ f0 }}"
-    state: powered-off
-  register: poweroff_instant_clone_from_vm_when_cluster
-  delegate_to: localhost
-
-- name: Clean VM
-  community.vmware.vmware_guest:
-    validate_certs: false
-    hostname: "{{ vcenter_hostname }}"
-    username: "{{ vcenter_username }}"
-    password: "{{ vcenter_password }}"
-    name: "cloned_vm_from_vm_cluster"
-    datacenter: "{{ dc1 }}"
-    state: absent
-  register: delete_instant_clone_from_vm_when_cluster
-  ignore_errors: true
   delegate_to: localhost
 
 - name: Instant Clone a VM with guest_customization

--- a/plugins/modules/vmware_guest_serial_port.py
+++ b/plugins/modules/vmware_guest_serial_port.py
@@ -246,7 +246,7 @@ class PyVmomiHelper(PyVmomi):
         if vm_obj.runtime.powerState == vim.VirtualMachinePowerState.poweredOff:
             return True
         self.module.fail_json(msg="A serial device cannot be added to a VM in the current state(" + vm_obj.runtime.powerState + "). "
-                                  "Please use the vmware_guest_powerstate module to power off the VM")
+                                  "Please power off the VM.")
 
     def get_serial_port_config_spec(self, vm_obj):
         """

--- a/plugins/modules/vmware_guest_tools_upgrade.py
+++ b/plugins/modules/vmware_guest_tools_upgrade.py
@@ -16,8 +16,7 @@ short_description: Module to upgrade VMTools
 description:
     - This module upgrades the VMware Tools on Windows and Linux guests and reboots them.
 notes:
-    - "In order to upgrade VMTools, please power on virtual machine before hand - either 'manually' or
-      using module M(community.vmware.vmware_guest_powerstate)."
+    - "In order to upgrade VMTools, please power on virtual machine before hand."
 options:
    name:
         description:

--- a/plugins/modules/vmware_guest_vgpu.py
+++ b/plugins/modules/vmware_guest_vgpu.py
@@ -16,7 +16,7 @@ module: vmware_guest_vgpu
 short_description: Modify vGPU video card profile of the specified virtual machine in the given vCenter infrastructure
 description:
     - This module is used to reconfigure vGPU card profile of the given virtual machine.
-    - VM must be power off M(community.vmware.vmware_guest_powerstate) module can perform that task.
+    - VM must be power off to reconfigure vGPU card profile.
 author:
     - Mohamed Alibi (@Medalibi)
     - Unknown (@matancarmeli7)


### PR DESCRIPTION
Fixes #2541

##### SUMMARY
Remove deprecated `vmware_guest_powerstate` from the documentation of other modules.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
vmware_guest_instant_clone
vmware_guest_serial_port
vmware_guest_tools_upgrade
vmware_guest_vgpu

##### ADDITIONAL INFORMATION
#2540
#2398