### PR TITLE
vmware_guest_network: Fix an issue with trunked / PVLAN portgroups

### DIFF
--- a/changelogs/fragments/2567-vmware_guest_network.yml
+++ b/changelogs/fragments/2567-vmware_guest_network.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - vmware_guest_network - Fix an issue with trunked / PVLAN portgroups
+    (https://github.com/ansible-collections/community.vmware/issues/2567).

--- a/plugins/modules/vmware_guest_network.py
+++ b/plugins/modules/vmware_guest_network.py
@@ -367,7 +367,9 @@ class PyVmomiHelper(PyVmomi):
         '''
         vlan_id = None
         if isinstance(network, vim.dvs.DistributedVirtualPortgroup):
-            vlan_id = network.config.defaultPortConfig.vlan.vlanId
+            vlan = network.config.defaultPortConfig.vlan
+            if isinstance(vlan, vim.dvs.VmwareDistributedVirtualSwitch.VlanIdSpec):
+                vlan_id = vlan.vlanId
 
         if isinstance(network, vim.Network) and hasattr(network, 'host'):
             for host in network.host:


### PR DESCRIPTION
Fixes #2567

##### SUMMARY
Fix an issue with trunked / PVLAN portgroups.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
vmware_guest_network

##### ADDITIONAL INFORMATION
The bug has been introduced with #2547.

The problem seems to be here:

https://github.com/ansible-collections/community.vmware/blob/f8fde60167ae8f6d252d46691913f7a451e2d723/plugins/modules/vmware_guest_network.py#L369-L370

Only [VmwareDistributedVirtualSwitchVlanIdSpec](https://developer.broadcom.com/xapis/vsphere-web-services-api/latest/vim.dvs.VmwareDistributedVirtualSwitch.VlanIdSpec.html) has a vlanId that is an Integer. In [VmwareDistributedVirtualSwitchTrunkVlanSpec](https://developer.broadcom.com/xapis/vsphere-web-services-api/latest/vim.dvs.VmwareDistributedVirtualSwitch.TrunkVlanSpec.html) it's a range and [VmwareDistributedVirtualSwitchPvlanSpec](https://developer.broadcom.com/xapis/vsphere-web-services-api/latest/vim.dvs.VmwareDistributedVirtualSwitch.PvlanSpec.html) has a pvlanId instead of a vlanId.