### PR TITLE
fix: normalize telemetry taxonomy values to conform with Ansible NRT v1.0

### DIFF
--- a/extensions/audit/event_query.yml
+++ b/extensions/audit/event_query.yml
@@ -10,8 +10,8 @@ community.vmware.vmware_guest:
         esxi: .hw_esxi_host
       },
       facts: {
-        infra_type: "PrivateCloud",
-        infra_bucket: "Compute",
-        device_type: "VM"
+        infra_type: "private_cloud",
+        infra_bucket: "compute",
+        device_type: "virtual_machine"
       }
     }


### PR DESCRIPTION
## Summary

The `event_query.yml` audit filter for `vmware_guest` emits vendor-specific strings as taxonomy values, blocking automated cross-vendor reporting against the Ansible Normalized Resource Taxonomy v1.0.

**Before:**
- `infra_type: "PrivateCloud"`
- `infra_bucket: "Compute"`
- `device_type: "VM"`

**After:**
- `infra_type: "private_cloud"`
- `infra_bucket: "compute"`
- `device_type: "virtual_machine"`

### Change

Single entry updated — `community.vmware.vmware_guest`. All three taxonomy fact values normalized to lowercase snake_case per Ansible NRT v1.0.

## Test Plan

- [x] YAML validates
- [x] JQ query logic unchanged — only string values modified
- [ ] Integration test with AAP telemetry pipeline (post-merge)

Signed-off-by: Steve Fulmer <sfulmer@redhat.com> (Red Hat)