### PR TITLE
Fix failing windows modules with community.vmware.vmware_tools module on ansible-core 2.21.1

### DIFF
--- a/plugins/connection/vmware_tools.py
+++ b/plugins/connection/vmware_tools.py
@@ -547,7 +547,7 @@ class Connection(ConnectionBase):
         stderr_response = self._fetch_file_from_vm(stderr)
         self.delete_file_in_guest(stderr)
 
-        return pid_info.exitCode, stdout_response.text, stderr_response.text
+        return pid_info.exitCode, stdout_response.content, stderr_response.content
 
     def fetch_file(self, in_path, out_path):
         """Fetch file."""

--- a/plugins/connection/vmware_tools.py
+++ b/plugins/connection/vmware_tools.py
@@ -206,6 +206,7 @@ ansible_shell_type: powershell
 '''
 
 import re
+import shlex
 from os.path import exists, getsize
 from socket import gaierror
 from ssl import SSLError
@@ -410,7 +411,16 @@ class Connection(ConnectionBase):
             #FIXME: Fix the unecessary invocation of cmd and run the command directly
             '''
             program_path = "cmd.exe"
-            arguments = "/c %s" % cmd
+            args = shlex.split(cmd)
+
+            for i in range(0, len(args)):
+                if args[i] not in ["-EncodedCommand", "-EncodedArguments"]:
+                    continue
+                index = i + 1
+                if len(args[index]) >= 2 and args[index][0] == args[index][-1] and args[index][0] in ("'", '"'):
+                    args[index] = args[index][1:-1]
+
+            arguments = "/c %s" % (" ".join(args))
         else:
             program_path = self.get_option("executable")
             arguments = re.sub(r"^%s\s*" % program_path, "", cmd)


### PR DESCRIPTION
##### SUMMARY
Currently the `community.vmware.vmware_tools` connection plugin does not work on windows targets with `ansible-core 2.21.1`. The underlying issues are the same as described here: https://github.com/ansible-collections/community.general/issues/12161
1. The stdout and stderr return values of the `exec_command` function should be of type bytes and not str.
2. The values in `-EncodedCommand` and `-EncodedArguments` must not be quoted otherwise powershell refuses to parse these parameters.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
community.vmware.vmware_tools


