### PR TITLE
Added New MTU Maximum Limit for Newer vDSes

### DIFF
--- a/plugins/modules/vmware_dvswitch.py
+++ b/plugins/modules/vmware_dvswitch.py
@@ -375,7 +375,7 @@ class VMwareDvSwitch(PyVmomi):
         self.mtu = self.module.params['mtu']
         # vSphere version and MTU sanity check
         if not 1280 <= self.mtu <= 9000:
-            if not self.vcenter_version_at_least((7, 0, 3)) or (self.switch_version is not None and self.vcenter_version_at_least( self.switch_version[0], self.switch_version[2], self.switch_version[4])):
+            if not self.vcenter_version_at_least((7, 0, 3)) or (self.switch_version is not None and int(self.switch_version[0]) <= 7 and int(self.switch_version[-1]) < 3):
                 self.module.fail_json(
                     msg="MTU value should be between 1280 and 9000 (both inclusive), provided %d." % self.mtu
                 )

--- a/plugins/modules/vmware_dvswitch.py
+++ b/plugins/modules/vmware_dvswitch.py
@@ -374,15 +374,22 @@ class VMwareDvSwitch(PyVmomi):
 
         self.mtu = self.module.params['mtu']
         # vSphere version and MTU sanity check
-        if not 1280 <= self.mtu <= 9190:
-            if int(self.switch_version[0]) <= 7 and int(self.switch_version[4]) < 3 and self.mtu > 9000:
+        if not 1280 <= self.mtu <= 9000:
+            if not self.vcenter_version_at_least((7, 0, 3)):
                 self.module.fail_json(
-                    msg="MTU value should be between 1280 and 9000 (both inclusive), provided %d." % self.mtu
+                    msg="MTU value should be between 1280 and 9000 (both inclusive) for Distributed Switch versions below 7.0.3, provided %d." % self.mtu
                 )
             else:
-                self.module.fail_json(
-                    msg="MTU value should be between 1280 and 9190 (both inclusive), provided %d." % self.mtu
-                )
+                if self.switch_version is not None and int(self.switch_version[0]) <= 7 and int(self.switch_version[-1]) < 3:
+                    self.module.fail_json(
+                        msg="MTU value should be between 1280 and 9000 (both inclusive) for Distributed Switch versions below 7.0.3, provided %d." % self.mtu
+                    )
+                elif self.mtu > 9190:
+                    self.module.fail_json(
+                        msg="MTU value should be between 1280 and 9190 (both inclusive) for Distributed Switch versions 7.0.3 and above, provided %d." % self.mtu
+                    )
+                else:
+                    pass
         self.multicast_filtering_mode = self.module.params['multicast_filtering_mode']
         self.uplink_quantity = self.module.params['uplink_quantity']
         self.uplink_prefix = self.module.params['uplink_prefix']

--- a/plugins/modules/vmware_dvswitch.py
+++ b/plugins/modules/vmware_dvswitch.py
@@ -49,7 +49,8 @@ options:
         description:
             - The switch maximum transmission unit.
             - Required if O(state=present).
-            - Accepts value between 1280 to 9000 (both inclusive).
+            - Accepts value between 1280 to 9000 (both inclusive) if Distributed Switch version is <7.0.3.
+            - Accepts value between 1280 to 9190 (both inclusive) if Distributed Switch version is >=7.0.3.
         type: int
         default: 1500
     multicast_filtering_mode:
@@ -372,11 +373,16 @@ class VMwareDvSwitch(PyVmomi):
             self.folder_obj = datacenter_obj.networkFolder
 
         self.mtu = self.module.params['mtu']
-        # MTU sanity check
-        if not 1280 <= self.mtu <= 9000:
-            self.module.fail_json(
-                msg="MTU value should be between 1280 and 9000 (both inclusive), provided %d." % self.mtu
-            )
+        # vSphere version and MTU sanity check
+        if not 1280 <= self.mtu <= 9190:
+            if int(self.switch_version[0]) <= 7 and int(self.switch_version[4]) < 3 and self.mtu > 9000:
+                self.module.fail_json(
+                    msg="MTU value should be between 1280 and 9000 (both inclusive), provided %d." % self.mtu
+                )
+            else:
+                self.module.fail_json(
+                    msg="MTU value should be between 1280 and 9190 (both inclusive), provided %d." % self.mtu
+                )
         self.multicast_filtering_mode = self.module.params['multicast_filtering_mode']
         self.uplink_quantity = self.module.params['uplink_quantity']
         self.uplink_prefix = self.module.params['uplink_prefix']

--- a/plugins/modules/vmware_dvswitch.py
+++ b/plugins/modules/vmware_dvswitch.py
@@ -375,21 +375,16 @@ class VMwareDvSwitch(PyVmomi):
         self.mtu = self.module.params['mtu']
         # vSphere version and MTU sanity check
         if not 1280 <= self.mtu <= 9000:
-            if not self.vcenter_version_at_least((7, 0, 3)):
+            if not self.vcenter_version_at_least((7, 0, 3)) or (self.switch_version is not None and self.vcenter_version_at_least( self.switch_version[0], self.switch_version[2], self.switch_version[4])):
                 self.module.fail_json(
-                    msg="MTU value should be between 1280 and 9000 (both inclusive) for Distributed Switch versions below 7.0.3, provided %d." % self.mtu
+                    msg="MTU value should be between 1280 and 9000 (both inclusive), provided %d." % self.mtu
                 )
             else:
-                if self.switch_version is not None and int(self.switch_version[0]) <= 7 and int(self.switch_version[-1]) < 3:
+                if self.mtu > 9190:
                     self.module.fail_json(
-                        msg="MTU value should be between 1280 and 9000 (both inclusive) for Distributed Switch versions below 7.0.3, provided %d." % self.mtu
+                        msg="MTU value should be between 1280 and 9190 (both inclusive), provided %d." % self.mtu
                     )
-                elif self.mtu > 9190:
-                    self.module.fail_json(
-                        msg="MTU value should be between 1280 and 9190 (both inclusive) for Distributed Switch versions 7.0.3 and above, provided %d." % self.mtu
-                    )
-                else:
-                    pass
+
         self.multicast_filtering_mode = self.module.params['multicast_filtering_mode']
         self.uplink_quantity = self.module.params['uplink_quantity']
         self.uplink_prefix = self.module.params['uplink_prefix']


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This change checks the version string to see if the version is below 7.0.3 to see if MTU should remain limited to 9000 or 9190 if the version is 7.0.3 or newer.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_dvswitch

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Since vSphere 7.0.3, vDSes have been allowed to go up to 9190 (inclusive) MTU size to accommodate for unique jumbo frames from some switches.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
# before
fatal: [localhost]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "contact": null,
            "datacenter": "test-datacenter",
            "datacenter_name": "test-datacenter",
            "description": null,
            "discovery_operation": "both",
            "discovery_proto": "disabled",
            "discovery_protocol": "disabled",
            "folder": null,
            "health_check": {
                "teaming_failover": false,
                "teaming_failover_interval": 0,
                "vlan_mtu": false,
                "vlan_mtu_interval": 0
            },
            "hostname": "test-esxi",
            "mtu": 9190,
            "multicast_filtering_mode": "snooping",
            "net_flow": {
                "active_flow_timeout": 60,
                "collector_ip": null,
                "collector_port": 0,
                "idle_flow_timeout": 15,
                "internal_flows_only": false,
                "observation_domain_id": 0,
                "sampling_rate": 4096,
                "switch_ip": null
            },
            "network_policy": null,
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "port": 443,
            "proxy_host": null,
            "proxy_port": null,
            "state": "present",
            "switch_name": "test-vds",
            "switch_version": null,
            "uplink_prefix": "Uplink ",
            "uplink_quantity": 2,
            "username": "administrator@vsphere.local",
            "validate_certs": false
        }
    },
    "msg": "MTU value should be between 1280 and 9000 (both inclusive), provided 9190."
}


# After
ok: [localhost] => {
    "changed": false,
    "contact": null,
    "contact_details": null,
    "description": null,
    "discovery_operation": "n/a",
    "discovery_protocol": "disabled",
    "dvswitch": "test-vds",
    "health_check_teaming": false,
    "health_check_teaming_interval": 0,
    "health_check_vlan": false,
    "health_check_vlan_interval": 0,
    "invocation": {
        "module_args": {
            "contact": null,
            "datacenter": "test-datacenter",
            "datacenter_name": "test-datacenter",
            "description": null,
            "discovery_operation": "both",
            "discovery_proto": "disabled",
            "discovery_protocol": "disabled",
            "folder": null,
            "health_check": {
                "teaming_failover": false,
                "teaming_failover_interval": 0,
                "vlan_mtu": false,
                "vlan_mtu_interval": 0
            },
            "hostname": "test-esxi",
            "mtu": 9190,
            "multicast_filtering_mode": "snooping",
            "net_flow": {
                "active_flow_timeout": 60,
                "collector_ip": null,
                "collector_port": 0,
                "idle_flow_timeout": 15,
                "internal_flows_only": false,
                "observation_domain_id": 0,
                "sampling_rate": 4096,
                "switch_ip": null
            },
            "network_policy": null,
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "port": 443,
            "proxy_host": null,
            "proxy_port": null,
            "state": "present",
            "switch_name": "test-vds",
            "switch_version": null,
            "uplink_prefix": "Uplink ",
            "uplink_quantity": 2,
            "username": "administrator@vsphere.local",
            "validate_certs": false
        }
    },
    "mtu": 9190,
    "multicast_filtering_mode": "snooping",
    "result": "DVS already configured properly",
    "uplink_quantity": 2,
    "uplinks": [
        "Uplink 1",
        "Uplink 2"
    ],
    "uuid": "50 08 73 80 13 c2 18 fd-f8 d1 57 ae 42 3d 16 d5",
    "version": "8.0.3"
}
```
