### PR TITLE
Deprecate modules moved to vmware.vmware

### DIFF
--- a/.github/workflows/extra-docs-linting.yml
+++ b/.github/workflows/extra-docs-linting.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install dependent collections
         run: >
           ansible-galaxy collection install
-          'vmware.vmware>=2.5.0'
+          'vmware.vmware>=2.10.0'
 
       - name: Run collection docs linter
         run: antsibull-docs lint-collection-docs . --plugin-docs --skip-rstcheck

--- a/changelogs/fragments/2568-deprecate-modules.yml
+++ b/changelogs/fragments/2568-deprecate-modules.yml
@@ -12,6 +12,8 @@ deprecated_features:
     (https://github.com/ansible-collections/community.vmware/pull/2568).
   - vmware_host_facts - the module has been deprecated and will be removed in community.vmware 8.0.0
     (https://github.com/ansible-collections/community.vmware/pull/2568).
+  - vmware_host_powerstate - the module has been deprecated and will be removed in community.vmware 8.0.0
+    (https://github.com/ansible-collections/community.vmware/pull/2568).
 major_changes:
   - Bump required ``vmware.vmware`` collection version to 2.10.0
     (https://github.com/ansible-collections/community.vmware/pull/2568).

--- a/changelogs/fragments/2568-deprecate-modules.yml
+++ b/changelogs/fragments/2568-deprecate-modules.yml
@@ -7,3 +7,6 @@ deprecated_features:
     (https://github.com/ansible-collections/community.vmware/pull/2568).
   - vmware_host_service_manager - the module has been deprecated and will be removed in community.vmware 8.0.0
     (https://github.com/ansible-collections/community.vmware/pull/2568).
+major_changes:
+  - Bump required ``vmware.vmware`` collection version to 2.10.0
+    (https://github.com/ansible-collections/community.vmware/pull/2568).

--- a/changelogs/fragments/2568-deprecate-modules.yml
+++ b/changelogs/fragments/2568-deprecate-modules.yml
@@ -6,6 +6,7 @@ deprecated_features:
   - vmware_host_service_info - the module has been deprecated and will be removed in community.vmware 8.0.0
     (https://github.com/ansible-collections/community.vmware/pull/2568).
   - vmware_host_service_manager - the module has been deprecated and will be removed in community.vmware 8.0.0
+  - vmware_tag - the module has been deprecated and will be removed in community.vmware 8.0.0
     (https://github.com/ansible-collections/community.vmware/pull/2568).
 major_changes:
   - Bump required ``vmware.vmware`` collection version to 2.10.0

--- a/changelogs/fragments/2568-deprecate-modules.yml
+++ b/changelogs/fragments/2568-deprecate-modules.yml
@@ -1,4 +1,6 @@
 deprecated_features:
+  - vcenter_standard_key_provider - the module has been deprecated and will be removed in community.vmware 8.0.0
+    (https://github.com/ansible-collections/community.vmware/pull/2568).
   - vmware_guest_snapshot_info - the module has been deprecated and will be removed in community.vmware 8.0.0
     (https://github.com/ansible-collections/community.vmware/pull/2568).
   - vmware_host_service_info - the module has been deprecated and will be removed in community.vmware 8.0.0

--- a/changelogs/fragments/2568-deprecate-modules.yml
+++ b/changelogs/fragments/2568-deprecate-modules.yml
@@ -10,6 +10,8 @@ deprecated_features:
     (https://github.com/ansible-collections/community.vmware/pull/2568).
   - vmware_tag_manager - the module has been deprecated and will be removed in community.vmware 8.0.0
     (https://github.com/ansible-collections/community.vmware/pull/2568).
+  - vmware_host_facts - the module has been deprecated and will be removed in community.vmware 8.0.0
+    (https://github.com/ansible-collections/community.vmware/pull/2568).
 major_changes:
   - Bump required ``vmware.vmware`` collection version to 2.10.0
     (https://github.com/ansible-collections/community.vmware/pull/2568).

--- a/changelogs/fragments/2568-deprecate-modules.yml
+++ b/changelogs/fragments/2568-deprecate-modules.yml
@@ -8,6 +8,8 @@ deprecated_features:
   - vmware_host_service_manager - the module has been deprecated and will be removed in community.vmware 8.0.0
   - vmware_tag - the module has been deprecated and will be removed in community.vmware 8.0.0
     (https://github.com/ansible-collections/community.vmware/pull/2568).
+  - vmware_tag_manager - the module has been deprecated and will be removed in community.vmware 8.0.0
+    (https://github.com/ansible-collections/community.vmware/pull/2568).
 major_changes:
   - Bump required ``vmware.vmware`` collection version to 2.10.0
     (https://github.com/ansible-collections/community.vmware/pull/2568).

--- a/changelogs/fragments/2568-deprecate-modules.yml
+++ b/changelogs/fragments/2568-deprecate-modules.yml
@@ -1,0 +1,7 @@
+deprecated_features:
+  - vmware_guest_snapshot_info - the module has been deprecated and will be removed in community.vmware 8.0.0
+    (https://github.com/ansible-collections/community.vmware/pull/2568).
+  - vmware_host_service_info - the module has been deprecated and will be removed in community.vmware 8.0.0
+    (https://github.com/ansible-collections/community.vmware/pull/2568).
+  - vmware_host_service_manager - the module has been deprecated and will be removed in community.vmware 8.0.0
+    (https://github.com/ansible-collections/community.vmware/pull/2568).

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -18,7 +18,7 @@ tags:
   - vmware
   - virtualization
 dependencies:
-  vmware.vmware: ">=2.5.0"
+  vmware.vmware: ">=2.10.0"
 repository: https://github.com/ansible-collections/community.vmware.git
 homepage: https://github.com/ansible-collections/community.vmware
 issues: https://github.com/ansible-collections/community.vmware/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -189,6 +189,10 @@ plugin_routing:
       deprecation:
         removal_version: 7.0.0
         warning_text: Use vmware.vmware.folder instead.
+    vcenter_standard_key_provider:
+      deprecation:
+        removal_version: 8.0.0
+        warning_text: Use vmware.vmware.key_provider_standard instead.
     vmware_cluster:
       tombstone:
         removal_version: 6.0.0

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -265,3 +265,7 @@ plugin_routing:
       deprecation:
         removal_version: 8.0.0
         warning_text: Use vmware.vmware.tags instead.
+    vmware_tag_manager:
+      deprecation:
+        removal_version: 8.0.0
+        warning_text: Use vmware.vmware.tag_associations instead.

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -237,10 +237,22 @@ plugin_routing:
       deprecation:
         removal_version: 8.0.0
         warning_text: Use vmware.vmware.vm_snapshot instead.
+    vmware_guest_snapshot_info:
+      deprecation:
+        removal_version: 8.0.0
+        warning_text: Use vmware.vmware.vm_snapshot_info instead.
     vmware_host:
       deprecation:
         removal_version: 7.0.0
         warning_text: Use vmware.vmware.esxi_host and vmware.vmware.esxi_connection instead.
+    vmware_host_service_info:
+      deprecation:
+        removal_version: 8.0.0
+        warning_text: Use vmware.vmware.esxi_service_info instead.
+    vmware_host_service_manager:
+      deprecation:
+        removal_version: 8.0.0
+        warning_text: Use vmware.vmware.esxi_service instead.
     vmware_maintenancemode:
       deprecation:
         removal_version: 7.0.0

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -261,3 +261,7 @@ plugin_routing:
       deprecation:
         removal_version: 7.0.0
         warning_text: Use vmware.vmware.esxi_maintenance_mode instead.
+    vmware_tag:
+      deprecation:
+        removal_version: 8.0.0
+        warning_text: Use vmware.vmware.tags instead.

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -253,6 +253,10 @@ plugin_routing:
       deprecation:
         removal_version: 8.0.0
         warning_text: Use vmware.vmware.esxi_info instead.
+    vmware_host_powerstate:
+      deprecation:
+        removal_version: 8.0.0
+        warning_text: Use vmware.vmware.esxi_powerstate instead.
     vmware_host_service_info:
       deprecation:
         removal_version: 8.0.0

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -249,6 +249,10 @@ plugin_routing:
       deprecation:
         removal_version: 7.0.0
         warning_text: Use vmware.vmware.esxi_host and vmware.vmware.esxi_connection instead.
+    vmware_host_facts:
+      deprecation:
+        removal_version: 8.0.0
+        warning_text: Use vmware.vmware.esxi_info instead.
     vmware_host_service_info:
       deprecation:
         removal_version: 8.0.0

--- a/plugins/modules/vcenter_folder.py
+++ b/plugins/modules/vcenter_folder.py
@@ -14,7 +14,7 @@ DOCUMENTATION = r'''
 module: vcenter_folder
 deprecated:
   removed_in: 7.0.0
-  why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+  why: This module has been L(moved to vmware.vmware,https://forum.ansible.com/t/5880).
   alternative: Use M(vmware.vmware.folder) instead.
 short_description: Manage folders on given datacenter
 description:

--- a/plugins/modules/vcenter_standard_key_provider.py
+++ b/plugins/modules/vcenter_standard_key_provider.py
@@ -13,6 +13,10 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 ---
 module: vcenter_standard_key_provider
+deprecated:
+  removed_in: 8.0.0
+  why: This module has been L(moved to vmware.vmware,https://forum.ansible.com/t/5880).
+  alternative: Use M(vmware.vmware.key_provider_standard) instead.
 short_description: Add, reconfigure or remove Standard Key Provider on vCenter server
 description: >
   This module is used for adding, reconfiguring or removing Standard Key Provider on vCenter server.

--- a/plugins/modules/vmware_cluster_ha.py
+++ b/plugins/modules/vmware_cluster_ha.py
@@ -16,7 +16,7 @@ DOCUMENTATION = r'''
 module: vmware_cluster_ha
 deprecated:
   removed_in: 7.0.0
-  why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+  why: This module has been L(moved to vmware.vmware,https://forum.ansible.com/t/5880).
   alternative: Use M(vmware.vmware.cluster_ha) instead.
 short_description: Manage High Availability (HA) on VMware vSphere clusters
 description:

--- a/plugins/modules/vmware_cluster_info.py
+++ b/plugins/modules/vmware_cluster_info.py
@@ -15,7 +15,7 @@ DOCUMENTATION = r'''
 module: vmware_cluster_info
 deprecated:
   removed_in: 7.0.0
-  why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+  why: This module has been L(moved to vmware.vmware,https://forum.ansible.com/t/5880).
   alternative: Use M(vmware.vmware.cluster_info) instead.
 short_description: Gather info about clusters available in given vCenter
 description:

--- a/plugins/modules/vmware_content_deploy_ovf_template.py
+++ b/plugins/modules/vmware_content_deploy_ovf_template.py
@@ -14,7 +14,7 @@ DOCUMENTATION = r'''
 module: vmware_content_deploy_ovf_template
 deprecated:
   removed_in: 7.0.0
-  why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+  why: This module has been L(moved to vmware.vmware,https://forum.ansible.com/t/5880).
   alternative: Use M(vmware.vmware.deploy_content_library_ovf) instead.
 short_description: Deploy Virtual Machine from ovf template stored in content library.
 description:

--- a/plugins/modules/vmware_content_deploy_template.py
+++ b/plugins/modules/vmware_content_deploy_template.py
@@ -15,7 +15,7 @@ DOCUMENTATION = r'''
 module: vmware_content_deploy_template
 deprecated:
   removed_in: 7.0.0
-  why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+  why: This module has been L(moved to vmware.vmware,https://forum.ansible.com/t/5880).
   alternative: Use M(vmware.vmware.deploy_content_library_template) instead.
 short_description: Deploy Virtual Machine from template stored in content library.
 description:

--- a/plugins/modules/vmware_content_library_manager.py
+++ b/plugins/modules/vmware_content_library_manager.py
@@ -15,7 +15,7 @@ DOCUMENTATION = r'''
 module: vmware_content_library_manager
 deprecated:
   removed_in: 7.0.0
-  why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+  why: This module has been L(moved to vmware.vmware,https://forum.ansible.com/t/5880).
   alternative: Use M(vmware.vmware.local_content_library) and M(vmware.vmware.subscribed_content_library) instead.
 short_description: Create, update and delete VMware content library
 description:

--- a/plugins/modules/vmware_guest_powerstate.py
+++ b/plugins/modules/vmware_guest_powerstate.py
@@ -14,7 +14,7 @@ DOCUMENTATION = r"""
 module: vmware_guest_powerstate
 deprecated:
   removed_in: 7.0.0
-  why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+  why: This module has been L(moved to vmware.vmware,https://forum.ansible.com/t/5880).
   alternative: Use M(vmware.vmware.vm_powerstate) instead.
 short_description: Manages power states of virtual machines in vCenter
 description:

--- a/plugins/modules/vmware_guest_snapshot.py
+++ b/plugins/modules/vmware_guest_snapshot.py
@@ -15,7 +15,7 @@ DOCUMENTATION = r'''
 module: vmware_guest_snapshot
 deprecated:
   removed_in: 8.0.0
-  why: This module has been L(moved to vmware.vmware,https://github.com/ansible-collections/vmware.vmware/pull/126)
+  why: This module has been L(moved to vmware.vmware,https://forum.ansible.com/t/5880).
   alternative: Use M(vmware.vmware.vm_snapshot) instead.
 short_description: Manages virtual machines snapshots in vCenter
 description:

--- a/plugins/modules/vmware_guest_snapshot_info.py
+++ b/plugins/modules/vmware_guest_snapshot_info.py
@@ -15,7 +15,7 @@ DOCUMENTATION = r'''
 module: vmware_guest_snapshot_info
 deprecated:
   removed_in: 8.0.0
-  why: This module has been L(moved to vmware.vmware,https://github.com/ansible-collections/vmware.vmware/pull/397).
+  why: This module has been L(moved to vmware.vmware,https://forum.ansible.com/t/5880).
   alternative: Use M(vmware.vmware.vm_snapshot_info) instead.
 short_description: Gather info about virtual machine's snapshots in vCenter
 description:

--- a/plugins/modules/vmware_guest_snapshot_info.py
+++ b/plugins/modules/vmware_guest_snapshot_info.py
@@ -13,6 +13,10 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 ---
 module: vmware_guest_snapshot_info
+deprecated:
+  removed_in: 8.0.0
+  why: This module has been L(moved to vmware.vmware,https://github.com/ansible-collections/vmware.vmware/pull/397).
+  alternative: Use M(vmware.vmware.vm_snapshot_info) instead.
 short_description: Gather info about virtual machine's snapshots in vCenter
 description:
     - This module can be used to gather information about virtual machine's snapshots.

--- a/plugins/modules/vmware_host.py
+++ b/plugins/modules/vmware_host.py
@@ -16,7 +16,7 @@ DOCUMENTATION = r'''
 module: vmware_host
 deprecated:
   removed_in: 7.0.0
-  why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+  why: This module has been L(moved to vmware.vmware,https://forum.ansible.com/t/5880).
   alternative: Use M(vmware.vmware.esxi_host) and M(vmware.vmware.esxi_connection) instead.
 short_description: Add, remove, or move an ESXi host to, from, or within vCenter
 description:

--- a/plugins/modules/vmware_host_facts.py
+++ b/plugins/modules/vmware_host_facts.py
@@ -12,6 +12,10 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 ---
 module: vmware_host_facts
+deprecated:
+  removed_in: 8.0.0
+  why: This module has been L(moved to vmware.vmware,https://forum.ansible.com/t/5880).
+  alternative: Use M(vmware.vmware.esxi_info) instead.
 short_description: Gathers facts about remote ESXi hostsystem
 description:
     - This module can be used to gathers facts like CPU, memory, datastore, network and system etc. about ESXi host system.

--- a/plugins/modules/vmware_host_powerstate.py
+++ b/plugins/modules/vmware_host_powerstate.py
@@ -13,6 +13,10 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 ---
 module: vmware_host_powerstate
+deprecated:
+  removed_in: 8.0.0
+  why: This module has been L(moved to vmware.vmware,https://forum.ansible.com/t/5880).
+  alternative: Use M(vmware.vmware.esxi_powerstate) instead.
 short_description: Manages power states of host systems in vCenter
 description:
 - This module can be used to manage power states of host systems in given vCenter infrastructure.

--- a/plugins/modules/vmware_host_service_info.py
+++ b/plugins/modules/vmware_host_service_info.py
@@ -12,6 +12,10 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 ---
 module: vmware_host_service_info
+deprecated:
+  removed_in: 8.0.0
+  why: This module has been L(moved to vmware.vmware,https://github.com/ansible-collections/vmware.vmware/pull/396).
+  alternative: Use M(vmware.vmware.esxi_service_info) instead.
 short_description: Gathers info about an ESXi host's services
 description:
 - This module can be used to gather information about an ESXi host's services.

--- a/plugins/modules/vmware_host_service_info.py
+++ b/plugins/modules/vmware_host_service_info.py
@@ -14,7 +14,7 @@ DOCUMENTATION = r'''
 module: vmware_host_service_info
 deprecated:
   removed_in: 8.0.0
-  why: This module has been L(moved to vmware.vmware,https://github.com/ansible-collections/vmware.vmware/pull/396).
+  why: This module has been L(moved to vmware.vmware,https://forum.ansible.com/t/5880).
   alternative: Use M(vmware.vmware.esxi_service_info) instead.
 short_description: Gathers info about an ESXi host's services
 description:

--- a/plugins/modules/vmware_host_service_manager.py
+++ b/plugins/modules/vmware_host_service_manager.py
@@ -14,7 +14,7 @@ DOCUMENTATION = r'''
 module: vmware_host_service_manager
 deprecated:
   removed_in: 8.0.0
-  why: This module has been L(moved to vmware.vmware,https://github.com/ansible-collections/vmware.vmware/pull/396).
+  why: This module has been L(moved to vmware.vmware,https://forum.ansible.com/t/5880).
   alternative: Use M(vmware.vmware.esxi_service) instead.
 short_description: Manage services on a given ESXi host
 description:

--- a/plugins/modules/vmware_host_service_manager.py
+++ b/plugins/modules/vmware_host_service_manager.py
@@ -12,6 +12,10 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 ---
 module: vmware_host_service_manager
+deprecated:
+  removed_in: 8.0.0
+  why: This module has been L(moved to vmware.vmware,https://github.com/ansible-collections/vmware.vmware/pull/396).
+  alternative: Use M(vmware.vmware.esxi_service) instead.
 short_description: Manage services on a given ESXi host
 description:
 - This module can be used to manage (start, stop, restart) services on a given ESXi host.

--- a/plugins/modules/vmware_maintenancemode.py
+++ b/plugins/modules/vmware_maintenancemode.py
@@ -15,7 +15,7 @@ DOCUMENTATION = r'''
 module: vmware_maintenancemode
 deprecated:
   removed_in: 7.0.0
-  why: This module has been moved to the L(new vmware.vmware collection,https://forum.ansible.com/t/5880)
+  why: This module has been L(moved to vmware.vmware,https://forum.ansible.com/t/5880).
   alternative: Use M(vmware.vmware.esxi_maintenance_mode) instead.
 short_description: Place a host into maintenance mode
 description:

--- a/plugins/modules/vmware_tag.py
+++ b/plugins/modules/vmware_tag.py
@@ -13,6 +13,10 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 ---
 module: vmware_tag
+deprecated:
+  removed_in: 8.0.0
+  why: This module has been L(moved to vmware.vmware,https://forum.ansible.com/t/5880).
+  alternative: Use M(vmware.vmware.tags) instead.
 short_description: Manage VMware tags
 description:
 - This module can be used to create / delete / update VMware tags.

--- a/plugins/modules/vmware_tag_manager.py
+++ b/plugins/modules/vmware_tag_manager.py
@@ -13,6 +13,10 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 ---
 module: vmware_tag_manager
+deprecated:
+  removed_in: 8.0.0
+  why: This module has been L(moved to vmware.vmware,https://forum.ansible.com/t/5880).
+  alternative: Use M(vmware.vmware.tag_associations) instead.
 short_description: Manage association of VMware tags with VMware objects
 description:
 - This module can be used to assign / remove VMware tags from the given VMware objects.


### PR DESCRIPTION
Deprecate modules that have been moved to `vmware.vmware`:

* vcenter_standard_key_provider ansible-collections/vmware.vmware#356
* vmware_guest_snapshot_info ansible-collections/vmware.vmware#397
* vmware_host_service_info ansible-collections/vmware.vmware#396
* vmware_host_service_manager ansible-collections/vmware.vmware#396
* vmware_tag ansible-collections/vmware.vmware#247
* vmware_tag_manager ansible-collections/vmware.vmware#251
* vmware_host_facts ansible-collections/vmware.vmware#401
* vmware_host_powerstate ansible-collections/vmware.vmware#401

Depends on ~~a new `vmware.vmware` release~~ [vmware.vmware 2.10.0](https://github.com/ansible-collections/vmware.vmware/releases/tag/2.10.0) that ships all those modules.

_edit_: Also unify deprecation reason in module documentation.