### PR TITLE
vmware_vcenter_settings: Deprecate defaults

### DIFF
--- a/changelogs/fragments/2559-vmware_vcenter_settings.yml
+++ b/changelogs/fragments/2559-vmware_vcenter_settings.yml
@@ -1,0 +1,3 @@
+deprecated_features:
+  - vmware_vcenter_settings - The defaults are deprecated and will be removed where possible in community.vmware 8.0.0
+    (https://github.com/ansible-collections/community.vmware/issues/2559).


### PR DESCRIPTION
##### SUMMARY
When using vmware_vcenter_settings to set a single advanced_settings value, it also overwrites all other vCenter settings to defaults which is not intuitive or expected. So all the defaults will be remove in `community.vmware` 8.0.0 where possible.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
vmware_vcenter_settings

##### ADDITIONAL INFORMATION
#2559