### PR TITLE
fix(vmware_guest_network): fix idempotency and diff issue due to the …

### DIFF
--- a/changelogs/fragments/2547-vmware_guest_network_check_mode_vlan_id.yml
+++ b/changelogs/fragments/2547-vmware_guest_network_check_mode_vlan_id.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - vmware_guest_network - populate ``vlan_id`` in gathered NIC data for Distributed Virtual Portgroup backings so check mode diff does not report a false change when the NIC is already on the requested network.

--- a/plugins/modules/vmware_guest_network.py
+++ b/plugins/modules/vmware_guest_network.py
@@ -60,6 +60,8 @@ options:
   mac_address:
     description:
       - MAC address of the NIC that should be altered, if a MAC address is not supplied a new nic will be created.
+      - Matching is case-sensitive; use the same MAC address case as reported by VMware to target an existing NIC.
+      - If the case does not match, the module can treat the adapter as missing and attempt to create a new NIC.
       - Required when O(state=absent).
     type: str
   label:

--- a/plugins/modules/vmware_guest_network.py
+++ b/plugins/modules/vmware_guest_network.py
@@ -412,6 +412,7 @@ class PyVmomiHelper(PyVmomi):
                     if hasattr(portgroup, 'key') and portgroup.key == key:
                         d_item['network_name'] = portgroup.name
                         d_item['switch'] = portgroup.config.distributedVirtualSwitch.name
+                        d_item['vlan_id'] = self._get_vlanid_from_network(portgroup)
                         break
             # If an NSX-T port group specified
             elif isinstance(nic.backing, vim.vm.device.VirtualEthernetCard.OpaqueNetworkBackingInfo):


### PR DESCRIPTION
…before state not showing vlan id at all while after state was showing vlan id

##### SUMMARY

When running the guest_vmware_network module, changes are always reported due to the vlan_id not being present in the before_diff, which messes up the comparison between before and after state.

As this happens, the module will create a new NIC even if one already exists on the same network with the same mac address.

This PR fixes this issue.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_guest_network module

##### ADDITIONAL INFORMATION
Running the module with the following parameters, in check mode with diff mode enabled : 

```
- name: "Set Network on VM {{ hostname }}"
  community.vmware.vmware_guest_network:
    hostname: '{{ vcenterhost }}'
    username: "{{ vcenter_username }}"
    password: "{{ vcenter_password }}"
    datacenter: "{{ datacenter }}"
    name: '{{ hostname }}'
    network_name: "{{ network_name }}"
    mac_address: "{{ mac_address}}"
    state: "present"	
```

Before changes :

```
TASK [vms_network : Set Network on VM virtual_machine_name] [CHECK MODE] ***************************************************************************************************************************************
--- before
+++ after
@@ -1,4 +1,11 @@
 {
+    "MAC_ADDR": {
+        "label": "check_mode_adapter",
+        "mac_address": "MAC_ADDR",
+        "network_name": "NETWORK_NAME",
+        "unit_number": 40000,
+        "vlan_id": 1006
+    },
     "MAC_ADDR": {
         "allow_guest_ctl": true,
         "connected": false,

changed: [localhost] => (item=NETWORK_NAME [MAC_ADDR]) => {
    "ansible_loop_var": "item",
    "changed": true,
    "item": "NETWORK_NAME [MAC_ADDR]",
    "network_info": [
        {
            "allow_guest_ctl": true,
            "connected": false,
            "device_type": "vmxnet3",
            "label": "Network adapter 1",
            "mac_address": "MAC_ADDR",
            "network_name": "NETWORK_NAME",
            "start_connected": true,
            "switch": "SWITCH_NAME",
            "unit_number": 7,
            "wake_onlan": false
        },
        {
            "label": "check_mode_adapter",
            "mac_address": "MAC_ADDR",
            "network_name": "NETWORK_NAME",
            "unit_number": 40000,
            "vlan_id": 1006
        }
    ]
}
```

After changes :

```
TASK [vms_network : Set Network on VM virtual_machine_name] [CHECK MODE] ***************************************************************************************************************************************
ok: [localhost] => (item=NETWORK_NAME [MAC_ADDR]) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": "NETWORK_NAME [MAC_ADDR]",
    "network_info": [
        {
            "allow_guest_ctl": true,
            "connected": false,
            "device_type": "vmxnet3",
            "label": "Network adapter 1",
            "mac_address": "MAC_ADDR",
            "network_name": "NETWORK_NAME",
            "start_connected": true,
            "switch": "SWITCH_NAME",
            "unit_number": 7,
            "vlan_id": 1006,
            "wake_onlan": false
        }
    ]
}
```

We can see that after the change, the module doesn't report "changed" anymore and that there is no diff displayed because no difference was found.